### PR TITLE
Add proper keyboard text input handling

### DIFF
--- a/src/studio.c
+++ b/src/studio.c
@@ -235,7 +235,7 @@ static struct
 static inline bool isCharacterValidSymbol(char c)
 {
     static const char symbols[] = " abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./ABCDEFGHIJKLMNOPQRSTUVWXYZ)!@#$%^&*(_+{}|:\"~<>?";
-	return index(symbols, c) != NULL;
+	return strchr(symbols, c) != NULL;
 }
 
 char getKeyboardText()

--- a/src/studio.c
+++ b/src/studio.c
@@ -232,33 +232,23 @@ static struct
 };
 
 
+static inline bool isCharacterValidSymbol(char c)
+{
+    static const char symbols[] = " abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./ABCDEFGHIJKLMNOPQRSTUVWXYZ)!@#$%^&*(_+{}|:\"~<>?";
+	return index(symbols, c) != NULL;
+}
+
 char getKeyboardText()
 {
-    tic_mem* tic = impl.studio.tic;
+    const char* text = impl.studio.textInput;
+    if (!strlen(text) == 1) // all valid symbols are 1-char long
+        return '\0';
 
-    static const char Symbols[] = 	" abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./ ";
-    static const char Shift[] =		" ABCDEFGHIJKLMNOPQRSTUVWXYZ)!@#$%^&*(_+{}|:\"~<>? ";
+    const char character = text[0];
+    if (!isCharacterValidSymbol(character))
+        return '\0';
 
-    enum{Count = sizeof Symbols};
-
-    for(s32 i = 0; i < TIC80_KEY_BUFFER; i++)
-    {
-        tic_key key = tic->ram.input.keyboard.keys[i];
-
-        if(key > 0 && key < Count && tic->api.keyp(tic, key, KEYBOARD_HOLD, KEYBOARD_PERIOD))
-        {
-            bool caps = tic->api.key(tic, tic_key_capslock);
-            bool shift = tic->api.key(tic, tic_key_shift);
-
-            return caps
-                ? key >= tic_key_a && key <= tic_key_z 
-                    ? shift ? Symbols[key] : Shift[key]
-                    : shift ? Shift[key] : Symbols[key]
-                : shift ? Shift[key] : Symbols[key];
-        }
-    }
-
-    return 0;
+    return character;
 }
 
 bool keyWasPressed(tic_key key)

--- a/src/system.h
+++ b/src/system.h
@@ -6,6 +6,10 @@
 #define TIC80_OFFSET_LEFT ((TIC80_FULLWIDTH-TIC80_WIDTH)/2)
 #define TIC80_OFFSET_TOP ((TIC80_FULLHEIGHT-TIC80_HEIGHT)/2)
 
+// SDL text input event max string size, conservative choice for any implementation
+// excludes null character
+#define TEXT_INPUT_SIZE (31)
+
 typedef struct
 {
 	void	(*setClipboardText)(const char* text);
@@ -88,6 +92,7 @@ typedef struct
 typedef struct
 {
 	tic_mem* tic;
+	char textInput[TEXT_INPUT_SIZE + 1];
 	bool quit;
 
 	void (*tick)();

--- a/src/system/sdlgpu.c
+++ b/src/system/sdlgpu.c
@@ -866,6 +866,18 @@ static void handleKeydown(SDL_Keycode keycode, bool down)
 		platform.keyboard.state[tic_key_escape] = down;
 }
 
+static void clearTextInput()
+{
+	platform.studio->textInput[0] = '\0';
+}
+
+static void handleTextInput(const char* text)
+{
+	// use fixed-size copy to avoid buffer overflow
+	strncpy(platform.studio->textInput, text, TEXT_INPUT_SIZE);
+	platform.studio->textInput[TEXT_INPUT_SIZE] = '\0';
+}
+
 static void pollEvent()
 {
 	tic_mem* tic = platform.studio->tic;
@@ -942,6 +954,9 @@ static void pollEvent()
 		case SDL_KEYUP:
 			handleKeydown(event.key.keysym.sym, false);
 			break;			
+		case SDL_TEXTINPUT:
+			handleTextInput(event.text.text);
+			break;
 		case SDL_QUIT:
 			platform.studio->exit();
 			break;
@@ -1441,6 +1456,7 @@ static void gpuTick()
 {
 	tic_mem* tic = platform.studio->tic;
 
+	clearTextInput();
 	pollEvent();
 
 	if(platform.studio->quit)

--- a/src/system/sokol.c
+++ b/src/system/sokol.c
@@ -161,6 +161,11 @@ static void app_init(void)
 	platform.audio.samples = calloc(sizeof platform.audio.samples[0], saudio_sample_rate() / TIC80_FRAMERATE * TIC_STEREO_CHANNELS);
 }
 
+static void clearTextInput()
+{
+	platform.studio->textInput[0] = '\0';
+}
+
 static void handleKeyboard()
 {
 	tic_mem* tic = platform.studio->tic;
@@ -196,6 +201,7 @@ static void app_frame(void)
 	saudio_push(platform.audio.samples, count / 2);
 	
 	input->mouse.scrollx = input->mouse.scrolly = 0;
+	clearTextInput();
 }
 
 static void handleKeydown(sapp_keycode keycode, bool down)
@@ -338,6 +344,18 @@ static void handleKeydown(sapp_keycode keycode, bool down)
 	}
 }
 
+static void handleTextInput(u32 charCode)
+{
+	const char text[5] = {
+		(char)(charCode & 0xFF),
+		(char)(charCode >> 8 & 0xFF),
+		(char)(charCode >> 16 & 0xFF),
+		(char)(charCode >> 24 & 0xFF),
+		'\0'
+	};
+	strcpy(platform.studio->textInput, text);
+}
+
 static void processMouse(sapp_mousebutton btn, s32 down)
 {
 	tic80_input* input = &platform.studio->tic->ram.input;
@@ -362,6 +380,9 @@ static void app_input(const sapp_event* event)
 		break;
 	case SAPP_EVENTTYPE_KEY_UP:
 		handleKeydown(event->key_code, false);
+		break;
+	case SAPP_EVENTTYPE_CHAR:
+		handleTextInput(event->char_code);
 		break;
 	case SAPP_EVENTTYPE_MOUSE_MOVE:
 		{


### PR DESCRIPTION
Fixes #747 and fixes #980. Text input is now handled using dedicated SDL and Sokol APIs, hence accounting for modifiers and keyboard layouts (_e.g._ French layout numbers row symbols now work again).

**This pull request breaks touch keyboard**, but I think it is a good thing, please check #1018 out.

Tested on Linux (X server) with French (`fr-fr`) keyboard layout, on both `tic80` and `tic80-sokol`.