### PR TITLE
minor rendering optimizations

### DIFF
--- a/src/surf.c
+++ b/src/surf.c
@@ -288,8 +288,10 @@ static void drawMenu(Surf* surf, s32 x, s32 y)
 
         s32 ym = Height * i + y - surf->menu.pos*MENU_HEIGHT - surf->menu.anim + (MENU_HEIGHT - TIC_FONT_HEIGHT)/2;
 
-        tic_api_print(tic, name, x + MAIN_OFFSET, ym + 1, tic_color_0, false, 1, false);
-        tic_api_print(tic, name, x + MAIN_OFFSET, ym, tic_color_12, false, 1, false);
+        if (ym > (-(TIC_FONT_HEIGHT + 1)) && ym <= TIC80_HEIGHT) {
+            tic_api_print(tic, name, x + MAIN_OFFSET, ym + 1, tic_color_0, false, 1, false);
+            tic_api_print(tic, name, x + MAIN_OFFSET, ym, tic_color_12, false, 1, false);
+        }
     }
 }
 


### PR DESCRIPTION
* surf will now no longer try to draw lines outside of render range (this *really* helps when browsing the TIC-80 website list on low-end hardware in particular)
* drawVLine now checks clipped boundaries instead of screen size for early cancellation
* some methods received an EARLY_CLIP check behind potentially expensive for loops (I'm not sure on this one, what are your thoughts?)