### PR TITLE
Code cursor undo change

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -27,24 +27,29 @@
 typedef struct Code Code;
 typedef struct OutlineItem OutlineItem;
 
+typedef struct Cursor Cursor;
+
+struct Cursor
+{
+	struct
+	{
+		char* position;
+		char* selection;
+		s32 column;
+	};
+
+	char* mouseDownPosition;
+	s32 delay;
+};
+
 struct Code
 {
 	tic_mem* tic;
 
 	char* src;
+	bool changed;
 
-	struct
-	{
-		struct
-		{
-			char* position;
-			char* selection;
-			s32 column;
-		};
-
-		char* mouseDownPosition;
-		s32 delay;
-	} cursor;
+	Cursor cursor;
 
 	tic_rect rect;
 

--- a/src/history.h
+++ b/src/history.h
@@ -27,7 +27,12 @@
 typedef struct History History;
 
 History* history_create(void* data, u32 size);
-bool history_add(History* history);
+void history_add(History* history);
+void history_add_if_changed(History* history);
 void history_undo(History* history);
 void history_redo(History* history);
 void history_delete(History* history);
+
+void history_add_with_tag(History* history, s32 tag);
+void history_undo_to_tag(History* history, s32 tag);
+void history_redo_to_tag(History* history, s32 tag);

--- a/src/map.c
+++ b/src/map.c
@@ -445,7 +445,7 @@ static void setMapSprite(Map* map, s32 x, s32 y)
 		for(s32 i = 0; i < map->sheet.rect.w; i++)
 			map->tic->api.map_set(map->tic, map->src, (x+i)%TIC_MAP_WIDTH, (y+j)%TIC_MAP_HEIGHT, (mx+i) + (my+j) * SHEET_COLS);
 
-	history_add(map->history);
+	history_add_if_changed(map->history);
 }
 
 static void drawTileCursor(Map* map)
@@ -601,7 +601,7 @@ static void drawPasteData(Map* map)
 			for(s32 i = 0; i < w; i++)
 				map->tic->api.map_set(map->tic, map->src, (mx+i)%TIC_MAP_WIDTH, (my+j)%TIC_MAP_HEIGHT, data[i + j * w]);
 
-		history_add(map->history);
+		history_add_if_changed(map->history);
 
 		free(map->paste);
 		map->paste = NULL;
@@ -806,7 +806,7 @@ static void processMouseFillMode(Map* map)
 		getMouseMap(map, &tx, &ty);
 
 		fillMap(map, tx, ty, map->tic->api.map_get(map->tic, map->src, tx, ty));
-		history_add(map->history);
+		history_add_if_changed(map->history);
 	}
 }
 
@@ -967,7 +967,7 @@ static void deleteSelection(Map* map)
 				map->src->data[index] = 0;
 			}
 
-		history_add(map->history);
+		history_add_if_changed(map->history);
 	}
 }
 

--- a/src/music.c
+++ b/src/music.c
@@ -629,7 +629,7 @@ static void copyToClipboard(Music* music, bool cut)
 			if(cut)
 			{
 				deleteSelection(music);
-				history_add(music->history);
+				history_add_if_changed(music->history);
 			}
 
 			resetSelection(music);
@@ -667,7 +667,7 @@ static void copyFromClipboard(Music* music)
 						header.size = MUSIC_PATTERN_ROWS - music->tracker.row;
 
 					memcpy(&pattern->rows[music->tracker.row], data + HeaderSize, header.size * RowSize);
-					history_add(music->history);
+					history_add_if_changed(music->history);
 				}
 
 				free(data);
@@ -698,7 +698,7 @@ static void setChannelPatternValue(Music* music, s32 patternId, s32 channel)
 	for(s32 b = 0; b < TRACK_PATTERNS_SIZE; b++)
 		track->data[frame * TRACK_PATTERNS_SIZE + b] = (patternData >> (b * BITS_IN_BYTE)) & 0xff;
 
-	history_add(music->history);
+	history_add_if_changed(music->history);
 }
 
 static void prevPattern(Music* music)
@@ -805,7 +805,7 @@ static void processTrackerKeyboard(Music* music)
 	else if(keyWasPressed(tic_key_delete)) 		
 	{
 		deleteSelection(music);
-		history_add(music->history);
+		history_add_if_changed(music->history);
 		downRow(music);
 	}
 	else if(keyWasPressed(tic_key_space)) playNote(music);
@@ -988,7 +988,7 @@ static void processTrackerKeyboard(Music* music)
 			break;			
 		}
 
-		history_add(music->history);
+		history_add_if_changed(music->history);
 	}
 }
 
