### PR TITLE
cmake: Fix build when SDL is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ endif()
 # SDL2 standalone cart player
 ################################
 
-if(BUILD_PLAYER)
+if(BUILD_SDL AND BUILD_PLAYER)
 
 	add_executable(player-sdl WIN32 ${CMAKE_SOURCE_DIR}/src/player/sdl.c)
 


### PR DESCRIPTION
When SDL is disabled, don't attempt to build the SDL player.