### PR TITLE
Fennel 0.3.0 syntax

### DIFF
--- a/src/luaapi.c
+++ b/src/luaapi.c
@@ -1632,7 +1632,8 @@ const tic_script_config* getMoonScriptConfig()
 #define FENNEL_CODE(...) #__VA_ARGS__
 
 static const char* execute_fennel_src = FENNEL_CODE(
-  local ok, msg = pcall(require('fennel').eval, ..., {filename="game", correlate=true})
+  local opts = {filename="game", correlate=true, allowedGlobals=false}
+  local ok, msg = pcall(require('fennel').eval, ..., opts)
   if(not ok) then return msg end
 );
 

--- a/src/luaapi.c
+++ b/src/luaapi.c
@@ -1681,9 +1681,11 @@ static bool initFennel(tic_mem* tic, const char* code)
 
 static const char* const FennelKeywords [] =
 {
+	"lua", "hashfn","macro", "macros",
 	"do", "values", "if", "when", "each", "for", "fn", "lambda", "partial",
-	"while", "set", "global", "var", "local", "let", "tset",
-	"or", "and", "true", "false", "nil", "#", ":", "->", "->>"
+	"while", "set", "global", "var", "local", "let", "tset", "doto", "match",
+	"or", "and", "true", "false", "nil", "not", "not=",
+	".", "..", "#", "...", ":", "->", "->>", "-?>", "-?>>", "$"
 };
 
 static const tic_outline_item* getFennelOutline(const char* code, s32* size)


### PR DESCRIPTION
This updates the syntax highlighting for new keywords in Fennel.

It also disables "strict globals" mode to make it more forgiving like Lua.

One question: it appears that the file `demos/fenneldemo.tic` is supposed to be loaded when you run `new fennel`. However, the actual contents that get loaded are slightly different; there is a stray `>` character that is not there in the `demos/` file. In addition the number passed to `cls` is different. Do you have any idea which file needs to get updated to fix this?