### PR TITLE
Fix .gitignore to ignore build/3rd-party

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.suo
 sexit
 .vscode/
+build/3rd-party/
 build/uwp/tic/Debug/
 build/uwp/tic/Release/
 build/uwp/tic/x64/


### PR DESCRIPTION
After building TIC-80 in the `build` directory, you're left with `build/3rd-party`. This adds that directory to the .gitignore so that it doesn't appear when running `git status`.