### PR TITLE
Fix missing entry point error on Windows 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,8 @@ set(TIC80CORE_SRC
 
 add_library(tic80core STATIC ${TIC80CORE_SRC})
 
+target_compile_definitions(tic80core PRIVATE DUK_USE_DATE_NOW_WINDOWS) # Avoid API introduced after Win7
+
 target_include_directories(tic80core 
 	PRIVATE 
 		${CMAKE_SOURCE_DIR}/include


### PR DESCRIPTION
The Duktape library invokes a function, GetSystemTimePreciseAsFileTime,
that was added in Win8.

This simply changes the build configuration to use a less precise
function. Hopefully this doesn't impact timing in any games.