### PR TITLE
Attempt to fix keyboard layout issues (WIP)

### DIFF
--- a/include/tic80.h
+++ b/include/tic80.h
@@ -121,7 +121,7 @@ typedef struct
 	tic80_gamepads gamepads;
 	tic80_mouse mouse;
 	tic80_keyboard keyboard;
-
+	s8 text_char;
 } tic80_input;
 
 TIC80_API tic80* tic80_create(s32 samplerate);

--- a/src/studio.c
+++ b/src/studio.c
@@ -240,21 +240,7 @@ static struct
 char getKeyboardText()
 {
 	tic_mem* tic = impl.studio.tic;
-
-	static const char Symbols[] = 	"abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./ ";
-	static const char Shift[] = 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ)!@#$%^&*(_+{}|:\"~<>? ";
-
-	enum{Count = sizeof Symbols};
-
-	for(s32 i = 0; i < TIC80_KEY_BUFFER; i++)
-	{
-		tic_key key = tic->ram.input.keyboard.keys[i];
-
-		if(key > 0 && key < Count && tic->api.keyp(tic, key, KEYBOARD_HOLD, KEYBOARD_PERIOD))
-			return tic->api.key(tic, tic_key_shift) ? Shift[key-1] : Symbols[key-1];
-	}
-
-	return 0;
+	return tic->ram.input.text_char;
 }
 
 bool keyWasPressed(tic_key key)

--- a/src/system.c
+++ b/src/system.c
@@ -715,6 +715,7 @@ static void pollEvent()
 	tic80_input* input = &tic->ram.input;
 
 	{
+		input->text_char = '\0';
 		input->mouse.btns = 0;
 	}
 
@@ -724,6 +725,14 @@ static void pollEvent()
 	{
 		switch(event.type)
 		{
+		case SDL_TEXTINPUT:
+			{
+				const char* symbol = event.text.text;
+
+				if(strlen(symbol) == 1)
+					input->text_char = *symbol;
+			}
+			break;
 		case SDL_MOUSEWHEEL:
 			{
 				input->mouse.scrollx = event.wheel.x;

--- a/src/tic.c
+++ b/src/tic.c
@@ -81,7 +81,7 @@ STATIC_ASSERT(tic_track, sizeof(tic_track) == 3*MUSIC_FRAMES+3);
 STATIC_ASSERT(tic_vram, sizeof(tic_vram) == TIC_VRAM_SIZE);
 STATIC_ASSERT(tic_ram, sizeof(tic_ram) == TIC_RAM_SIZE);
 STATIC_ASSERT(tic_sound_register, sizeof(tic_sound_register) == 16+2);
-STATIC_ASSERT(tic80_input, sizeof(tic80_input) == 12);
+STATIC_ASSERT(tic80_input, sizeof(tic80_input) == 16);
 
 static void update_amp(blip_buffer_t* blip, tic_sound_register_data* data, s32 new_amp )
 {

--- a/src/tic.h
+++ b/src/tic.h
@@ -419,7 +419,7 @@ typedef union
 		tic_tiles sprites;
 		tic_map map;
 		tic80_input input;
-		u8 unknown[16];
+		u8 unknown[12];
 		tic_sound_register registers[TIC_SOUND_CHANNELS];
 		tic_sfx sfx;
 		tic_music music;


### PR DESCRIPTION
This approach uses SDL_TextInputEvent a bit similarly to 0.60.3; The 1st byte out of 16 currently unused is now used to store one of the characters that were input in the current frame or 0 if there weren't any. getKeyboardText() simply returns it. It's readable with peek(65420) and can be also made available via an API function, for convenience.

Note: I didn't know how to convince the compiler that tic80_input should be 13 bytes, so it's 16 instead, with 12 bytes remaining.

Also, this breaks the android touch keyboard. Probably. I don't know how to build for android. It might be fixable by simply using the code I removed from getKeyboardText() to set text_char, but only when the touch KB is in use.

but fixes #655, #661