### PR TITLE
Follow cursor on music editor

### DIFF
--- a/src/music.c
+++ b/src/music.c
@@ -309,7 +309,8 @@ static void upRow(Music* music)
 static void downRow(Music* music)
 {
     const tic_sound_state* pos = getMusicPos(music);
-    if(pos->music.track == music->track && music->tracker.follow) return;
+	// Don't move the cursor if the track is being played/recorded
+    if(pos->music.track == music->track && (music->tracker.record || music->tracker.follow)) return;
 
     if (music->tracker.row < getRows(music) - 1)
     {
@@ -383,20 +384,9 @@ static void toggleFollowMode(Music* music)
     music->tracker.follow = !music->tracker.follow;
 }
 
-static void enableFollowMode(Music* music)
-{
-    music->tracker.follow = true;
-}
-
-static void disableFollowMode(Music* music)
-{
-    music->tracker.follow = false;
-}
-
 static void toggleRecordMode(Music* music)
 {
 	music->tracker.record = !music->tracker.record;
-	enableFollowMode(music);
 }
 
 
@@ -1671,7 +1661,7 @@ static void drawTrackerLayout(Music* music)
 
     processKeyboard(music);
 
-    if(music->tracker.follow)
+    if(music->tracker.follow || music->tracker.record)
     {
         const tic_sound_state* pos = getMusicPos(music);
 

--- a/src/music.c
+++ b/src/music.c
@@ -285,14 +285,14 @@ static void updateTracker(Music* music)
 {
     s32 row = music->tracker.row;
 
-    if (row < music->tracker.scroll) music->tracker.scroll = row;
-    else if (row >= music->tracker.scroll + TRACKER_ROWS)
-        music->tracker.scroll = row - TRACKER_ROWS + 1;
+	if (row < music->tracker.scroll + TRACKER_ROWS/2) music->tracker.scroll = row - TRACKER_ROWS/2;
+	else if (row >= music->tracker.scroll + TRACKER_ROWS - TRACKER_ROWS/2)
+		music->tracker.scroll = row - TRACKER_ROWS + TRACKER_ROWS/2;
 
-    {
-        s32 rows = getRows(music);
-        if (music->tracker.row >= rows) music->tracker.row = rows - 1;
-    }
+	{
+		s32 rows = getRows(music);
+		if (music->tracker.row >= rows) music->tracker.row = rows - 1;
+	}
 
     updateScroll(music);
 }

--- a/src/music.c
+++ b/src/music.c
@@ -1447,9 +1447,25 @@ static void drawTracker(Music* music, s32 x, s32 y)
         drawTrackerChannel(music, x + ChannelWidth * i, y, i);
 }
 
-static void enableFollowMode(Music* music)
+static void toggleFollowMode(Music* music)
 {
     music->tracker.follow = !music->tracker.follow;
+}
+
+static void enableFollowMode(Music* music)
+{
+    music->tracker.follow = true;
+}
+
+static void disableFollowMode(Music* music)
+{
+    music->tracker.follow = false;
+}
+
+static void toggleRecordMode(Music* music)
+{
+	music->tracker.record = !music->tracker.record;
+	enableFollowMode(music);
 }
 
 static void drawPlayButtons(Music* music)
@@ -1509,13 +1525,13 @@ static void drawPlayButtons(Music* music)
             static const char* Tooltips[] = { "RECORD MUSIC", "PLAY FRAME [enter]", "PLAY TRACK", "STOP [enter]" };
             showTooltip(Tooltips[i]);
 
-            static void(*const Handlers[])(Music*) = { enableFollowMode, playFrame, playTrack, stopTrack };
+            static void(*const Handlers[])(Music*) = { toggleRecordMode, playFrame, playTrack, stopTrack };
 
             if (checkMouseClick(&rect, tic_mouse_left))
                 Handlers[i](music);
         }
 
-        if(i == 0 && music->tracker.follow)
+        if(i == 0 && music->tracker.record)
             drawBitIcon(rect.x, rect.y, Icons + i*Rows, over ? tic_color_2 : tic_color_2);
         else
             drawBitIcon(rect.x, rect.y, Icons + i*Rows, over ? tic_color_14 : tic_color_13);
@@ -1716,7 +1732,8 @@ void initMusic(Music* music, tic_mem* tic, tic_music* src)
         .track = 0,
         .tracker =
         {
-            .follow = false,
+            .follow = true,
+            .record = false,
             .frame = 0,
             .col = 0,
             .row = 0,

--- a/src/music.c
+++ b/src/music.c
@@ -378,6 +378,28 @@ static void doTab(Music* music)
     updateTracker(music);
 }
 
+static void toggleFollowMode(Music* music)
+{
+    music->tracker.follow = !music->tracker.follow;
+}
+
+static void enableFollowMode(Music* music)
+{
+    music->tracker.follow = true;
+}
+
+static void disableFollowMode(Music* music)
+{
+    music->tracker.follow = false;
+}
+
+static void toggleRecordMode(Music* music)
+{
+	music->tracker.record = !music->tracker.record;
+	enableFollowMode(music);
+}
+
+
 static void upFrame(Music* music)
 {
     music->tracker.frame--;
@@ -1085,6 +1107,7 @@ static void processKeyboard(Music* music)
         else if(keyWasPressed(tic_key_y))   redo(music);
         else if(keyWasPressed(tic_key_up))  upFrame(music);
         else if(keyWasPressed(tic_key_down)) downFrame(music);
+        else if(keyWasPressed(tic_key_f)) toggleFollowMode(music);
     }
     else
     {
@@ -1445,27 +1468,6 @@ static void drawTracker(Music* music, s32 x, s32 y)
 
     for (s32 i = 0; i < TIC_SOUND_CHANNELS; i++)
         drawTrackerChannel(music, x + ChannelWidth * i, y, i);
-}
-
-static void toggleFollowMode(Music* music)
-{
-    music->tracker.follow = !music->tracker.follow;
-}
-
-static void enableFollowMode(Music* music)
-{
-    music->tracker.follow = true;
-}
-
-static void disableFollowMode(Music* music)
-{
-    music->tracker.follow = false;
-}
-
-static void toggleRecordMode(Music* music)
-{
-	music->tracker.record = !music->tracker.record;
-	enableFollowMode(music);
 }
 
 static void drawPlayButtons(Music* music)

--- a/src/music.h
+++ b/src/music.h
@@ -37,6 +37,7 @@ struct Music
     struct
     {
         bool follow;
+        bool record;
         s32 patternCol;
 
         s32 frame;


### PR DESCRIPTION
Hi! :)

First of all, congratulations for your work with TIC-80, I've been in love with it recently.

So I've changed the behavior of the cursor in the editor. Now, when you play a track or a frame, the editor will scroll with the cursor allowing you to see what's currently being played. I made this behavior true by default.

I also changed how the editor follows the cursor. Before, the cursor was always at the bottom/top of the editor when scrolling, now it's always at the center. That's default [for](https://www.youtube.com/watch?v=Dmhtc5S4atU) [most](https://www.youtube.com/watch?v=mD6F3b2GiFc) [trackers](https://www.youtube.com/watch?v=B_IQ709vIuo).

One last thing, I also added a shortcut to toggle follow mode: CTRL + F.

![cursor-scroll](https://user-images.githubusercontent.com/15495352/80563017-e32d3f00-89e9-11ea-8a12-d3b760e3a226.gif)