### PR TITLE
Fix segmentation fault caused by findMatchedDelim unsafe NULL pointer

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -247,6 +247,7 @@ const char* findMatchedDelim(Code* code, const char* current)
            code->syntax[current - start] == SyntaxTypeString) continue;
         if(*current == seeking) return current;
         if(*current == initial) current = findMatchedDelim(code, current);
+        if(!current) break;
     }
 
     return NULL;


### PR DESCRIPTION
built on current master.

In the code editor, trying to highlight a matching delimiter in the following code will cause segmentation fault.
```lua
func())))))
```

findMatchedDelim may return NULL, which should instantaneously break out of the loop and avoid dereferencing a NULL pointer when checking for the loop condition.

Also, the `current` pointer should probably be bound by TIC_CODE_SIZE (it currently isn't and looks like it can go outside of the code memory segment).