### PR TITLE
Add timestamp() function

### DIFF
--- a/src/jsapi.c
+++ b/src/jsapi.c
@@ -591,6 +591,15 @@ static duk_ret_t duk_time(duk_context* duk)
 	return 1;
 }
 
+static duk_ret_t duk_date(duk_context* duk)
+{
+	tic_mem* memory = (tic_mem*)getDukMachine(duk);
+
+	duk_push_number(duk, memory->api.date(memory));
+
+	return 1;
+}
+
 static duk_ret_t duk_exit(duk_context* duk)
 {
 	tic_machine* machine = getDukMachine(duk);
@@ -809,6 +818,7 @@ static const struct{duk_c_function func; s32 params;} ApiFunc[] =
 	{duk_trace, 2},
 	{duk_pmem, 2},
 	{duk_time, 0},
+	{duk_date, 0},
 	{duk_exit, 0},
 	{duk_font, 8},
 	{duk_mouse, 0},

--- a/src/jsapi.c
+++ b/src/jsapi.c
@@ -591,11 +591,11 @@ static duk_ret_t duk_time(duk_context* duk)
 	return 1;
 }
 
-static duk_ret_t duk_date(duk_context* duk)
+static duk_ret_t duk_timestamp(duk_context* duk)
 {
 	tic_mem* memory = (tic_mem*)getDukMachine(duk);
 
-	duk_push_number(duk, memory->api.date(memory));
+	duk_push_number(duk, memory->api.timestamp(memory));
 
 	return 1;
 }
@@ -818,7 +818,7 @@ static const struct{duk_c_function func; s32 params;} ApiFunc[] =
 	{duk_trace, 2},
 	{duk_pmem, 2},
 	{duk_time, 0},
-	{duk_date, 0},
+	{duk_timestamp, 0},
 	{duk_exit, 0},
 	{duk_font, 8},
 	{duk_mouse, 0},

--- a/src/luaapi.c
+++ b/src/luaapi.c
@@ -1105,6 +1105,15 @@ static s32 lua_time(lua_State *lua)
 	return 1;
 }
 
+static s32 lua_date(lua_State *lua)
+{
+	tic_mem* memory = (tic_mem*)getLuaMachine(lua);
+	
+	lua_pushnumber(lua, memory->api.date(memory));
+
+	return 1;
+}
+
 static s32 lua_exit(lua_State *lua)
 {
 	tic_machine* machine = getLuaMachine(lua);
@@ -1172,7 +1181,7 @@ static const lua_CFunction ApiFunc[] =
 	NULL, NULL, NULL, lua_print, lua_cls, lua_pix, lua_line, lua_rect, 
 	lua_rectb, lua_spr, lua_btn, lua_btnp, lua_sfx, lua_map, lua_mget, 
 	lua_mset, lua_peek, lua_poke, lua_peek4, lua_poke4, lua_memcpy, 
-	lua_memset, lua_trace, lua_pmem, lua_time, lua_exit, lua_font, lua_mouse, 
+	lua_memset, lua_trace, lua_pmem, lua_time, lua_date, lua_exit, lua_font, lua_mouse, 
 	lua_circ, lua_circb, lua_tri, lua_textri, lua_clip, lua_music, lua_sync, lua_reset,
 	lua_key, lua_keyp
 };

--- a/src/luaapi.c
+++ b/src/luaapi.c
@@ -1105,11 +1105,11 @@ static s32 lua_time(lua_State *lua)
 	return 1;
 }
 
-static s32 lua_date(lua_State *lua)
+static s32 lua_timestamp(lua_State *lua)
 {
 	tic_mem* memory = (tic_mem*)getLuaMachine(lua);
-	
-	lua_pushnumber(lua, memory->api.date(memory));
+
+	lua_pushnumber(lua, memory->api.timestamp(memory));
 
 	return 1;
 }
@@ -1181,7 +1181,7 @@ static const lua_CFunction ApiFunc[] =
 	NULL, NULL, NULL, lua_print, lua_cls, lua_pix, lua_line, lua_rect, 
 	lua_rectb, lua_spr, lua_btn, lua_btnp, lua_sfx, lua_map, lua_mget, 
 	lua_mset, lua_peek, lua_poke, lua_peek4, lua_poke4, lua_memcpy, 