@@ -1102,7 +1102,7 @@ static void setTempo(Music* music, s32 delta, void* data)
 
 	track->tempo = tempo;
 
-	history_add(music->history);
+	history_add_if_changed(music->history);
 }
 
 static void setSpeed(Music* music, s32 delta, void* data)
@@ -1124,7 +1124,7 @@ static void setSpeed(Music* music, s32 delta, void* data)
 
 	track->speed = speed;
 
-	history_add(music->history);
+	history_add_if_changed(music->history);
 }
 
 static void setRows(Music* music, s32 delta, void* data)
@@ -1147,7 +1147,7 @@ static void setRows(Music* music, s32 delta, void* data)
 
 	updateTracker(music);
 
-	history_add(music->history);
+	history_add_if_changed(music->history);
 }
 
 static void drawTopPanel(Music* music, s32 x, s32 y)
@@ -1596,7 +1596,7 @@ static void scrollNotes(Music* music, s32 delta)
 			}
 		}
 
-		history_add(music->history);
+		history_add_if_changed(music->history);
 	}
 }
 

--- a/src/sfx.c
+++ b/src/sfx.c
@@ -120,7 +120,7 @@ static void setSpeed(Sfx* sfx, s32 delta)
 
 	effect->speed += delta;
 
-	history_add(sfx->history);
+	history_add_if_changed(sfx->history);
 }
 
 static void drawStereoSwitch(Sfx* sfx, s32 x, s32 y)
@@ -180,7 +180,7 @@ static void setLoopStart(Sfx* sfx, s32 delta)
 
 	loop->start += delta;
 
-	history_add(sfx->history);
+	history_add_if_changed(sfx->history);
 }
 
 static void setLoopSize(Sfx* sfx, s32 delta)
@@ -190,7 +190,7 @@ static void setLoopSize(Sfx* sfx, s32 delta)
 
 	loop->size += delta;
 
-	history_add(sfx->history);
+	history_add_if_changed(sfx->history);
 }
 
 static void drawLoopPanel(Sfx* sfx, s32 x, s32 y)
@@ -437,7 +437,7 @@ static void drawCanvas(Sfx* sfx, s32 x, s32 y)
 			default: break;
 			}
 
-			history_add(sfx->history);
+			history_add_if_changed(sfx->history);
 		}
 	}
 
@@ -627,7 +627,7 @@ static void resetSfx(Sfx* sfx)
 	tic_sample* effect = getEffect(sfx);
 	memset(effect, 0, sizeof(tic_sample));
 
-	history_add(sfx->history);
+	history_add_if_changed(sfx->history);
 }
 
 static void resetWave(Sfx* sfx)
@@ -635,7 +635,7 @@ static void resetWave(Sfx* sfx)
 	tic_waveform* wave = getWaveform(sfx);
 	memset(wave, 0, sizeof(tic_waveform));
 
-	history_add(sfx->history);
+	history_add_if_changed(sfx->history);
 }
 
 static void cutToClipboard(Sfx* sfx)
@@ -655,7 +655,7 @@ static void copyFromClipboard(Sfx* sfx)
 	tic_sample* effect = getEffect(sfx);
 
 	if(fromClipboard(effect, sizeof(tic_sample), true, false))
-		history_add(sfx->history);
+		history_add_if_changed(sfx->history);
 }
 
 static void copyWaveFromClipboard(Sfx* sfx)
@@ -663,7 +663,7 @@ static void copyWaveFromClipboard(Sfx* sfx)
 	tic_waveform* wave = getWaveform(sfx);
 
 	if(fromClipboard(wave, sizeof(tic_waveform), true, false))
-		history_add(sfx->history);
+		history_add_if_changed(sfx->history);
 }
 
 static void processKeyboard(Sfx* sfx)
@@ -962,7 +962,7 @@ static void drawWaveformCanvas(Sfx* sfx, s32 x, s32 y)
 
 			tic_tool_poke4(wave->data, mx, Rows - my - 1);
 
-			history_add(sfx->history);
+			history_add_if_changed(sfx->history);
 		}
 	}
 

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -151,7 +151,7 @@ static void processDrawCanvasMouse(Sprite* sprite, s32 x, s32 y, s32 sx, s32 sy)
 				for(s32 i = 0; i < pixels; i++)
 					setSheetPixel(sprite, sx+i, sy+j, color);
 
-			history_add(sprite->history);
+			history_add_if_changed(sprite->history);
 		}
 	}
 }
