### PR TITLE
Export based on current directory, not internal data folder.

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -2144,7 +2144,12 @@ static void onConsoleExportHtmlCommand(Console* console, const char* providedNam
 
             if(data && providedName)
             {
-                if(fsSaveFile(console->fs, providedName, data, sizeof(data), false))
+                if(fsExists(providedName))
+                {
+                    printError(console, "\nfile already exists");
+                    return commandDone(console);
+                }
+                else if(fsWriteFile(providedName, data, sizeof(data)))
                     return onFileDownloaded(FS_FILE_DOWNLOADED, console);
                 else
                     return onFileDownloaded(FS_FILE_NOT_DOWNLOADED, console);


### PR DESCRIPTION
This fixes the functionality introduced in #1101 so it can accept any path rather than saving inside the data directory.

Also show a more useful error message when the file already exists.