### PR TITLE
Remove whitespaces when pasting a new palette

### DIFF
--- a/src/sfx.c
+++ b/src/sfx.c
@@ -625,7 +625,7 @@ static void copyFromClipboard(Sfx* sfx)
 {
 	tic_sound_effect* effect = getEffect(sfx);
 
-	if(fromClipboard(effect, sizeof(tic_sound_effect), true))
+	if(fromClipboard(effect, sizeof(tic_sound_effect), true, false))
 		history_add(sfx->history.envelope);
 }
 
@@ -633,7 +633,7 @@ static void copyWaveFromClipboard(Sfx* sfx)
 {
 	tic_waveform* wave = getWaveform(sfx);
 
-	if(fromClipboard(wave, sizeof(tic_waveform), true))
+	if(fromClipboard(wave, sizeof(tic_waveform), true, false))
 		history_add(sfx->history.waveform);
 }
 

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -648,8 +648,8 @@ static void drawRGBSlider(Sprite* sprite, s32 x, s32 y, u8* value)
 
 static void pasteColor(Sprite* sprite)
 {
-	fromClipboard(sprite->tic->cart.palette.data, sizeof(tic_palette), false);
-	fromClipboard(&sprite->tic->cart.palette.colors[sprite->color], sizeof(tic_rgb), false);
+	fromClipboard(sprite->tic->cart.palette.data, sizeof(tic_palette), false, true);
+	fromClipboard(&sprite->tic->cart.palette.colors[sprite->color], sizeof(tic_rgb), false, true);
 }
 
 static void drawRGBTools(Sprite* sprite, s32 x, s32 y)
@@ -1240,7 +1240,7 @@ static void copyFromClipboard(Sprite* sprite)
 
 	if(buffer)
 	{
-		if(fromClipboard(buffer, size, true))
+		if(fromClipboard(buffer, size, true, false))
 		{
 			SDL_Rect rect = getSpriteRect(sprite);
 			s32 r = rect.x + rect.w;

--- a/src/studio.c
+++ b/src/studio.c
@@ -373,7 +373,24 @@ void str2buf(const char* str, s32 size, void* buf, bool flip)
 	}
 }
 
-bool fromClipboard(void* data, s32 size, bool flip)
+void removeWhiteSpaces(char* str)
+{
+        int i = 0;
+        int len = strlen(str);
+    
+        for (int j = 0; j < len; j++) {
+                if (!isspace(str[j])) {
+                        str[i] = str[j];
+                        i++;
+                }
+        }
+    
+        if (i < len - 1) {
+                str[i] = '\0';
+        }
+}
+
+bool fromClipboard(void* data, s32 size, bool flip, bool remove_white_spaces)
 {
 	if(data)
 	{
@@ -383,6 +400,10 @@ bool fromClipboard(void* data, s32 size, bool flip)
 
 			if(clipboard)
 			{
+                                if (remove_white_spaces)
+                                        removeWhiteSpaces(clipboard);
+                            
+                            
 				bool valid = strlen(clipboard) == size * 2;
 
 				if(valid) str2buf(clipboard, strlen(clipboard), data, flip);

--- a/src/studio.h
+++ b/src/studio.h
@@ -154,8 +154,9 @@ void exitStudio();
 u32 unzip(u8** dest, const u8* source, size_t size);
 
 void str2buf(const char* str, s32 size, void* buf, bool flip);
+void removeWhiteSpaces(char* str);
 void toClipboard(const void* data, s32 size, bool flip);
-bool fromClipboard(void* data, s32 size, bool flip);
+bool fromClipboard(void* data, s32 size, bool flip, bool remove_white_spaces);
 
 typedef enum
 {


### PR DESCRIPTION
Im trying to solve issue https://github.com/nesbox/TIC-80/issues/455.
When copying a hex palette from the web, it may contain spaces, tabs or carriage commands (\r or \n).
Pasting it on TIC-80 will not work, making the users' life difficult (they have to fix the string in an editor).

This commit enables pasting hex palettes with blank spaces.

PS: it has been more than 10 years since the last time I wrote a single line in C. Please, let me know if Im making really noob mistakes.