### PR TITLE
Fix failing #ifndef TARGET_OS_IPHONE check when building for macOS

### DIFF
--- a/include/tic80_config.h
+++ b/include/tic80_config.h
@@ -31,7 +31,7 @@
 #if defined(__APPLE__)
 #	include "AvailabilityMacros.h"
 #	include "TargetConditionals.h"
-#	ifndef TARGET_OS_IPHONE
+#	if !TARGET_OS_IPHONE
 #		undef __TIC_MACOSX__
 #		define __TIC_MACOSX__ 1
 #		if MAC_OS_X_VERSION_MIN_REQUIRED < 1060


### PR DESCRIPTION
Currently, tic80_config.h checks to see if the project is being built on macOS but not iOS using `#ifndef TARGET_OS_IPHONE`. This doesn't work correctly because `TARGET_OS_IPHONE` _is_ defined on macOS, it's just defined to 0 instead of 1. So, the correct check is `#if TARGET_OS_IPHONE`.

This PR fixes that, which makes export (and probably other things) work again in builds on macOS.