### PR TITLE
Collaboration feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(BUILD_LIBRETRO "libretro Enabled" ${BUILD_LIBRETRO_DEFAULT})
 option(BUILD_DEMO_CARTS "Demo Carts Enabled" ${BUILD_DEMO_CARTS_DEFAULT})
 option(BUILD_PRO "Build PRO version" FALSE)
 option(BUILD_PLAYER "Build standalone players" ${BUILD_PLAYER_DEFAULT})
+option(BUILD_COLLAB "Build with collaboration feature" OFF)
 
 if (BAREMETALPI)
 
@@ -276,6 +277,10 @@ set(TIC80CORE_SRC
 )
 
 add_library(tic80core STATIC ${TIC80CORE_SRC})
+
+if(BUILD_COLLAB)
+	target_compile_definitions(tic80core PUBLIC TIC_BUILD_WITH_COLLAB)
+endif()
 
 target_include_directories(tic80core PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(tic80core PRIVATE ${THIRDPARTY_DIR}/blip-buf)
@@ -612,6 +617,10 @@ set(TIC80LIB_SRC
 	${TIC80LIB_DIR}/surf.c
 	${TIC80LIB_DIR}/net.c
 )
+
+if(BUILD_COLLAB)
+	list(APPEND TIC80LIB_SRC ${TIC80LIB_DIR}/collab.c)
+endif()
 
 set(TIC80_OUTPUTS tic80)
 

--- a/src/code.h
+++ b/src/code.h
@@ -25,7 +25,12 @@
 #include "studio.h"
 
 typedef struct Code Code;
+
 typedef struct OutlineItem OutlineItem;
+#if defined(TIC_BUILD_WITH_COLLAB)
+typedef struct Edit Edit;
+typedef struct Collab Collab;
+#endif
 
 struct Code
 {
@@ -69,6 +74,19 @@ struct Code
 	struct History* history;
 	struct History* cursorHistory;
 
+#if defined(TIC_BUILD_WITH_COLLAB)
+	struct
+	{
+		Collab* collab;
+		
+		Edit* edits;
+		s32 editCount;
+
+		s32 diffCounter;
+		s32 diffNeeded;
+	} collab;
+#endif
+
 	enum
 	{
 		TEXT_RUN_CODE,
@@ -103,6 +121,9 @@ struct Code
 	void(*tick)(Code*);
 	void(*escape)(Code*);
 	void(*event)(Code*, StudioEvent);
+#if defined(TIC_BUILD_WITH_COLLAB)
+	void(*diff)(Code*);
+#endif
 	void(*update)(Code*);
 };
 

--- a/src/collab.c
+++ b/src/collab.c
@@ -1,0 +1,221 @@
+// MIT License
+
+// Copyright (c) 2017 Vadim Grigoruk @nesbox // grigoruk@gmail.com
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "collab.h"
+#include "studio.h"
+
+struct
+{
+    tic_mem *tic;
+
+	u8* stream;
+	s32 streamPos;
+	s32 streamSize;
+} impl;
+
+struct Collab
+{
+	s32 offset;
+	s32 size;
+	s32 count;
+	u8* changedBits;
+	bool anyChanged;
+};
+
+struct Collab* collab_create(s32 offset, s32 size, s32 count)
+{
+	Collab* collab = (Collab*)malloc(sizeof(Collab));
+
+	collab->offset = offset;
+	collab->size = size;
+	collab->count = count;
+
+	collab->changedBits = (u8*)malloc(BITARRAY_SIZE(count));
+	memset(collab->changedBits, 0, BITARRAY_SIZE(count));
+
+	collab->anyChanged = false;
+
+	return collab;
+}
+
+void collab_delete(Collab* collab)
+{
+	free(collab->changedBits);
+}
+
+void collab_diff(Collab* collab, tic_mem* tic)
+{
+	collab->anyChanged = false;
+
+    u8* cart = (u8*)&tic->cart + collab->offset;
+    u8* server = (u8*)&tic->collab + collab->offset;
+
+    for(s32 index = 0; index < collab->count; index++)
+    {
+        bool diff = memcmp(cart, server, collab->size);
+
+        if(diff)
+            collab->anyChanged = true;
+
+        tic_tool_poke1(collab->changedBits, index, diff);
+
+        cart += collab->size;
+        server += collab->size;
+    }
+}
+
+void* collab_data(Collab *collab, tic_mem *tic, s32 index)
+{
+    return (u8*)&tic->collab + collab->offset + collab->size * index;
+}
+
+bool collab_isChanged(Collab* collab, s32 index)
+{
+	return tic_tool_peek1(collab->changedBits, index);
+}
+
+void collab_setChanged(Collab* collab, s32 index, u8 value)
+{
+	tic_tool_poke1(collab->changedBits, index, value);
+}
+
+bool collab_anyChanged(Collab* collab)
+{
+	return collab->anyChanged;
+}
+
+void getCollabData(const char* path, void *dest, s32 destSize)
+{
+	char url[256];
+	snprintf(url, sizeof(url), "%s%s", getCollabUrl(), path);
+
+	s32 size;
+	void *buffer = getSystem()->getUrlRequest(url, &size);
+
+	if(buffer)
+	{
+		if(size == destSize)
+			memcpy(dest, buffer, destSize);
+		
+		free(buffer);
+	}
+}
+
+void collab_put(Collab* collab, tic_mem* tic)
+{
+    u8* data = (u8*)&tic->cart + collab->offset;
+    s32 size = collab->size * collab->count;
+
+    char url[1024];
+    snprintf(url, sizeof(url), "%s/?offset=%d&size=%d", getCollabUrl(), collab->offset, size);
+	getSystem()->putUrlRequest(url, data, size);
+}
+
+void collab_get(Collab* collab, tic_mem* tic)
+{
+    u8* data = (u8*)&tic->cart + collab->offset;
+    s32 size = collab->size * collab->count;
+
+    char url[1024];
+    snprintf(url, sizeof(url), "/?offset=%d&size=%d", collab->offset, size);
+    getCollabData(url, data, size);
+}
+
+void collab_putRange(Collab* collab, tic_mem* tic, s32 first, s32 count)
+{
+    s32 offset = collab->offset + collab->size * first;
+    s32 size = count * collab->size;
+    u8* data = (u8*)&tic->cart + offset;
+
+    char url[1024];
+    snprintf(url, sizeof(url), "%s/?offset=%d&size=%d", getCollabUrl(), offset, size);
+	getSystem()->putUrlRequest(url, data, size);
+}
+
+void collab_getRange(Collab* collab, tic_mem* tic, s32 first, s32 count)
+{
+    s32 offset = collab->offset + collab->size * first;
+    s32 size = count * collab->size;
+    u8* data = (u8*)&tic->cart + offset;
+
+    char url[1024];
+    snprintf(url, sizeof(url), "/?offset=%d&size=%d", offset, size);
+    getCollabData(url, data, size);
+}
+
+void collab_putInitialData(tic_mem *tic)
+{
+    char url[1024];
+    snprintf(url, sizeof(url), "%s/?offset=0&size=%d", getCollabUrl(), (int)sizeof(tic_cartridge));
+	getSystem()->putUrlRequest(url, &tic->cart, sizeof(tic_cartridge));
+}
+
+typedef struct
+{
+	s32 offset;
+	s32 size;
+} StreamChunk;
+
+static void collab_streamCallback(u8* buffer, s32 size, void* data)
+{
+	if(impl.streamPos + size > impl.streamSize)
+	{
+		impl.streamSize = impl.streamPos + size;
+		impl.stream = realloc(impl.stream, impl.streamSize);
+	}
+
+	memcpy(impl.stream + impl.streamPos, buffer, size);
+	impl.streamPos += size;
+
+	while(impl.streamPos >= sizeof(StreamChunk))
+	{
+		StreamChunk* chunk = (StreamChunk*)impl.stream;
+
+		if(chunk->offset > sizeof(tic_cartridge))
+			continue;
+		if(chunk->offset + chunk->size > sizeof(tic_cartridge))
+			chunk->size = sizeof(tic_cartridge) - chunk->offset;
+
+		char url[1024];
+		snprintf(url, sizeof(url), "/?offset=%d&size=%d", chunk->offset, chunk->size);
+		getCollabData(url, (u8*)&impl.tic->collab + chunk->offset, chunk->size);
+
+		memmove(impl.stream, impl.stream + sizeof(StreamChunk), impl.streamPos - sizeof(StreamChunk));
+		impl.streamPos -= sizeof(StreamChunk);
+	}
+
+    onCollabChanges();
+}
+
+void collab_startChangesStream(tic_mem *tic)
+{
+    impl.tic = tic;
+
+	char url[1024];
+	snprintf(url, sizeof(url), "%s/?watch=1", getCollabUrl());
+	getSystem()->getUrlStream(url, collab_streamCallback, NULL);
+}
+
+void collab_stopChangesStream()
+{
+	getSystem()->getUrlStream("", NULL, NULL);
+}

--- a/src/collab.h
+++ b/src/collab.h
@@ -22,68 +22,33 @@
 
 #pragma once
 
-#include "studio.h"
-
-typedef struct Sprite Sprite;
-
-typedef struct History History;
 #if defined(TIC_BUILD_WITH_COLLAB)
+#define IF_COLLAB( ... ) __VA_ARGS__
+#else
+#define IF_COLLAB( ... )
+#endif
+
+#if defined(TIC_BUILD_WITH_COLLAB)
+
+#include <tic80_types.h>
+
+typedef struct tic_mem tic_mem;
+
 typedef struct Collab Collab;
+
+struct Collab* collab_create(s32 offset, s32 size, s32 count);
+void collab_delete(Collab* collab);
+void collab_diff(Collab *collab, tic_mem *tic);
+void* collab_data(Collab *collab, tic_mem *tic, s32 index);
+bool collab_isChanged(Collab *collab, s32 index);
+void collab_setChanged(Collab* collab, s32 index, u8 value);
+bool collab_anyChanged(Collab *collab);
+void collab_put(Collab* collab, tic_mem* tic);
+void collab_get(Collab* collab, tic_mem* tic);
+void collab_putRange(Collab* collab, tic_mem* tic, s32 first, s32 count);
+void collab_getRange(Collab* collab, tic_mem* tic, s32 first, s32 count);
+void collab_putInitialData(tic_mem *tic);
+void collab_startChangesStream(tic_mem *tic);
+void collab_stopChangesStream();
+
 #endif
-
-struct Sprite
-{
-	tic_mem* tic;
-
-	tic_tiles* src;
-
-	s32 bank;
-	
-	u32 tickCounter;
-
-	u16 index;
-	u8 color;
-	u8 color2;
-	u8 size;
-	u8 brushSize;
-
-	bool editPalette;
-
-	struct
-	{
-		tic_rect rect;
-		tic_point start;
-		bool drag;
-		u8* back;
-		u8* front;
-	}select;
-
-	enum
-	{
-		SPRITE_DRAW_MODE,
-		SPRITE_PICK_MODE,
-		SPRITE_SELECT_MODE,
-		SPRITE_FILL_MODE,
-	}mode;
-
-	struct History* history;
-
-#if defined(TIC_BUILD_WITH_COLLAB)
-	struct
-	{
-		struct Collab* tiles;
-		struct Collab* flags;
-		struct Collab* palette;
-	}collab;
-#endif
-	
-	void (*tick)(Sprite*);
-	void (*event)(Sprite*, StudioEvent);
-#if defined(TIC_BUILD_WITH_COLLAB)
-	void (*diff)(Sprite*);
-#endif
-	void (*scanline)(tic_mem* tic, s32 row, void* data);
-	void (*overline)(tic_mem* tic, void* data);
-};
-
-void initSprite(Sprite*, tic_mem*, s32 bank);

--- a/src/fs.c
+++ b/src/fs.c
@@ -301,7 +301,7 @@ static void onDirResponse(u8* buffer, s32 size, void* data)
 static void netDirRequest(const char* path, ListCallback callback, void* data)
 {
 	char request[FILENAME_MAX] = {'\0'};
-	sprintf(request, "/api?fn=dir&path=%s", path);
+	sprintf(request, "http://"TIC_HOST"/api?fn=dir&path=%s", path);
 
 	s32 size = 0;
 	void* buffer = getSystem()->getUrlRequest(request, &size);
@@ -1083,7 +1083,7 @@ void* fsLoadFileByHash(FileSystem* fs, const char* hash, s32* size)
 	}
 
 	char path[FILENAME_MAX] = {0};
-	sprintf(path, "/cart/%s/cart.tic", hash);
+	sprintf(path, "http://"TIC_HOST"/cart/%s/cart.tic", hash);
 	void* data = getSystem()->getUrlRequest(path, size);
 
 	if(data)

--- a/src/map.h
+++ b/src/map.h
@@ -26,6 +26,10 @@
 
 typedef struct Map Map;
 
+#if defined(TIC_BUILD_WITH_COLLAB)
+typedef struct Collab Collab;
+#endif
+
 struct Map
 {
 	tic_mem* tic;
@@ -79,11 +83,17 @@ struct Map
 	u8* paste;
 
 	struct History* history;
+#if defined(TIC_BUILD_WITH_COLLAB)
+	struct Collab* collab;
+#endif
 
 	void (*tick)(Map*);
 	void (*event)(Map*, StudioEvent);
+#if defined(TIC_BUILD_WITH_COLLAB)
+	void (*diff)(Map*);
+#endif
 	void (*scanline)(tic_mem* tic, s32 row, void* data);
 	void (*overline)(tic_mem* tic, void* data);
 };
 
-void initMap(Map*, tic_mem*, tic_map* src);
+void initMap(Map*, tic_mem*, s32 bank);

--- a/src/music.h
+++ b/src/music.h
@@ -26,6 +26,10 @@
 
 typedef struct Music Music;
 
+#if defined(TIC_BUILD_WITH_COLLAB)
+typedef struct Collab Collab;
+#endif
+
 struct Music
 {
 	tic_mem* tic;
@@ -70,9 +74,20 @@ struct Music
 	} tab;
 
 	struct History* history;
-	
+
+#if defined(TIC_BUILD_WITH_COLLAB)
+	struct
+	{
+		Collab* patterns;
+		Collab* tracks;
+	} collab;
+#endif
+
 	void(*tick)(Music*);
 	void(*event)(Music*, StudioEvent);
+#if defined(TIC_BUILD_WITH_COLLAB)
+	void(*diff)(Music*);
+#endif
 };
 
-void initMusic(Music*, tic_mem*, tic_music* src);
+void initMusic(Music*, tic_mem*, s32 bank);

--- a/src/net.c
+++ b/src/net.c
@@ -30,12 +30,31 @@
 
 struct Net
 {
-	struct Curl_easy* curl;
+	struct
+	{
+		struct Curl_easy* curl;
+	} get;
+
+	struct
+	{
+		struct Curl_easy* curl;
+	} put;
+
+	struct
+	{
+		CURLM* multi;
+		struct Curl_easy* curl;
+		bool active;
+		char url[1024];
+		NetResponse callback;
+		void* data;
+		s32 retryCounter;
+	} stream;
 };
 
 typedef struct
 {
-    void* buffer;
+    u8* buffer;
     s32 size;
 } CurlData;
 
@@ -44,26 +63,23 @@ static size_t writeCallback(void *contents, size_t size, size_t nmemb, void *use
 	CurlData* data = (CurlData*)userp;
 
 	const size_t total = size * nmemb;
-	data->buffer = realloc(data->buffer, data->size + total);
-	memcpy((u8*)data->buffer + data->size, contents, total);
+	data->buffer = (u8*)realloc(data->buffer, data->size + total);
+	memcpy(data->buffer + data->size, contents, total);
 	data->size += total;
 
 	return total;
 }
 
-void* netGetRequest(Net* net, const char* path, s32* size)
+void* netGetRequest(Net* net, const char* url, s32* size)
 {
 	CurlData data = {NULL, 0};
 
-	if(net->curl)
+	if(net->get.curl)
 	{
-		char url[FILENAME_MAX] = "http://" TIC_HOST;
-		strcat(url, path);
-		
-		curl_easy_setopt(net->curl, CURLOPT_URL, url);
-		curl_easy_setopt(net->curl, CURLOPT_WRITEDATA, &data);
+		curl_easy_setopt(net->get.curl, CURLOPT_URL, url);
+		curl_easy_setopt(net->get.curl, CURLOPT_WRITEDATA, &data);
 
-		if(curl_easy_perform(net->curl) != CURLE_OK)
+		if(curl_easy_perform(net->get.curl) != CURLE_OK)
 			return NULL;
 	}
 
@@ -72,24 +88,169 @@ void* netGetRequest(Net* net, const char* path, s32* size)
     return data.buffer;
 }
 
+static size_t readCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+	CurlData* data = (CurlData*)userp;
+
+	size_t total = MIN(size * nmemb, (size_t)data->size);
+
+	memcpy((u8*)contents, data->buffer, total);
+
+	data->buffer += total;
+	data->size -= total;
+
+	return total;
+}
+
+void netPutRequest(Net* net, const char *url, void *content, s32 size)
+{
+	CurlData data = {(u8*)content, size};
+
+	struct curl_slist *headers = NULL;
+
+	if(net->put.curl)
+	{
+		char contentLength[1024];
+		snprintf(contentLength, sizeof(contentLength), "Content-Length: %d", size);
+		headers = curl_slist_append(headers, contentLength);
+		headers = curl_slist_append(headers, "Expect:");
+		headers = curl_slist_append(headers, "Transfer-Encoding:");
+
+		curl_easy_setopt(net->put.curl, CURLOPT_URL, url);
+		curl_easy_setopt(net->put.curl, CURLOPT_HTTPHEADER, headers);
+		curl_easy_setopt(net->put.curl, CURLOPT_READDATA, &data);
+		curl_easy_setopt(net->put.curl, CURLOPT_INFILESIZE, size);
+
+		curl_easy_perform(net->put.curl);
+
+		curl_slist_free_all(headers);
+	}
+}
+
+static size_t streamCallback(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	Net* net = (Net*)userdata;
+
+	size_t total = size * nmemb;
+	
+	if(net->stream.callback)
+		net->stream.callback(ptr, total, net->stream.data);
+
+	return total;
+}
+
+static void netStartStream(Net* net)
+{
+	curl_easy_setopt(net->stream.curl, CURLOPT_URL, net->stream.url);
+	curl_easy_setopt(net->stream.curl, CURLOPT_WRITEDATA, net);
+
+	curl_multi_add_handle(net->stream.multi, net->stream.curl);
+	net->stream.active = true;
+}
+
+static void netStopStream(Net *net)
+{
+	curl_multi_remove_handle(net->stream.multi, net->stream.curl);
+	net->stream.active = false;
+}
+
+void netGetStream(Net* net, const char *url, NetResponse callback, void* data)
+{
+	if(net->stream.active)
+		netStopStream(net);
+
+	snprintf(net->stream.url, sizeof(net->stream.url), "%s", url);
+	net->stream.callback = callback;
+	net->stream.data = data;
+	net->stream.retryCounter = 0;
+
+	if(url[0] != '\0')
+		netStartStream(net);
+}
+
+void netTick(Net *net)
+{
+	int running;
+	curl_multi_perform(net->stream.multi, &running);
+
+	int pending;
+	CURLMsg *msg;
+	while((msg = curl_multi_info_read(net->stream.multi, &pending)))
+	{
+		if(msg->easy_handle == net->stream.curl)
+		{
+			// Occurs in the case of a dropped connection, e.g. server restart or network loss.
+			if(msg->msg == CURLMSG_DONE)
+			{
+				netStopStream(net);
+				net->stream.retryCounter = 300;
+			}
+		}
+	}
+
+	if(!net->stream.active && net->stream.retryCounter > 0)
+	{
+		net->stream.retryCounter--;
+		if(net->stream.retryCounter == 0)
+			netStartStream(net);
+	}
+}
+
 Net* createNet()
 {
 	Net* net = (Net*)malloc(sizeof(Net));
 
 	*net = (Net)
 	{
-		.curl = curl_easy_init()
+		.get =
+		{
+			.curl = curl_easy_init(),
+		},
+		.put = 
+		{
+			.curl = curl_easy_init(),
+		},
+		.stream = 
+		{
+			.multi = curl_multi_init(),
+			.curl = curl_easy_init(),
+			.active = false,
+			.callback = NULL,
+			.data = NULL,
+		},
 	};
 
-	curl_easy_setopt(net->curl, CURLOPT_WRITEFUNCTION, writeCallback);
+	curl_easy_setopt(net->get.curl, CURLOPT_WRITEFUNCTION, writeCallback);
+
+	curl_easy_setopt(net->put.curl, CURLOPT_PUT, 1);
+	curl_easy_setopt(net->put.curl, CURLOPT_READFUNCTION, readCallback);
+
+	curl_easy_setopt(net->stream.curl, CURLOPT_WRITEFUNCTION, streamCallback);
+
+	// Make the OS check for dropped connections automatically:
+	curl_easy_setopt(net->stream.curl, CURLOPT_TCP_KEEPALIVE, 1L);
+	curl_easy_setopt(net->stream.curl, CURLOPT_TCP_KEEPIDLE, 120L);
+	curl_easy_setopt(net->stream.curl, CURLOPT_TCP_KEEPINTVL, 60L);
 
 	return net;
 }
 
 void closeNet(Net* net)
 {
-	if(net->curl)
-		curl_easy_cleanup(net->curl);
+	if(net->get.curl)
+		curl_easy_cleanup(net->get.curl);
+
+	if(net->put.curl)
+		curl_easy_cleanup(net->put.curl);
+
+	if(net->stream.active)
+		netStopStream(net);
+
+	if(net->stream.curl)
+		curl_easy_cleanup(net->stream.curl);
+
+	if(net->stream.multi)
+		curl_multi_cleanup(net->stream.multi);
 
 	free(net);
 }

