### PR TITLE
Crash fix

### DIFF
--- a/src/jsapi.c
+++ b/src/jsapi.c
@@ -645,10 +645,10 @@ static duk_ret_t duk_tri(duk_context* duk)
 
 static duk_ret_t duk_textri(duk_context* duk)
 {
-	s32 pt[12];
+	float pt[12];
 
 	for (s32 i = 0; i < COUNT_OF(pt); i++)
-		pt[i] = duk_to_int(duk, i);
+		pt[i] = (float)duk_to_number(duk, i);
 	tic_mem* memory = (tic_mem*)getDukMachine(duk);
 	bool use_map = duk_is_null_or_undefined(duk, 12) ? false : duk_to_boolean(duk, 12);
 	u8 chroma = duk_is_null_or_undefined(duk, 13) ? 0xff : duk_to_int(duk, 13);

--- a/src/luaapi.c
+++ b/src/luaapi.c
@@ -299,7 +299,7 @@ static s32 lua_textri(lua_State* lua)
 		float pt[12];
 
 		for (s32 i = 0; i < COUNT_OF(pt); i++)
-			pt[i] = getLuaNumber(lua, i + 1);
+			pt[i] = (float)lua_tonumber(lua, i + 1);
 
 		tic_mem* memory = (tic_mem*)getLuaMachine(lua);
 		u8 chroma = 0xff;

--- a/src/tic.c
+++ b/src/tic.c
@@ -846,6 +846,7 @@ static void ticTexLine(tic_mem* memory, TexVert *v0, TexVert *v1)
 
 	float dy = bot->y - top->y;
 	if ((s32)dy == 0)	return;
+	if ((s32)dy > TIC80_HEIGHT)	return;	//	reject large polys 
 
 	float step_x = (bot->x - top->x) / dy;
 	float step_u = (bot->u - top->u) / dy;
@@ -864,7 +865,7 @@ static void ticTexLine(tic_mem* memory, TexVert *v0, TexVert *v1)
 	}
 }
 
-static void api_textri(tic_mem* memory, s32 x1, s32 y1, s32 x2, s32 y2, s32 x3, s32 y3, s32 u1, s32 v1, s32 u2, s32 v2, s32 u3, s32 v3,bool use_map,u8 chroma)
+static void api_textri(tic_mem* memory, float x1, float y1, float x2, float y2, float x3, float y3, float u1, float v1, float u2, float v2, float u3, float v3, bool use_map, u8 chroma)
 {
 	tic_machine* machine = (tic_machine*)memory;
 	TexVert V0, V1, V2;

--- a/src/ticapi.h
+++ b/src/ticapi.h
@@ -82,7 +82,7 @@ typedef struct
 	void (*circle)				(tic_mem* memory, s32 x, s32 y, u32 radius, u8 color);
 	void (*circle_border)		(tic_mem* memory, s32 x, s32 y, u32 radius, u8 color);
 	void (*tri)					(tic_mem* memory, s32 x1, s32 y1, s32 x2, s32 y2, s32 x3, s32 y3, u8 color);
-	void (*textri)				(tic_mem* memory, s32 x1, s32 y1, s32 x2, s32 y2, s32 x3, s32 y3, s32 u1, s32 v1, s32 u2, s32 v2, s32 u3, s32 v3 ,bool use_map,u8 chroma);
+	void(*textri)				(tic_mem* memory, float x1, float y1, float x2, float y2, float x3, float y3, float u1, float v1, float u2, float v2, float u3, float v3, bool use_map, u8 chroma);
 	void (*clip)				(tic_mem* memory, s32 x, s32 y, s32 width, s32 height);
 	void (*sfx)					(tic_mem* memory, s32 index, s32 note, s32 octave, s32 duration, s32 channel);
 	void (*sfx_stop)			(tic_mem* memory, s32 channel);


### PR DESCRIPTION
reject triangles that can crash
XYUV's switched to Floats. for textri ( this is important )