### PR TITLE
Workaround for freeze on fullscreen under macOS

### DIFF
--- a/src/system/sdlgpu.c
+++ b/src/system/sdlgpu.c
@@ -776,6 +776,7 @@ static void pollEvent()
 
 	SDL_Event event;
 
+	SDL_PumpEvents();
 	while(SDL_PollEvent(&event))
 	{
 		switch(event.type)


### PR DESCRIPTION
Hi all ^ ^

On macOS 10.13.5, the TIC-80 window freezes when fullscreen mode is toggled. Reproducible with both official release and binary built from source.

Only the SDL backend has the problem, and I've traced down the issue to be an upstream issue reported in [SDL bugzilla](https://bugzilla.libsdl.org/show_bug.cgi?id=4369). In short, the Cocoa implementation of `SDL_PumpEvents()` has a weird behaviour — it may report "no events" during one call and find an event in the next (called in a row without any delay). This would result in some events not processed and thus freezing the SDL window.

I suppose it's better to research a bit more and report it to SDL, but I have come up with a workaround for now. It's very simple, but it's inconvenient for me to confirm it doesn't break on other platforms, so please help with that. Thanks in advance!