### PR TITLE
Ignore files/folders generated by cmake Xcode generator on macOS (#320)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ build/macosx/tic80.dmg
 build/macosx/3rd-party/
 build/macosx/CMakeScripts/
 build/macosx/TIC-80.xcodeproj/
+build/macosx/TIC-80.build/
+build/macosx/bin/
 tools/bundler/assets/
 tools/bundler/bin/
 tools/bin2txt/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ lib/macos/.DS_Store
 build/macosx/tic80.icns
 build/macosx/tic80.app/
 build/macosx/tic80.dmg
+build/macosx/3rd-party/
+build/macosx/CMakeScripts/
+build/macosx/TIC-80.xcodeproj/
 tools/bundler/assets/
 tools/bundler/bin/
 tools/bin2txt/*.exe


### PR DESCRIPTION
If you use cmake's Xcode generator, it creates some folders in build/macosx that weren't ignored. This PR adds those (3rd-party/, CMakeScripts/, and TIC-80.xcodeproj/, and build product folders) to the .gitignore file.