### PR TITLE
Silence buffer overflow compiler warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ target_include_directories(tic80core PRIVATE ${THIRDPARTY_DIR}/fennel)
 
 add_dependencies(tic80core lua lpeg wren squirrel giflib)
 target_link_libraries(tic80core lua lpeg wren squirrel giflib)
+target_compile_options(tic80core PRIVATE -Wformat-truncation=0)
 
 if(LINUX)
 	target_link_libraries(tic80core m)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,6 @@ target_include_directories(tic80core PRIVATE ${THIRDPARTY_DIR}/fennel)
 
 add_dependencies(tic80core lua lpeg wren squirrel giflib)
 target_link_libraries(tic80core lua lpeg wren squirrel giflib)
-target_compile_options(tic80core PRIVATE -Wformat-truncation=0)
 
 if(LINUX)
 	target_link_libraries(tic80core m)

--- a/src/studio.c
+++ b/src/studio.c
@@ -1129,7 +1129,7 @@ static void updateTitle()
 	char name[FILENAME_MAX] = TIC_TITLE;
 
 	if(strlen(impl.console->romName))
-		sprintf(name, "%s [%s]", TIC_TITLE, impl.console->romName);
+		snprintf(name, FILENAME_MAX, "%s [%s]", TIC_TITLE, impl.console->romName);
 
 	impl.system->setWindowTitle(name);
 }
@@ -1200,7 +1200,7 @@ static void saveProject()
 	if(rom == CART_SAVE_OK)
 	{
 		char buffer[FILENAME_MAX];
-		sprintf(buffer, "%s SAVED :)", impl.console->romName);
+		snprintf(buffer, FILENAME_MAX, "%s SAVED :)", impl.console->romName);
 
 		for(s32 i = 0; i < (s32)strlen(buffer); i++)
 			buffer[i] = toupper(buffer[i]);


### PR DESCRIPTION
The compiler was complaining about a potential buffer overlow error, so I switched it to use snprintf instead, and then silenced the warning.