### PR TITLE
Can set parameters and specific cartridge through arguments option.

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1528,15 +1528,21 @@ static void onEmscriptenWgetError(const char* error) {}
 
 static void emsStart(s32 argc, char **argv, const char* folder)
 {
-	if(argc == 2)
+	if (argc >= 2)
 	{
-		startVars.argc = argc;
-		startVars.argv = argv;
-		startVars.folder = folder;
+		int pos = strlen(argv[1]) - strlen(".tic");
+		if (pos >= 0 && strcmp(&argv[1][pos], ".tic") == 0)
+		{
+			startVars.argc = argc;
+			startVars.argv = argv;
+			startVars.folder = folder;
 
-		emscripten_async_wget(argv[1], DEFAULT_CART, onEmscriptenWget, onEmscriptenWgetError);
+			emscripten_async_wget(argv[1], DEFAULT_CART, onEmscriptenWget, onEmscriptenWgetError);
+			return;
+		}
 	}
-	else start(argc, argv, folder);
+
+	start(argc, argv, folder);
 }
 
 #endif


### PR DESCRIPTION
I wanted to set an optional parameter (for example `-uiscale`) and specific cartridge when initialize time on `wasm`.
Then I wrote the following code in Javascript.
```javascript
<script type="text/javascript">
  var Module = {
    canvas: document.getElementById('canvas'),
    arguments: ["tetris.tic", "-uiscale", "1.5"]
  };
</script>
```		

However, it couldn't work as my expected. An optional parameter was worked but didn't boot the cartridge.

I investigate the cause then found it. This p/r is my proposal.

My idea is that if `argc[1]` has `.tic` to suffix, we judge to it was given a cartridge.

Please take a look if you have time.
Regards.