--- a/src/net.h
+++ b/src/net.h
@@ -26,6 +26,11 @@
 
 typedef struct Net Net;
 
+typedef void(*NetResponse)(u8* buffer, s32 size, void* data);
+
 Net* createNet();
-void* netGetRequest(Net* net, const char* path, s32* size);
+void netTick(Net *net);
+void* netGetRequest(Net* net, const char *url, s32* size);
+void netPutRequest(Net* net, const char *url, void *data, s32 size);
+void netGetStream(Net* net, const char *url, NetResponse callback, void* data);
 void closeNet(Net* net);

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -26,6 +26,10 @@
 
 typedef struct Sfx Sfx;
 
+#if defined(TIC_BUILD_WITH_COLLAB)
+typedef struct Collab Collab;
+#endif
+
 struct Sfx
 {
 	tic_mem* tic;
@@ -60,9 +64,19 @@ struct Sfx
 	} tab;
 
 	struct History* history;
+#if defined(TIC_BUILD_WITH_COLLAB)
+	struct
+	{
+		Collab* waveform;
+		Collab* samples;
+	} collab;
+#endif
 
 	void(*tick)(Sfx*);
 	void(*event)(Sfx*, StudioEvent);
+#if defined(TIC_BUILD_WITH_COLLAB)
+	void(*diff)(Sfx*);
+#endif
 };
 
