### PR TITLE
Fix SDL cursors memory leak

### DIFF
--- a/src/system/sdlgpu.c
+++ b/src/system/sdlgpu.c
@@ -1132,7 +1132,9 @@ static void renderCursor()
 				else
 				{
 					SDL_ShowCursor(SDL_ENABLE);
-					SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND));
+					SDL_Cursor* cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+					SDL_SetCursor(cursor);
+					SDL_FreeCursor(cursor);
 				}
 			}
 			break;
@@ -1146,7 +1148,9 @@ static void renderCursor()
 				else
 				{
 					SDL_ShowCursor(SDL_ENABLE);
-					SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_IBEAM));
+					SDL_Cursor* cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_IBEAM);
+					SDL_SetCursor(cursor);
+					SDL_FreeCursor(cursor);
 				}
 			}
 			break;
@@ -1160,7 +1164,9 @@ static void renderCursor()
 				else
 				{
 					SDL_ShowCursor(SDL_ENABLE);
-					SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW));
+					SDL_Cursor* cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
+					SDL_SetCursor(cursor);
+					SDL_FreeCursor(cursor);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #587. When using the SDL backend, cursors were created every frame but not being freed by [`SDL_FreeCursor`](https://wiki.libsdl.org/SDL_FreeCursor) (in fact they were not even tracked at all). This led the [Xorg server cursor memory](https://www.x.org/wiki/Development/Documentation/CursorHandling/) to fill up and never be freed, ending up requiring restarting X.

This issue did not happen when using the Sokol backend.

[`xrestop`](https://www.freedesktop.org/wiki/Software/xrestop/) makes it easy to figure this leak out, while `tic80` is running
```bash
$ xrestop -b -m 1 | grep -A 15 'TIC-80' | grep cursors | cut -d: -f 2 | xargs
824 # before fix, increased _a lot_ every frame, would end up in gigabytes of memory used

$ xrestop -b -m 1 | grep -A 15 'TIC-80' | grep cursors | cut -d: -f 2 | xargs
1 # after fix
```