### PR TITLE
Add ScrollX and ScrollY to mouse()

### DIFF
--- a/src/jsapi.c
+++ b/src/jsapi.c
@@ -644,6 +644,10 @@ static duk_ret_t duk_mouse(duk_context* duk)
 	duk_put_prop_index(duk, idx, 3);
 	duk_push_boolean(duk, mouse->right);
 	duk_put_prop_index(duk, idx, 4);
+	duk_push_int(duk, mouse->scrollx);
+	duk_put_prop_index(duk, idx, 5);
+	duk_push_int(duk, mouse->scrolly);
+	duk_put_prop_index(duk, idx, 6);
 
 	return 1;
 }

--- a/src/luaapi.c
+++ b/src/luaapi.c
@@ -1121,8 +1121,10 @@ static s32 lua_mouse(lua_State *lua)
 	lua_pushboolean(lua, mouse->left);
 	lua_pushboolean(lua, mouse->middle);
 	lua_pushboolean(lua, mouse->right);
+	lua_pushinteger(lua, mouse->scrollx);
+	lua_pushinteger(lua, mouse->scrolly);
 
-	return 5;
+	return 7;
 }
 
 static s32 lua_dofile(lua_State *lua)

--- a/src/squirrelapi.c
+++ b/src/squirrelapi.c
@@ -1226,7 +1226,7 @@ static SQInteger squirrel_mouse(HSQUIRRELVM vm)
 
 	const tic80_mouse* mouse = &machine->memory.ram.input.mouse;
 
-	sq_newarray(vm, 5);
+	sq_newarray(vm, 7);
 	sq_pushinteger(vm, mouse->x);
 	sq_arrayappend(vm, -2);
 	sq_pushinteger(vm, mouse->y);
@@ -1236,6 +1236,10 @@ static SQInteger squirrel_mouse(HSQUIRRELVM vm)
 	sq_pushbool(vm, mouse->middle ? SQTrue : SQFalse);
 	sq_arrayappend(vm, -2);
 	sq_pushbool(vm, mouse->right ? SQTrue : SQFalse);
+	sq_arrayappend(vm, -2);
+	sq_pushinteger(vm, mouse->scrollx);
+	sq_arrayappend(vm, -2);
+	sq_pushinteger(vm, mouse->scrolly);
 	sq_arrayappend(vm, -2);
 
 	return 1;

--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -459,8 +459,6 @@ static void tic80_libretro_update_mouse(tic80_mouse* mouse)
 		mouse->y = 0;
 	}
 
-	// TODO: Add Mouse Wheel Scrolling. scrollx and scrolly
-
 	// Have the mouse disappear after a certain time of inactivity.
 	if (mouse->x != state.mousePreviousX || mouse->y != state.mousePreviousY) {
 		state.mouseHideTimer = TIC_LIBRETRO_MOUSE_HIDE_TIMER_START;
@@ -469,6 +467,19 @@ static void tic80_libretro_update_mouse(tic80_mouse* mouse)
 	}
 	if (state.mouseHideTimer > 0) {
 		state.mouseHideTimer--;
+	}
+
+	// Mouse Scroll Wheels
+	mouse->scrollx = mouse->scrolly = 0;
+	if (input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP) > 0) {
+		mouse->scrollx = 1;
+	} else if (input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN) > 0) {
+		mouse->scrollx = -1;
+	}
+	if (input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_WHEELUP) > 0) {
+		mouse->scrolly = 1;
+	} else if (input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_WHEELDOWN) > 0) {
+		mouse->scrolly = -1;
 	}
 }
 

--- a/src/wrenapi.c
+++ b/src/wrenapi.c
@@ -364,7 +364,7 @@ static void wren_mouse(WrenVM* vm)
 
 	const tic80_mouse* mouse = &machine->memory.ram.input.mouse;
 
-	wrenEnsureSlots(vm, 4);
+	wrenEnsureSlots(vm, 6);
 	wrenSetSlotNewList(vm, 0);
 	wrenSetSlotDouble(vm, 1, mouse->x);
 	wrenInsertInList(vm, 0, 0, 1);
@@ -376,6 +376,10 @@ static void wren_mouse(WrenVM* vm)
 	wrenInsertInList(vm, 0, 3, 1);
 	wrenSetSlotBool(vm, 1, mouse->right);
 	wrenInsertInList(vm, 0, 4, 1);
+	wrenSetSlotDouble(vm, 1, mouse->scrollx);
+	wrenInsertInList(vm, 0, 5, 1);
+	wrenSetSlotDouble(vm, 1, mouse->scrolly);
+	wrenInsertInList(vm, 0, 6, 1);
 }
 
 static void wren_print(WrenVM* vm)


### PR DESCRIPTION
This adds `scrollx` and `scrolly` support to `mouse()` for the mouse wheel information (horizontal/vertical).

Fixes #988

The following example is taken from @StinkerB06 cart for testing....

[mouse.tic.zip](https://github.com/nesbox/TIC-80/files/4194529/mouse.tic.zip)
``` lua
-- title:  Input reader
-- author: StinkerB06
-- input: mouse
function TIC()
	local x,y,left,right,middle,scrollx,scrolly=mouse()

	print("X: "..tostring(x), 1, 40, 4, 0, 2)
	print("left: "..tostring(left), 1, 60, 4, 0, 2)
	print("ScrollX: "..tostring(scrollx), 1, 80, 4, 0, 2)
	print("ScrollY: "..tostring(scrolly), 1, 100, 4, 0, 2)
end
```

Once merged, I can update the wiki documentation.