-void initSfx(Sfx*, tic_mem*, tic_sfx* src);
+void initSfx(Sfx*, tic_mem*, s32 bank);

--- a/src/studio.h
+++ b/src/studio.h
@@ -123,6 +123,19 @@ typedef enum
 
 ClipboardEvent getClipboardEvent();
 
+#if defined(TIC_BUILD_WITH_COLLAB)
+
+typedef enum
+{
+	TIC_COLLAB_NONE,
+	TIC_COLLAB_PULL,
+	TIC_COLLAB_PUSH,
+} CollabEvent;
+
+CollabEvent getCollabEvent();
+
+#endif
+
 typedef enum
 {
 	TIC_TOOLBAR_CUT,
@@ -130,10 +143,24 @@ typedef enum
 	TIC_TOOLBAR_PASTE,
 	TIC_TOOLBAR_UNDO,
 	TIC_TOOLBAR_REDO,
+#if defined(TIC_BUILD_WITH_COLLAB)
+	TIC_TOOLBAR_PUSH,
+	TIC_TOOLBAR_PULL,
+#endif
 } StudioEvent;
 
 void setStudioEvent(StudioEvent event);
 void showTooltip(const char* text);
+
+#if defined(TIC_BUILD_WITH_COLLAB)
+bool collabEnabled();
+bool collabShowDiffs();
+void drawDiffRect(tic_mem *tic, s32 x, s32 y, s32 w, s32 h);
+void onCollabChanges();
+void setCollabUrl(const char* collabUrl, bool initPlz);
+char* getCollabUrl();
+void disableCollab();
+#endif
 
 tic_key* getKeymap();
 

