### PR TITLE
Highlight matching delimiters in code editor

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -98,6 +98,7 @@ struct Code
         s32 index;
     } outline;
 
+    char* matchedDelim;
     bool altFont;
 
     void(*tick)(Code*);


### PR DESCRIPTION
When you're in the code editor, this will make it so having your cursor over a `(` character will highlight the matching `)` character. (or similarly with `[`/`]` and `{`/`}`). This makes it much easier to avoid syntax errors.

The highlighting uses `rectb` around the matching delimiter with the same color as the cursor, so it is visually similar to the cursor but more subtle.

I could also add a config setting to allow you to disable this feature, but I haven't done so yet; do you think this is a good idea?

Fixes #1075.