### PR TITLE
Wren outline lets you navigate by class.

### DIFF
--- a/src/wrenapi.c
+++ b/src/wrenapi.c
@@ -1361,6 +1361,8 @@ static const char* const WrenKeywords [] =
 	"static", "super", "this", "true", "var", "while"
 };
 
+static inline bool isalnum_(char c) {return isalnum(c) || c == '_';}
+
 static const tic_outline_item* getWrenOutline(const char* code, s32* size)
 {
 	enum{Size = sizeof(tic_outline_item)};
@@ -1368,6 +1370,56 @@ static const tic_outline_item* getWrenOutline(const char* code, s32* size)
 	*size = 0;
 
 	static tic_outline_item* items = NULL;
+
+	if(items)
+	{
+		free(items);
+		items = NULL;
+	}
+
+	const char* ptr = code;
+
+	while(true)
+	{
+		// Lets look for all of the class definitions.
+		// Finding the methods within each class might be nice someday.
+		static const char ClassString[] = "class ";
+
+		ptr = strstr(ptr, ClassString);
+
+		if(ptr)
+		{
+			ptr += sizeof ClassString - 1;
+
+			const char* start = ptr;
+			const char* end = start;
+
+			while(*ptr)
+			{
+				char c = *ptr;
+
+				if(isalnum_(c));
+				else
+				{
+					end = ptr;
+					break;
+				}
+
+				ptr++;
+			}
+
+			if(end > start)
+			{
+				items = items ? realloc(items, (*size + 1) * Size) : malloc(Size);
+
+				items[*size].pos = start - code;
+				items[*size].size = end - start;
+
+				(*size)++;
+			}
+		}
+		else break;
+	}
 
 	return items;
 }


### PR DESCRIPTION
This PR adds support for the outline mode when coding in Wren.

It navigates from class to class. It would be better to navigate method to method, but parsing that is a bit harder. This at least gives you something useful than an empty outline :)

The code is mostly copied from jsapi.c's `getJsOutline()`
