### PR TITLE
Allow Docker (dapper) builds

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,6 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y git cmake libgtk-3-dev \ 
+    libglvnd-dev libglu1-mesa-dev freeglut3-dev libasound2-dev
+WORKDIR ${DAPPER_SOURCE:-/source}
+ENV DAPPER_OUTPUT bin
+ENTRYPOINT ["sh", "-c", "cmake . && make -j4"]


### PR DESCRIPTION
This pull request adds a `Dockerfile.dapper` which builds TIC-80 on an Ubuntu 18.04 Docker container using [dapper](//github.com/rancher/dapper).

Build instructions:
1. Download [dapper](https://github.com/rancher/dapper#installation).
2. `$ git clone http://github.nesbox/TIC-80 --recurse-submodules`
3. `$ dapper`

Binaries will be located at `bin/`, as always.