### PR TITLE
Fix flipping a selection then trying to move it

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -548,6 +548,7 @@ static void flipCanvasHorz(Sprite* sprite)
 		}
 
 	history_add(sprite->history);
+	copySelection(sprite);
 }
 
 static void flipCanvasVert(Sprite* sprite)
@@ -569,6 +570,7 @@ static void flipCanvasVert(Sprite* sprite)
 		}
 
 	history_add(sprite->history);
+	copySelection(sprite);
 }
 
 static void drawMoveButtons(Sprite* sprite)


### PR DESCRIPTION
After flipping a selection, when we try to move it, TIC-80 was getting the previous seleciton back and then moving it.