--- a/src/surf.c
+++ b/src/surf.c
@@ -471,7 +471,7 @@ static void* requestCover(Surf* surf, const char* hash, s32* size)
 	}
 
 	char path[FILENAME_MAX] = {0};
-	sprintf(path, "/cart/%s/cover.gif", hash);
+	sprintf(path, "http://"TIC_HOST"/cart/%s/cover.gif", hash);
 	void* data = getSystem()->getUrlRequest(path, size);
 
 	if(data)

--- a/src/system.h
+++ b/src/system.h
@@ -6,6 +6,8 @@
 #define TIC80_OFFSET_LEFT ((TIC80_FULLWIDTH-TIC80_WIDTH)/2)
 #define TIC80_OFFSET_TOP ((TIC80_FULLHEIGHT-TIC80_HEIGHT)/2)
 
+typedef void(*url_stream_callback)(u8* buffer, s32 size, void* data);
+
 typedef struct
 {
 	void	(*setClipboardText)(const char* text);
@@ -17,6 +19,9 @@ typedef struct
 	u64 	(*getPerformanceFrequency)();
 
 	void* (*getUrlRequest)(const char* url, s32* size);
+	void  (*putUrlRequest)(const char* url, void *data, s32 size);
+
+	void  (*getUrlStream)(const char* url, url_stream_callback callback, void *data);
 
 	void (*fileDialogLoad)(file_dialog_load_callback callback, void* data);
 	void (*fileDialogSave)(file_dialog_save_callback callback, const char* name, const u8* buffer, size_t size, void* data, u32 mode);

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -111,6 +111,14 @@ static void* getUrlRequest(const char* url, s32* size)
 	return NULL;
 }
 