-	lua_memset, lua_trace, lua_pmem, lua_time, lua_date, lua_exit, lua_font, lua_mouse, 
+	lua_memset, lua_trace, lua_pmem, lua_time, lua_timestamp, lua_exit, lua_font, lua_mouse, 
 	lua_circ, lua_circb, lua_tri, lua_textri, lua_clip, lua_music, lua_sync, lua_reset,
 	lua_key, lua_keyp
 };

--- a/src/machine.h
+++ b/src/machine.h
@@ -34,7 +34,7 @@
 
 #define API_KEYWORDS {TIC_FN, SCN_FN, OVR_FN, "print", "cls", "pix", "line", "rect", "rectb", \
 	"spr", "btn", "btnp", "sfx", "map", "mget", "mset", "peek", "poke", "peek4", "poke4", \
-	"memcpy", "memset", "trace", "pmem", "time", "date", "exit", "font", "mouse", "circ", "circb", "tri", "textri", \
+	"memcpy", "memset", "trace", "pmem", "time", "timestamp", "exit", "font", "mouse", "circ", "circb", "tri", "textri", \
 	"clip", "music", "sync", "reset", "key", "keyp"}
 	
 typedef struct

--- a/src/machine.h
+++ b/src/machine.h
@@ -34,7 +34,7 @@
 
 #define API_KEYWORDS {TIC_FN, SCN_FN, OVR_FN, "print", "cls", "pix", "line", "rect", "rectb", \
 	"spr", "btn", "btnp", "sfx", "map", "mget", "mset", "peek", "poke", "peek4", "poke4", \
-	"memcpy", "memset", "trace", "pmem", "time", "exit", "font", "mouse", "circ", "circb", "tri", "textri", \
+	"memcpy", "memset", "trace", "pmem", "time", "date", "exit", "font", "mouse", "circ", "circb", "tri", "textri", \
 	"clip", "music", "sync", "reset", "key", "keyp"}
 	
 typedef struct

--- a/src/squirrelapi.c
+++ b/src/squirrelapi.c
@@ -1210,6 +1210,15 @@ static SQInteger squirrel_time(HSQUIRRELVM vm)
 	return 1;
 }
 
+static SQInteger squirrel_date(HSQUIRRELVM vm)
+{
+	tic_mem* memory = (tic_mem*)getSquirrelMachine(vm);
+	
+	sq_pushinteger(vm, (SQFloat)(memory->api.date(memory)));
+
+	return 1;
+}
+
 static SQInteger squirrel_exit(HSQUIRRELVM vm)
 {
 	tic_machine* machine = getSquirrelMachine(vm);
@@ -1270,7 +1279,7 @@ static const SQFUNCTION ApiFunc[] =
 	NULL, NULL, NULL, squirrel_print, squirrel_cls, squirrel_pix, squirrel_line, squirrel_rect, 
 	squirrel_rectb, squirrel_spr, squirrel_btn, squirrel_btnp, squirrel_sfx, squirrel_map, squirrel_mget, 
 	squirrel_mset, squirrel_peek, squirrel_poke, squirrel_peek4, squirrel_poke4, squirrel_memcpy, 
-	squirrel_memset, squirrel_trace, squirrel_pmem, squirrel_time, squirrel_exit, squirrel_font, squirrel_mouse, 
+	squirrel_memset, squirrel_trace, squirrel_pmem, squirrel_time, squirrel_date, squirrel_exit, squirrel_font, squirrel_mouse, 
 	squirrel_circ, squirrel_circb, squirrel_tri, squirrel_textri, squirrel_clip, squirrel_music, squirrel_sync, squirrel_reset,
 	squirrel_key, squirrel_keyp
 };

--- a/src/squirrelapi.c
+++ b/src/squirrelapi.c
@@ -1210,11 +1210,11 @@ static SQInteger squirrel_time(HSQUIRRELVM vm)
 	return 1;
 }
 
-static SQInteger squirrel_date(HSQUIRRELVM vm)
+static SQInteger squirrel_timestamp(HSQUIRRELVM vm)
 {
 	tic_mem* memory = (tic_mem*)getSquirrelMachine(vm);
 	
-	sq_pushinteger(vm, (SQFloat)(memory->api.date(memory)));
+	sq_pushinteger(vm, (SQFloat)(memory->api.timestamp(memory)));
 
 	return 1;
 }
