### PR TITLE
cmake: Update CMake minimum version to 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.0)
 
 project(TIC-80 C CXX)
 message("Building for target : ${CMAKE_SYSTEM_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.3)
 
 project(TIC-80 C CXX)
 message("Building for target : ${CMAKE_SYSTEM_NAME}")


### PR DESCRIPTION
Is there a feature from CMake 3.9 that we need? Could we use 3.3? This will help with the NES Mini build.

From madmonkey.