### PR TITLE
Added "wiki" command to open github wiki in browser

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -323,6 +323,12 @@ static void processConsoleBackspace(Console* console)
 
 static void onConsoleHelpCommand(Console* console, const char* param);
 
+static void onConsoleWikiCommand(Console* console, const char* param)
+{
+	getSystem()->openSystemPath("https://github.com/nesbox/TIC-80/wiki");
+	commandDone(console);
+}
+
 static void onConsoleExitCommand(Console* console, const char* param)
 {
 	exitStudio();
@@ -2350,6 +2356,7 @@ static const struct
 } AvailableConsoleCommands[] =
 {
 	{"help", 	NULL, "show this info", 			onConsoleHelpCommand},
+	{"wiki", 	NULL, "open github wiki page", 		onConsoleWikiCommand},
 	{"ram", 	NULL, "show memory info", 			onConsoleRamCommand},
 	{"exit", 	"quit", "exit the application", 	onConsoleExitCommand},
 	{"new", 	NULL, "create new cart",			onConsoleNewCommand},


### PR DESCRIPTION
This would close issue #549. I find it useful for quickly opening the wiki. It also shows new users that the wiki exists.