@@ -1279,7 +1279,7 @@ static const SQFUNCTION ApiFunc[] =
 	NULL, NULL, NULL, squirrel_print, squirrel_cls, squirrel_pix, squirrel_line, squirrel_rect, 
 	squirrel_rectb, squirrel_spr, squirrel_btn, squirrel_btnp, squirrel_sfx, squirrel_map, squirrel_mget, 
 	squirrel_mset, squirrel_peek, squirrel_poke, squirrel_peek4, squirrel_poke4, squirrel_memcpy, 
-	squirrel_memset, squirrel_trace, squirrel_pmem, squirrel_time, squirrel_date, squirrel_exit, squirrel_font, squirrel_mouse, 
+	squirrel_memset, squirrel_trace, squirrel_pmem, squirrel_time, squirrel_timestamp, squirrel_exit, squirrel_font, squirrel_mouse, 
 	squirrel_circ, squirrel_circb, squirrel_tri, squirrel_textri, squirrel_clip, squirrel_music, squirrel_sync, squirrel_reset,
 	squirrel_key, squirrel_keyp
 };

--- a/src/tic.c
+++ b/src/tic.c
@@ -1880,7 +1880,7 @@ static double api_time(tic_mem* memory)
 	return (double)((machine->data->counter() - machine->data->start)*1000)/machine->data->freq();
 }
 
-static int api_date(tic_mem* memory)
+static int api_timestamp(tic_mem* memory)
 {
 	tic_machine* machine = (tic_machine*)memory;
 	return (int)time(NULL);
@@ -2210,7 +2210,7 @@ static void initApi(tic_api* api)
 	INIT_API(music);
 	INIT_API(music_frame);
 	INIT_API(time);
-	INIT_API(date);
+	INIT_API(timestamp);
 	INIT_API(tick);
 	INIT_API(scanline);
 	INIT_API(overline);

--- a/src/tic.c
+++ b/src/tic.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <stddef.h>
+#include <time.h>
 
 #include "ticapi.h"
 #include "tools.h"
@@ -1879,6 +1880,12 @@ static double api_time(tic_mem* memory)
 	return (double)((machine->data->counter() - machine->data->start)*1000)/machine->data->freq();
 }
 
