### PR TITLE
Fix colour replacement misses borders

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -266,8 +266,8 @@ static void floodFill(Sprite* sprite, s32 l, s32 t, s32 r, s32 b, s32 x, s32 y, 
 
 static void replaceColor(Sprite* sprite, s32 l, s32 t, s32 r, s32 b, s32 x, s32 y, u8 color, u8 fill)
 {
-	for(s32 sy = t; sy < b; sy++)
-		for(s32 sx = l; sx < r; sx++)
+	for(s32 sy = t; sy <= b; sy++)
+		for(s32 sx = l; sx <= r; sx++)
 			if(getSheetPixel(sprite, sx, sy) == color)
 				setSheetPixel(sprite, sx, sy, fill);
 }


### PR DESCRIPTION
A fix for a little bug, #586.

I didn't change the actual arguments in order to keep consistency with `floodFill()`, which receives inclusive coordinates. Hope it helps!