+static void putUrlRequest(const char* url, void *data, s32 size)
+{
+}
+
+static void getUrlStream(const char* url, url_stream_callback callback, void *data)
+{
+}
+
 static void agoFullscreen()
 {
 }
@@ -161,6 +169,8 @@ static System systemInterface =
 	.getPerformanceFrequency = getPerformanceFrequency,
 
 	.getUrlRequest = getUrlRequest,
+	.putUrlRequest = putUrlRequest,
+	.getUrlStream = getUrlStream,
 
 	.fileDialogLoad = NULL, //file_dialog_load,
 	.fileDialogSave = NULL, //file_dialog_save,

--- a/src/system/sdlgpu.c
+++ b/src/system/sdlgpu.c
@@ -1195,6 +1195,16 @@ static void* getUrlRequest(const char* url, s32* size)
 	return netGetRequest(platform.net, url, size);
 }
 
+static void putUrlRequest(const char* url, void *data, s32 size)
+{
+	netPutRequest(platform.net, url, data, size);
+}
+
+static void getUrlStream(const char* url, url_stream_callback callback, void *data)
+{
+	netGetStream(platform.net, url, callback, data);
+}
+
 static void preseed()
 {
 #if defined(__MACOSX__)
@@ -1315,6 +1325,8 @@ static System systemInterface =
 	.getPerformanceFrequency = getPerformanceFrequency,
 
 	.getUrlRequest = getUrlRequest,
+	.putUrlRequest = putUrlRequest,
+	.getUrlStream = getUrlStream,
 
 	.fileDialogLoad = file_dialog_load,
 	.fileDialogSave = file_dialog_save,
@@ -1334,6 +1346,8 @@ static void gpuTick()
 	tic_mem* tic = platform.studio->tic;
 
 	pollEvent();
+
+	netTick(platform.net);
 
 	if(platform.studio->quit)
 	{

--- a/src/system/sokol.c
+++ b/src/system/sokol.c
@@ -91,6 +91,16 @@ static void* getUrlRequest(const char* url, s32* size)
 	return netGetRequest(platform.net, url, size);
 }
 
+static void putUrlRequest(const char* url, void *data, s32 size)
+{
+	netPutRequest(platform.net, url, data, size);
+}
+
+static void getUrlStream(const char* url, url_stream_callback callback, void *data)
+{
+	netGetStream(platform.net, url, callback, data);
+}
+
 static void goFullscreen()
 {
 }
@@ -140,6 +150,8 @@ static System systemInterface =
 	.getPerformanceFrequency = getPerformanceFrequency,
 
 	.getUrlRequest = getUrlRequest,
+	.putUrlRequest = putUrlRequest,
+	.getUrlStream = getUrlStream,
 
 	.fileDialogLoad = file_dialog_load,
 	.fileDialogSave = file_dialog_save,
@@ -180,6 +192,8 @@ static void app_frame(void)
 	tic_mem* tic = platform.studio->tic;
 
 	if(platform.studio->quit) exit(0);
+
+	netTick(platform.net);
 
 	tic80_input* input = &tic->ram.input;
 

--- a/src/tic.h
+++ b/src/tic.h
@@ -51,6 +51,8 @@
 #define TIC_HOST "tic80.com"
 #define TIC_COPYRIGHT "https://" TIC_HOST " (C) 2019"
 
+#define TIC_COLLAB_PROTOCOL_VERSION 1
+
 #define TIC_VRAM_SIZE (16*1024) //16K
 #define TIC_RAM_SIZE (TIC_VRAM_SIZE+80*1024) //16K+80K
 #define TIC_FONT_WIDTH 6

--- a/src/ticapi.h
+++ b/src/ticapi.h
@@ -176,6 +176,9 @@ struct tic_mem
 {
 	tic_ram 			ram;
 	tic_cartridge 		cart;
+#if defined(TIC_BUILD_WITH_COLLAB)
+	tic_cartridge 		collab;
+#endif
 	tic_font 			font;
 	tic_api 			api;
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -25,6 +25,9 @@
 
 #include <string.h>
 
+extern void tic_tool_poke1(void* addr, u32 index, u8 value);
+extern u8 tic_tool_peek1(const void* addr, u32 index);
+
 extern void tic_tool_poke4(void* addr, u32 index, u8 value);
 extern u8 tic_tool_peek4(const void* addr, u32 index);
 
@@ -109,4 +112,9 @@ u32* tic_palette_blit(const tic_palette* srcpal)
 bool tic_tool_has_ext(const char* name, const char* ext)
 {
 	return strcmp(name + strlen(name) - strlen(ext), ext) == 0;
+}
+
+s32 tic_tool_cart_offset(const tic_cartridge *tic, const void* addr)
+{
+	return (const u8*)addr - (const u8*)tic;
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -24,6 +24,24 @@
 
 #include "tic.h"
 
+#define BITARRAY_SIZE(n) ((n + BITS_IN_BYTE - 1) / BITS_IN_BYTE)
+
+inline void tic_tool_poke1(void* addr, u32 index, u8 value)
+{
+	u8* val = (u8*)addr + (index >> 3);
+	u8 bit = 1 << (index & 7);
+	*val &= ~bit;
+	if(value)
+		*val |= bit;
+}
+
+inline u8 tic_tool_peek1(const void* addr, u32 index)
+{
+	u8 val = ((u8*)addr)[index >> 3];
+	u8 bit = 1 << (index & 7);
+	return (val & bit) ? 1 : 0;
+}
+
 inline void tic_tool_poke4(void* addr, u32 index, u8 value)
 {
 	u8* val = (u8*)addr + (index >> 1);
@@ -53,3 +71,4 @@ void tic_tool_set_pattern_id(tic_track* track, s32 frame, s32 channel, s32 id);
 u32 tic_tool_find_closest_color(const tic_rgb* palette, const tic_rgb* color);
 u32* tic_palette_blit(const tic_palette* src);
 bool tic_tool_has_ext(const char* name, const char* ext);
+s32 tic_tool_cart_offset(const tic_cartridge *tic, const void* addr);

--- a/src/world.c
+++ b/src/world.c
@@ -22,6 +22,7 @@
 
 #include "world.h"
 #include "map.h"
+#include "collab.h"
 
 #define PREVIEW_SIZE (TIC80_WIDTH * TIC80_HEIGHT * TIC_PALETTE_BPP / BITS_IN_BYTE)
 
@@ -111,5 +112,10 @@ void initWorld(World* world, tic_mem* tic, Map* map)
 
 			tic_tool_poke4(world->preview, i, max);
 		}
+
+#if defined(TIC_BUILD_WITH_COLLAB)
+		if(collabShowDiffs() && collab_isChanged(map->collab, i))
+			tic_tool_poke4(world->preview, i, (tic_color_yellow));
+#endif
 	}
 }

--- a/tools/collabserver/collabserver.py
+++ b/tools/collabserver/collabserver.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python3
+#
+# MIT License
+#
+# Copyright (c) 2019 Wade Brainerd - wadetb@gmail.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+import argparse
+import pathlib
+import re
+import socket
+import struct
+import time
+import threading
+
+import http.server
+import socketserver
+
+from urllib.parse import urlparse, parse_qs
+
+DEFAULT_PORT = 8000
+DEFAULT_DATA_DIRECTORY = '.'
+DEFAULT_GREETING = 'welcome to collab :)'
+
+PROTOCOL_VERSION = 1
+
+TIC80_SIZE = 1 * 1024 * 1024
+
+DATA_EXT = '.tic_collab'
+
+
+class TIC:
+    def __init__(self, data_path, name):
+        self.path = (data_path / name).with_suffix(DATA_EXT)
+
+        if not self.path.exists():
+            with self.path.open('wb') as file:
+                file.write(b'\0' * TIC80_SIZE)
+            self.init_needed = True
+        else:
+            self.init_needed = False
+
+        # No buffering, as multiple clients will access the same file simultaneously.
+        self.file = self.path.open('r+b', buffering=0)
+
+        self.condition = threading.Condition()
+        self.watchers = {}
+
+    def read_mem(self, offset, size):
+        self.file.seek(offset)
+        return self.file.read(size)
+
+    def write_mem(self, offset, data):
+        self.file.seek(offset)
+        self.file.write(data)
+
+    def signal_update(self, offset, size):
+        with self.condition:
+            for k in self.watchers.keys():
+                self.watchers[k].append((offset, size))
+            self.condition.notify_all()
+
+    def watch(self, client_key):
+        pending_updates = []
+        self.watchers[client_key] = pending_updates
+        while True:
+            with self.condition:
+                self.condition.wait()
+                while len(pending_updates):
+                    yield pending_updates.pop()
+
+
+class CollabRequestHandler(http.server.BaseHTTPRequestHandler):
+    def lookup_tic(self, path):
+        name = path.replace('/', '').lower()
+
+        if re.match(r'[^a-z_-]', name):
+            raise ValueError
+
+        if not name in self.server.tics:
+            self.server.tics[name] = TIC(server.data_path, name)
+
+        return self.server.tics[name]
+
+    def send_response_with_content(self, content):
+        self.send_response(200)
+        self.send_header('Content-Length', '{}'.format(len(content)))
+        self.end_headers()
+
+        self.wfile.write(content)
+
+    def do_request(self):
+        url = urlparse(self.path)
+        query = parse_qs(url.query)
+
+        try:
+            tic = self.lookup_tic(url.path)
+
+            if self.command == 'GET':
+                if not len(query):
+                    header = struct.pack('<bb', PROTOCOL_VERSION,
+                                         tic.init_needed)
+                    greeting = self.server.greeting.encode()
+                    self.send_response_with_content(header + greeting)
+                    tic.init_needed = False
+
+                elif 'watch' in query:
+                    self.send_response(200)
+                    self.send_header('Transfer-Encoding', 'chunked')
+                    self.send_header('X-Accel-Buffering', 'no')
+                    self.end_headers()
+
+                    # Long-lived connection, ensure routers don't drop it.
+                    self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+                    prefix = '8\r\n'.encode()
+                    suffix = '\r\n'.encode()
+                    self.wfile.write(prefix + struct.pack('<ii', 0, TIC80_SIZE) + suffix)
+
+                    for offset, size in tic.watch(self.client_address):
+                        if offset is None:
+                            break
+                        self.wfile.write(prefix + struct.pack('<ii', offset, size) + suffix)
+
+                    self.wfile.write('0\r\n\r\n'.encode())
+
+                elif 'offset' in query:
+                    offset = int(query['offset'][0])
+                    size = int(query['size'][0])
+
+                    self.send_response_with_content(tic.read_mem(offset, size))
+
+            elif self.command == 'PUT':
+                offset = int(query['offset'][0])
+                size = int(query['size'][0])
+
+                tic.write_mem(offset, self.rfile.read(size))
+                tic.signal_update(offset, size)
+
+                self.send_response(200)
+                self.send_header('Content-Length', '0')
+                self.end_headers()
+
+        except ValueError:
+            self.send_error(400)
+        except BrokenPipeError:
+            pass
+        except OSError:
+            self.send_error(500)
+
+    def do_GET(self):
+        self.do_request()
+
+    def do_PUT(self):
+        self.do_request()
+
+
+class CollabServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    def __init__(self, address, port, data_dir, greeting):
+        super().__init__((address, port), CollabRequestHandler)
+
+        self.tics = {}
+
+        self.data_path = pathlib.Path(data_dir)
+        self.data_path.mkdir(exist_ok=True)
+
+        self.greeting = greeting
+
+    def shutdown(self):
+        self.socket.close()
+        for tic in self.tics.values():
+            tic.signal_update(None, None)
+
+
+try:
+    parser = argparse.ArgumentParser(description='TIC-80 collaboration server')
+    parser.add_argument('--address',
+                        type=str,
+                        default='',
+                        help='Listen address [default: all interfaces]')
+    parser.add_argument('--port',
+                        type=int,
+                        default=DEFAULT_PORT,
+                        help='Listen port [default: 8000]')
+    parser.add_argument('--data-dir',
+                        type=str,
+                        default=DEFAULT_DATA_DIRECTORY,
+                        metavar='DIR',
+                        help='Data directory [default: current directory]')
+    parser.add_argument('--greeting',
+                        type=str,
+                        default=DEFAULT_GREETING,
+                        help='Alternate server greeting')
+    args = parser.parse_args()
+
+    server = CollabServer(args.address, args.port, args.data_dir,
+                          args.greeting)
+    print('Started collab server on port {}:{} with data in "{}"'.format(
+        args.address, args.port, args.data_dir))
+    server.serve_forever()
+
+except KeyboardInterrupt:
+    print('Shutting down collab server')
+    server.shutdown()


### PR DESCRIPTION
Hi there. 

I'm not sure if there's any interest in this feature. It adds Google Docs-like collaboration to TIC-80, while keeping to the spirit of the overall project, at least to the best of my understanding and ability.

The feature is not finished but is usable in the current state, and I thought it would be a good time to seek feedback. 

Some background:

Over the past few years I've been running workshops for groups ages 8 up to college, using a combination of PICO-8 and TIC-80, and it's very difficult for the kids to work together. For instance, one kid makes an awesome animation and the other kids want to grab it, one kid wants to do the characters while another does the backgrounds and another one does the music, or just two or three kids want to collaborate on a project without knowing who does what. 

The implementation high level view is that there is a server maintaining a database of "shared carts", and TIC-80 instances can "connect" to a shared cart and push & pull changes. I very intentionally stayed away from source control topics such as conflicts, history, and so on. All pushes to and pulls from the shared cart are manual operations by the TIC-80 user, and if they don't like the result of a pull they can simply undo it. The only automatic part of the system is a realtime display that shows where the local cart differs from the shared cart at a fairly fine-grained level, e.g. the line of code, the sprite, the music track, etc.

The code diff is the only complicated part of the implementation, in that it performs a full text diff with line matching in order to accurately display highlights and to push and pull line diffs.

The server is a simple Python script that ideally should run behind something like Nginx through a proxy. It maintains the state of the shared carts as files in a working directory. While it's possible that a central, official collaboration server be established, I do wonder about security, privacy and so on. It might be easier if individual users just run the server on their own instances. If a central server was desired then I feel like we'd want to establish the ability for users to administer their shared carts in some way.

Here is a video showing a rough demo of an older version, with two instances connected to a shared cart:

https://youtu.be/d_KLZINw6U4

Regarding what's left in the implementation, I think the feature could be wrapped in a define so as to not break ports that might lack threads or networking, and the thread creation needs to be abstracted into the system interface. Additionally, I'd like to move the code diff into a helper thread which will delay the display slightly but ensure that even giant code files continue to update smoothly.

As far as ongoing development goes, I'm happy to continue to support the feature long term, in fact I'm submitting it to the project rather than maintaining the private fork, in the vain hope that it might be released for Android before my next set of workshops in March, which utilize Chromebooks.

If you'd like to chat about this work further or would like to see a demo and have a walk-through review of the code, feel free to contact me as wadeb on TIC-80 Discord.