### PR TITLE
Add eval command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ To make a retro styled game, the whole process of creation and execution takes p
 ![TIC-80](https://user-images.githubusercontent.com/1101448/29687467-3ddc432e-8925-11e7-8156-5cec3700cc04.gif)
 
 ### Features
-- Multiple progamming languages: Lua, Moonscript, Javascript and Wren
+- Multiple progamming languages: [Lua](https://www.lua.org),
+  [Moonscript](https://moonscript.org),
+  [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript),
+  [Wren](http://wren.io/), and [Fennel](https://fennel-lang.org).
 - Games can have mouse and keyboard as input
 - Games can have up to 4 controllers as input
 - Builtin editors: for code, sprites, world maps, sound effects and music

--- a/src/console.c
+++ b/src/console.c
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "ext/gif.h"
 #include "ext/file_dialog.h"
-#include "machine.h"
 
 #include <zlib.h>
 #include <ctype.h>
@@ -2221,20 +2220,8 @@ static void onConsoleEvalCommand(Console* console, const char* param)
 {
 	printLine(console);
 
-	tic_machine* machine = (tic_machine*)console->tic;
-	lua_State* lua = machine->lua;
-
-	// TODO: check for other languages/runtimes?
-	if(lua)
-	{
-		if(luaL_dostring(lua, param) != LUA_OK)
-        {
-			printError(console, lua_tostring(lua, -1));
-		}
-		lua_settop(lua, 0);
-	}
-	else
-		printError(console, "Lua state uninitialized.\n");
+	const tic_script_config* script_config = console->tic->api.get_script_config(console->tic);
+	script_config->eval(console->tic, param);
 
 	commandDone(console);
 }

--- a/src/console.c
+++ b/src/console.c
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "ext/gif.h"
 #include "ext/file_dialog.h"
+#include "machine.h"
 
 #include <zlib.h>
 #include <ctype.h>
@@ -2216,6 +2217,28 @@ static void onConsoleResumeCommand(Console* console, const char* param)
 	resumeRunMode();
 }
 
+static void onConsoleEvalCommand(Console* console, const char* param)
+{
+	printLine(console);
+
+	tic_machine* machine = (tic_machine*)console->tic;
+	lua_State* lua = machine->lua;
+
+	// TODO: check for other languages/runtimes?
+	if(lua)
+	{
+		if(luaL_dostring(lua, param) != LUA_OK)
+        {
+			printError(console, lua_tostring(lua, -1));
+		}
+		lua_settop(lua, 0);
+	}
+	else
+		printError(console, "Lua state uninitialized.\n");
+
+	commandDone(console);
+}
+
 static void onAddFile(const char* name, AddResult result, void* data)
 {
 	Console* console = (Console*)data;
@@ -2418,6 +2441,7 @@ static const struct
 	{"save", 	NULL, "save cart",	 				onConsoleSaveCommand},
 	{"run",		NULL, "run loaded cart",			onConsoleRunCommand},
 	{"resume",	NULL, "resume run cart",			onConsoleResumeCommand},
+	{"eval",	"=",  "run code",					onConsoleEvalCommand},
 	{"dir",		"ls", "show list of files", 		onConsoleDirCommand},
 	{"cd",		NULL, "change directory", 			onConsoleChangeDirectory},
 	{"mkdir",	NULL, "make directory", 			onConsoleMakeDirectory},

--- a/src/jsapi.c
+++ b/src/jsapi.c
@@ -1001,6 +1001,10 @@ static const tic_outline_item* getJsOutline(const char* code, s32* size)
 	return items;
 }
 
+void evalJs(tic_mem* tic, const char* code) {
+	printf("TODO: JS eval not yet implemented\n.");
+}
+
 static const tic_script_config JsSyntaxConfig = 
 {
 	.init 				= initJavascript,
@@ -1011,6 +1015,7 @@ static const tic_script_config JsSyntaxConfig =
 
 	.getOutline			= getJsOutline,
 	.parse 				= parseCode,
+	.eval				= evalJs,
 
 	.blockCommentStart 	= "/*",
 	.blockCommentEnd 	= "*/",

--- a/src/ticapi.h
+++ b/src/ticapi.h
@@ -106,6 +106,7 @@ struct tic_script_config
 
 	const tic_outline_item* (*getOutline)(const char* code, s32* size);
 	void (*parse)(const tic_script_config* config, const char* start, u8* color, const tic_code_theme* theme);
+	void (*eval)(tic_mem* tic, const char* code);
 
 	const char* blockCommentStart;
 	const char* blockCommentEnd;

--- a/src/wrenapi.c
+++ b/src/wrenapi.c
@@ -1344,6 +1344,10 @@ static const tic_outline_item* getWrenOutline(const char* code, s32* size)
 	return items;
 }
 
+void evalWren(tic_mem* tic, const char* code) {
+	printf("TODO: Wren eval not yet implemented\n.");
+}
+
 static const tic_script_config WrenSyntaxConfig = 
 {
 	.init 				= initWren,
@@ -1354,6 +1358,7 @@ static const tic_script_config WrenSyntaxConfig =
 
 	.getOutline			= getWrenOutline,
 	.parse 				= parseCode,
+	.eval				= evalWren,
 
 	.blockCommentStart 	= "/*",
 	.blockCommentEnd 	= "*/",


### PR DESCRIPTION
I have this working as a new command in console.c. I named it "eval"
so that it can be extended with other languages in the future. However
I think some of this code belongs in a different file. Maybe luaapi.c?
It feels wrong to be calling `lua_*` functions directly from here. Let
me know if you have a suggestion for how to improve this or if I'm
wrong and it's fine where it is.

Also, I haven't used the C API for Lua enough to know whether this is
correct use of the stack; I'm guessing that unless we call
`lua_settop(lua, 0)` the values from the code that's run (or the error
message string) would be left on the stack? Is `lua_settop` the right
way to clear out these values and ensure they get GCed?

The problem with moving the dostring code to another file is that I'm
not sure how you would return an error message from a function in
luaapi.c but still be careful not to call `lua_settop` until after the
string has been printed. Interested in hearing what you think about this.