### PR TITLE
fix -fullscreen

### DIFF
--- a/src/studio.c
+++ b/src/studio.c
@@ -1875,11 +1875,6 @@ Studio* studioInit(s32 argc, char **argv, s32 samplerate, const char* folder, Sy
 		setStudioMode(TIC_CONSOLE_MODE);
 	}
 
-	if(impl.console->goFullscreen)
-	{
-		goFullscreen();
-	}
-
 	if(impl.console->crtMonitor)
 	{
 		impl.config->data.crtMonitor = true;
@@ -1893,6 +1888,15 @@ Studio* studioInit(s32 argc, char **argv, s32 samplerate, const char* folder, Sy
 	impl.studio.isGamepadMode = isGamepadMode;
 
 	return &impl.studio;
+}
+
+void studioInitPost() {
+
+	if(impl.console->goFullscreen)
+	{
+		goFullscreen();
+	}
+
 }
 
 System* getSystem()

--- a/src/system.h
+++ b/src/system.h
@@ -101,3 +101,4 @@ typedef struct
 } Studio;
 
 TIC80_API Studio* studioInit(s32 argc, char **argv, s32 samplerate, const char* appFolder, System* system);
+TIC80_API void studioInitPost();

--- a/src/system/sdlgpu.c
+++ b/src/system/sdlgpu.c
@@ -1455,6 +1455,8 @@ static s32 start(s32 argc, char **argv, const char* folder)
 		SDL_GetWindowSize(platform.window, &w, &h);
 		GPU_SetWindowResolution(w, h);
 	}
+	
+	studioInitPost();
 
 	initTouchGamepad();
 	initTouchKeyboard();


### PR DESCRIPTION
src/system/sdlgpu.c start

the studioInit is called before SDL_CreateWindow
so the goFullscreen wont get a valid window ID ,makes the fullscreen not working at all

so seperate the goFullscreen from studioInit and call it after SDL_CreateWindow
everything works now

