### PR TITLE
Map view fixes when wrapping around the edge

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -648,8 +648,6 @@ static void processMouseSelectMode(Map* map)
 				mx /= TIC_SPRITESIZE;
 				my /= TIC_SPRITESIZE;
 
-				normalizeMapRect(&mx, &my);
-
 				if(map->select.drag)
 				{
 					s32 rl = MIN(mx, map->select.start.x);

--- a/src/world.c
+++ b/src/world.c
@@ -51,14 +51,29 @@ static void drawGrid(World* world)
 		{
 			map->scroll.x = (mx - TIC_MAP_SCREEN_WIDTH/2) * TIC_SPRITESIZE;
 			map->scroll.y = (my - TIC_MAP_SCREEN_HEIGHT/2) * TIC_SPRITESIZE;
+			if(map->scroll.x < 0)
+				map->scroll.x += TIC_MAP_WIDTH * TIC_SPRITESIZE;
+			if(map->scroll.y < 0)
+				map->scroll.y += TIC_MAP_HEIGHT * TIC_SPRITESIZE;
 		}
 
 		if(checkMouseClick(&rect, tic_mouse_left))
 			setStudioMode(TIC_MAP_MODE);
 	}
 
-	world->tic->api.rect_border(world->tic, map->scroll.x / TIC_SPRITESIZE, map->scroll.y / TIC_SPRITESIZE, 
-		TIC_MAP_SCREEN_WIDTH+1, TIC_MAP_SCREEN_HEIGHT+1, (tic_color_red));
+	s32 x = map->scroll.x / TIC_SPRITESIZE;
+	s32 y = map->scroll.y / TIC_SPRITESIZE;
+
+	world->tic->api.rect_border(world->tic, x, y, TIC_MAP_SCREEN_WIDTH+1, TIC_MAP_SCREEN_HEIGHT+1, (tic_color_red));
+
+	if(x >= TIC_MAP_WIDTH - TIC_MAP_SCREEN_WIDTH)
+		world->tic->api.rect_border(world->tic, x - TIC_MAP_WIDTH, y, TIC_MAP_SCREEN_WIDTH+1, TIC_MAP_SCREEN_HEIGHT+1, (tic_color_red));
+
+	if(y >= TIC_MAP_HEIGHT - TIC_MAP_SCREEN_HEIGHT)
+		world->tic->api.rect_border(world->tic, x, y - TIC_MAP_HEIGHT, TIC_MAP_SCREEN_WIDTH+1, TIC_MAP_SCREEN_HEIGHT+1, (tic_color_red));
+
+	if(x >= TIC_MAP_WIDTH - TIC_MAP_SCREEN_WIDTH && y >= TIC_MAP_HEIGHT - TIC_MAP_SCREEN_HEIGHT)
+		world->tic->api.rect_border(world->tic, x - TIC_MAP_WIDTH, y - TIC_MAP_HEIGHT, TIC_MAP_SCREEN_WIDTH+1, TIC_MAP_SCREEN_HEIGHT+1, (tic_color_red));
 }
 
 static void tick(World* world)


### PR DESCRIPTION
- When trying to select across the edge of the map, the selection
rectangle no longer jumps and stretches across the entire map.

The mouse coordinates were being normalized prior to expanding the
selection extent, so for example a 1,1 start point and a -1,-1 end point
would evaluate to 1,1..W-1,H-1, turning a 2x2 selection into the entire
map!.

It's actually fine for the selection rectangle to go outside the valid
range because the copy/paste functions all normalize the individual
gets/sets.

- Don't allow scrolling into negative offsets in the world view. This
breaks the grid drawing code temporarily when you switch back to the
map.

- When the map rectangle wraps around in the world view, draw all the
wrapped quadrants. This makes it clearer how the map wraps around and
avoids "losing" the viewport when you scroll slightly left or up.