### PR TITLE
Fix libretro Makefile

### DIFF
--- a/build/libretro/Makefile.common
+++ b/build/libretro/Makefile.common
@@ -7,6 +7,7 @@ INCLUDES   :=  \
 	$(CORE_DIR)/vendor/blip-buf \
 	$(CORE_DIR)/vendor/duktape/src \
 	$(CORE_DIR)/vendor/fennel \
+	$(CORE_DIR)/vendor/giflib \
 	$(CORE_DIR)/vendor/lpeg \
 	$(CORE_DIR)/vendor/lua \
 	$(CORE_DIR)/vendor/moonscript \


### PR DESCRIPTION
- http://paste.libretro.com/201007
- was working on my pc using gcc version 9.3.0...