### PR TITLE
gitmodules: Ignore modifications in 3rd-party submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "3rd-party"]
 	path = 3rd-party
 	url = https://github.com/nesbox/3rd-party.git
+	ignore = dirty


### PR DESCRIPTION
When building, there can be built assets that report changes in the 3rd-party submodule when executing `git status`.

```
➜  TIC-80 git:(master) cmake .
➜  TIC-80 git:(master) make
➜  TIC-80 git:(master) git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)

	modified:   3rd-party (modified content)
```

With this change, the modified content is ignored. Since it's 3rd-party stuff, we should likely just ignore those changes.

```
➜  TIC-80 git:(git-modules) git status
On branch git-modules
nothing to commit, working tree clean
➜  TIC-80 git:(git-modules) 
```