### PR TITLE
Don't show mouse if we don't use it for input.

### DIFF
--- a/src/studio.c
+++ b/src/studio.c
@@ -2300,13 +2300,17 @@ static void blitCursor(const u8* in)
 
 static void renderCursor()
 {
-	if(studio.mode == TIC_RUN_MODE &&
-		studio.tic->ram.vram.vars.cursor)
-		{
-			SDL_ShowCursor(SDL_DISABLE);
-			blitCursor(studio.tic->ram.sprites.data[studio.tic->ram.vram.vars.cursor].data);
-			return;
-		}
+	if(studio.mode == TIC_RUN_MODE && !studio.tic->input.mouse)
+	{
+		SDL_ShowCursor(SDL_DISABLE);
+		return;
+	}
+	if(studio.mode == TIC_RUN_MODE && studio.tic->ram.vram.vars.cursor)
+	{
+		SDL_ShowCursor(SDL_DISABLE);
+		blitCursor(studio.tic->ram.sprites.data[studio.tic->ram.vram.vars.cursor].data);
+		return;
+	}
 
 	SDL_ShowCursor(getConfig()->theme.cursor.sprite >= 0 ? SDL_DISABLE : SDL_ENABLE);
 

--- a/src/tic.c
+++ b/src/tic.c
@@ -1577,7 +1577,7 @@ static void api_tick(tic_mem* tic, tic_tick_data* data)
 					tic->input.gamepad = 1;
 				else if(compareMetatag(code, "input", "keyboard", config->singleComment))
 					tic->input.keyboard = 1;
-				else tic->input.data = -1;
+				else tic->input.data = -1;  // default is all enabled
 
 				data->start = data->counter();
 				


### PR DESCRIPTION
Hide mouse when the input tag in the header is set to:
--input: keyboard
--input: gamepad