### PR TITLE
Accept and run commands from argv.

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -3306,15 +3306,27 @@ static bool checkUIScale(Console* console, const char* param, const char* value)
     return done;
 }
 
-static bool checkCommand(Console* console, const char* command)
+static bool checkCommand(Console* console, const char* argument)
 {
     for(s32 i = 0; i < COUNT_OF(AvailableConsoleCommands); i++)
     {
+        char command[16];
+        for(s32 i = 0; i < sizeof(command); i++)
+        {
+            if(argument[i] == ' ' || argument[i] == '\t')
+            {
+                command[i] = 0;
+                break;
+            }
+            command[i] = argument[i];
+        }
+        command[15] = 0;
+
         if(tic_strcasecmp(command, AvailableConsoleCommands[i].command) == 0 ||
             (AvailableConsoleCommands[i].alt &&
              tic_strcasecmp(command, AvailableConsoleCommands[i].alt) == 0))
         {
-            processCommand(console, command);
+            processCommand(console, argument);
             return true;
         }
     }

--- a/src/console.c
+++ b/src/console.c
@@ -3306,13 +3306,17 @@ static bool checkUIScale(Console* console, const char* param, const char* value)
     return done;
 }
 
-static bool checkCommand(Console* console, const char* param, const char* value)
+static bool checkCommand(Console* console, const char* command)
 {
-    if(strcmp(param, "-command") == 0)
+    for(s32 i = 0; i < COUNT_OF(AvailableConsoleCommands); i++)
     {
-        processCommand(console, value);
-        exitStudio();
-        return true;
+        if(tic_strcasecmp(command, AvailableConsoleCommands[i].command) == 0 ||
+            (AvailableConsoleCommands[i].alt &&
+             tic_strcasecmp(command, AvailableConsoleCommands[i].alt) == 0))
+        {
+            processCommand(console, command);
+            return true;
+        }
     }
     return false;
 }
@@ -3415,8 +3419,7 @@ void initConsole(Console* console, tic_mem* tic, FileSystem* fs, Config* config,
                 if(cmdInjectCode(console, first, second)
                     || cmdInjectSprites(console, first, second)
                     || cmdInjectMap(console, first, second)
-                    || checkUIScale(console, first, second)
-                    || checkCommand(console, first, second))
+                    || checkUIScale(console, first, second))
                     argp |= mask;
             }
         }
@@ -3456,9 +3459,12 @@ void initConsole(Console* console, tic_mem* tic, FileSystem* fs, Config* config,
         {
             if(~argp & 1 << i)
             {
-                char buf[256];
-                sprintf(buf, "parameter or file not processed: %s\n", argv[i]);
-                getSystem()->showMessageBox("Warning", buf);
+                if(!checkCommand(console, argv[i]))
+                {
+                    char buf[256];
+                    sprintf(buf, "parameter or file not processed: %s\n", argv[i]);
+                    getSystem()->showMessageBox("Warning", buf);
+                }
             }
         }
     }

--- a/src/console.c
+++ b/src/console.c
@@ -3306,6 +3306,17 @@ static bool checkUIScale(Console* console, const char* param, const char* value)
     return done;
 }
 
+static bool checkCommand(Console* console, const char* param, const char* value)
+{
+    if(strcmp(param, "-command") == 0)
+    {
+        processCommand(console, value);
+        exitStudio();
+        return true;
+    }
+    return false;
+}
+
 void initConsole(Console* console, tic_mem* tic, FileSystem* fs, Config* config, s32 argc, char **argv)
 {
     if(!console->buffer) console->buffer = malloc(CONSOLE_BUFFER_SIZE);
@@ -3404,7 +3415,8 @@ void initConsole(Console* console, tic_mem* tic, FileSystem* fs, Config* config,
                 if(cmdInjectCode(console, first, second)
                     || cmdInjectSprites(console, first, second)
                     || cmdInjectMap(console, first, second)
-                    || checkUIScale(console, first, second))
+                    || checkUIScale(console, first, second)
+                    || checkCommand(console, first, second))
                     argp |= mask;
             }
         }


### PR DESCRIPTION
I was thinking it might be nice to be able to export to HTML from my makefile. I have two commits here to make that happen; the first one makes it so the CLI accepts a `-command foo` flag which gets run as a console command, and then exits. As far as I can tell this works. The second commit attempts to make it so that the console command `export html foo.zip` will use "foo.zip" as its output filename instead of popping up a system save dialog box. This part does not work yet.

Anyway, if you think this is a good idea I can continue to work on this and get the problems ironed out, but if you think this complicates things too much that is fine too; I wanted to ask your opinion before I spent much more time on it.

Thanks!