### PR TITLE
When --watch flag is passed, reload all the code upon resume.

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -2156,6 +2156,11 @@ static void onConsoleResumeCommand(Console* console, const char* param)
 {
 	commandDone(console);
 
+	const tic_script_config* script_config = console->tic->api.get_script_config(console->tic);
+	if (script_config->eval && console->codeLiveReload.active)
+	{
+		script_config->eval(console->tic, console->tic->cart.code.data);
+	}
 	console->tic->api.resume(console->tic);
 
 	resumeRunMode();


### PR DESCRIPTION
One of the biggest problems I ran into when working on [my latest game jam entry](https://technomancy.itch.io/this-is-my-mech) was that the only way to make changes to the game state without restarting the whole game was `eval` which only takes a line at a time. I wanted to be able to reload my code and resume without wiping game state.

This patch implements that; when it detects that it is in "watch" mode, it automatically reloads all the game's code when you run `resume` in the console.

However, I'm not convinced that watch mode is the right way to determine whether to reload or not. For codebases that aren't written specifically to support reloading (that is, they do not preserve state in globals to keep them around between loads) resuming can act more like a full reset, which defeats the purpose of resuming; might as well just do `run` for that. So maybe another option would be to make the command take a param and only do this when someone runs `resume reload` instead?

I am open to other suggestions too; would love to hear your thoughts.