+static int api_date(tic_mem* memory)
+{
+	tic_machine* machine = (tic_machine*)memory;
+	return (int)time(NULL);
+}
+
 static u32 api_btnp(tic_mem* tic, s32 index, s32 hold, s32 period)
 {
 	tic_machine* machine = (tic_machine*)tic;
@@ -2203,6 +2210,7 @@ static void initApi(tic_api* api)
 	INIT_API(music);
 	INIT_API(music_frame);
 	INIT_API(time);
+	INIT_API(date);
 	INIT_API(tick);
 	INIT_API(scanline);
 	INIT_API(overline);

--- a/src/ticapi.h
+++ b/src/ticapi.h
@@ -150,7 +150,7 @@ typedef struct
 	void (*music)				(tic_mem* memory, s32 track, s32 frame, s32 row, bool loop);
 	void (*music_frame)			(tic_mem* memory, s32 track, s32 frame, s32 row, bool loop);
 	double (*time)				(tic_mem* memory);
-	int (*date)                 (tic_mem* memory);
+	int  (*timestamp)			(tic_mem* memory);
 	void (*tick)				(tic_mem* memory, tic_tick_data* data);
 	void (*scanline)			(tic_mem* memory, s32 row, void* data);
 	void (*overline)				(tic_mem* memory, void* data);

--- a/src/ticapi.h
+++ b/src/ticapi.h
@@ -150,6 +150,7 @@ typedef struct
 	void (*music)				(tic_mem* memory, s32 track, s32 frame, s32 row, bool loop);
 	void (*music_frame)			(tic_mem* memory, s32 track, s32 frame, s32 row, bool loop);
 	double (*time)				(tic_mem* memory);
+	int (*date)                 (tic_mem* memory);
 	void (*tick)				(tic_mem* memory, tic_tick_data* data);
 	void (*scanline)			(tic_mem* memory, s32 row, void* data);
 	void (*overline)				(tic_mem* memory, void* data);

--- a/src/wrenapi.c
+++ b/src/wrenapi.c
@@ -104,6 +104,7 @@ class TIC {\n\
 	foreign static music(track, frame)\n\
 	foreign static music(track, frame, loop)\n\
 	foreign static time()\n\
+	foreign static date()\n\
 	foreign static sync()\n\
 	foreign static sync(mask)\n\
 	foreign static sync(mask, bank)\n\
@@ -1067,6 +1068,13 @@ static void wren_time(WrenVM* vm)
 	wrenSetSlotDouble(vm, 0, memory->api.time(memory));
 }
 
+static void wren_date(WrenVM* vm)
+{
+	tic_mem* memory = (tic_mem*)getWrenMachine(vm);
+
+	wrenSetSlotDouble(vm, 0, memory->api.date(memory));
+}
+
 static void wren_sync(WrenVM* vm)
 {
 	tic_mem* memory = (tic_mem*)getWrenMachine(vm);
@@ -1187,6 +1195,7 @@ static WrenForeignMethodFn foreignTicMethods(const char* signature)
 	if (strcmp(signature, "static TIC.music(_,_,_)"    			) == 0) return wren_music;
 
 	if (strcmp(signature, "static TIC.time()"    			    ) == 0) return wren_time;
+	if (strcmp(signature, "static TIC.date()"    			    ) == 0) return wren_date;
 	if (strcmp(signature, "static TIC.sync()"    			    ) == 0) return wren_sync;
 	if (strcmp(signature, "static TIC.sync(_)"                  ) == 0) return wren_sync;
 	if (strcmp(signature, "static TIC.sync(_,_)"                ) == 0) return wren_sync;

--- a/src/wrenapi.c
+++ b/src/wrenapi.c
@@ -104,7 +104,7 @@ class TIC {\n\
 	foreign static music(track, frame)\n\
 	foreign static music(track, frame, loop)\n\
 	foreign static time()\n\
-	foreign static date()\n\
+	foreign static timestamp()\n\
 	foreign static sync()\n\
 	foreign static sync(mask)\n\
 	foreign static sync(mask, bank)\n\
@@ -1068,11 +1068,11 @@ static void wren_time(WrenVM* vm)
 	wrenSetSlotDouble(vm, 0, memory->api.time(memory));
 }
 
-static void wren_date(WrenVM* vm)
+static void wren_timestamp(WrenVM* vm)
 {
 	tic_mem* memory = (tic_mem*)getWrenMachine(vm);
 
-	wrenSetSlotDouble(vm, 0, memory->api.date(memory));
+	wrenSetSlotDouble(vm, 0, memory->api.timestamp(memory));
 }
 
 static void wren_sync(WrenVM* vm)
@@ -1195,7 +1195,7 @@ static WrenForeignMethodFn foreignTicMethods(const char* signature)
 	if (strcmp(signature, "static TIC.music(_,_,_)"    			) == 0) return wren_music;
 
 	if (strcmp(signature, "static TIC.time()"    			    ) == 0) return wren_time;
-	if (strcmp(signature, "static TIC.date()"    			    ) == 0) return wren_date;
+	if (strcmp(signature, "static TIC.timestamp()"				) == 0) return wren_timestamp;
 	if (strcmp(signature, "static TIC.sync()"    			    ) == 0) return wren_sync;
 	if (strcmp(signature, "static TIC.sync(_)"                  ) == 0) return wren_sync;
 	if (strcmp(signature, "static TIC.sync(_,_)"                ) == 0) return wren_sync;


### PR DESCRIPTION
This adds a `timestamp()` function to allow grabbing the [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) in seconds. This would allow making persistent games by storing the timestamp in `pmem()`, and then calculate elapsed time between game runs.

``` lua
currentTime = timestamp()
```

Fixes https://github.com/nesbox/TIC-80/issues/841


# Wiki entry

## timestamp
timetamp    -> The current unix timestamp in seconds.

## Output:
* **seconds** : the number of _seconds_ that have passed since January 1st, 1970. 

## Description:
This function returns the number of _seconds_ elapsed since January 1st, 1970. Useful for creating persistent games which evolve over time between plays.

## Example

![Example](https://i.imgur.com/dCUa09x.gif)

``` lua
-- title: timestamp demo

elapsed = -1

function TIC()
  cls(15)

  -- Display the current time stamp
  current = timestamp()
  print('Timestamp: ' .. current, 10, 10, 1)

  -- Calculate how long ago they last played
  last = pmem(0)
  if last <= 0 then
    last = current
  end
  if elapsed == -1 then
    elapsed = current - last
  end
  pmem(0, current)

  -- Display the elapsed time away
  print('Time away: ' .. elapsed, 10, 24, 1)
end
```