@@ -178,7 +178,7 @@ static void pasteSelection(Sprite* sprite)
 		for(s32 sx = l; sx < r; sx++)
 			setSheetPixel(sprite, sx, sy, sprite->select.front[i++]);
 
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 }
 
 static void copySelection(Sprite* sprite)
@@ -308,7 +308,7 @@ static void processFillCanvasMouse(Sprite* sprite, s32 x, s32 y, s32 l, s32 t)
 					: floodFill(sprite, l, t, l + sprite->size-1, t + sprite->size-1, sx, sy, color, fill);
 			}
 
-			history_add(sprite->history);
+			history_add_if_changed(sprite->history);
 		}
 	}
 }
@@ -503,7 +503,7 @@ static void rotateCanvas(Sprite* sprite)
 			
 			rotateSelectRect(sprite);
 			pasteSelection(sprite);
-			history_add(sprite->history);
+			history_add_if_changed(sprite->history);
 		}
 
 		free(buffer);
@@ -525,7 +525,7 @@ static void deleteCanvas(Sprite* sprite)
 
 	clearCanvasSelection(sprite);
 	
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 }
 
 static void flipCanvasHorz(Sprite* sprite)
@@ -546,7 +546,7 @@ static void flipCanvasHorz(Sprite* sprite)
 			setSheetPixel(sprite, i, y, color);
 		}
 
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 	copySelection(sprite);
 }
 
@@ -568,7 +568,7 @@ static void flipCanvasVert(Sprite* sprite)
 			setSheetPixel(sprite, x, i, color);
 		}
 
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 	copySelection(sprite);
 }
 
@@ -1162,7 +1162,7 @@ static void flipSpriteHorz(Sprite* sprite)
 			setSheetPixel(sprite, i, y, color);
 		}
 
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 }
 
 static void flipSpriteVert(Sprite* sprite)
@@ -1179,7 +1179,7 @@ static void flipSpriteVert(Sprite* sprite)
 			setSheetPixel(sprite, x, i, color);
 		}
 
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 }
 
 static void rotateSprite(Sprite* sprite)
@@ -1202,7 +1202,7 @@ static void rotateSprite(Sprite* sprite)
 				for(s32 x = rect.x, i = 0; x < r; x++, i++)
 					setSheetPixel(sprite, x, y, buffer[j + (Size-i-1)*Size]);
 
-			history_add(sprite->history);
+			history_add_if_changed(sprite->history);
 		}
 
 		free(buffer);
@@ -1221,7 +1221,7 @@ static void deleteSprite(Sprite* sprite)
 
 	clearCanvasSelection(sprite);
 
-	history_add(sprite->history);
+	history_add_if_changed(sprite->history);
 }
 
 static void(* const SpriteToolsFunc[])(Sprite*) = {flipSpriteHorz, flipSpriteVert, rotateSprite, deleteSprite};
@@ -1457,7 +1457,7 @@ static void copyFromClipboard(Sprite* sprite)
 				for(s32 x = rect.x; x < r; x++)
 					setSheetPixel(sprite, x, y, tic_tool_peek4(buffer, i++));
 
-			history_add(sprite->history);
+			history_add_if_changed(sprite->history);
 		}
 
 		free(buffer);


### PR DESCRIPTION
Fixes the cursor getting out of sync when undoing and redoing in the
code window.

Under the hood this is quite complicated, but I hope it produces the
desired effect and also it may enable some other undo improvements in
the future.

The principle is that when undoing a code change, you want the cursor to
end up where it was before the code change, and when redoing a code
change, you want the cursor to end up where it was _after_ the change.

To accomplish this, cursor undo is stored with a TAG (before or after).
When the code is modified by any means, both a BEFORE and an AFTER
cursor tag are added. When undoing, the cursor history is rewound to the
next BEFORE tag, and when redoing, it is forwarded to the next AFTER
tag.

One issue that is handled is the case of an edit after undoing. Normally,
edits creates a BABA... alternation in the cursor undo history.
If the user makes some changes, undoes a change, and then makes more
changes, you can get a BABBA where the BB is the point of the undone
change. To resolve this, when the tag being added to the history matches
the latest tag in the history, the latest tag is replaced so there won't
be two of the same tag in the sequence. I'm on the fence about whether
this behavior belongs in the history system or in the code, but there
are no other users of the tags yet so I'll leave it as written. In the
future the tags system might be used to implement "word" undo ala
VSCode, or stroke undo (instead of per-pixel) in the sprite editor. But
I'm not sure, these features might better benefit from an overhaul of
the undo system, I'd need to research other possibilities.

As a simplification, code changes are now flagged in a bool, which
triggers all the syntax highlighting, undo, etc. This may have fixed a
few places where these were applied redundantly.