### PR TITLE
Add pixel color format field to TIC-80 structs and blitting.

### DIFF
--- a/include/tic80.h
+++ b/include/tic80.h
@@ -38,6 +38,13 @@ extern "C" {
 #define TIC80_SAMPLERATE 44100
 #define TIC80_FRAMERATE 60
 
+typedef enum {
+    TIC80_PIXEL_COLOR_ARGB8888 = (1 << 8) | 32,
+    TIC80_PIXEL_COLOR_ABGR8888 = (2 << 8) | 32,
+    TIC80_PIXEL_COLOR_RGBA8888 = (3 << 8) | 32,
+    TIC80_PIXEL_COLOR_BGRA8888 = (4 << 8) | 32
+} tic80_pixel_color_format;
+
 typedef struct 
 {
 	struct
@@ -54,6 +61,7 @@ typedef struct
 	} sound;
 
 	u32* screen;
+	tic80_pixel_color_format screen_format;
 	
 } tic80;
 

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -181,25 +181,14 @@ static System systemInterface =
 	.updateConfig = updateConfig,
 };
 
-u32 rgbaToBgra(u32 u){
-	u8 r = u & 0xFF;
-	u8 g = (u >> 8) & 0xff;
-	u8 b = (u >> 16) & 0xff;
-	return (b & 0xFF)      
-					| ((g & 0xFF) << 8)
-					| ((r & 0xFF)   << 16)
-					| (0xFF << 24);
-}
-
 void screenCopy(CScreenDevice* screen, u32* ts)
 {
 	u32 pitch = screen->GetPitch();
 	u32* buf = screen->GetBuffer();
 	for (int y = 0; y<136;y++)
-	for (int x = 0; x<240;x++)
 	{
-		u32 p = ts[(y+4)*(8+240+8)+(x+8)];
-		buf[pitch*y + x] = rgbaToBgra(p);
+		u32 *line = ts + ((y+TIC80_OFFSET_TOP)*(TIC80_FULLWIDTH) + TIC80_OFFSET_LEFT);
+		memcpy(buf + (pitch * y), line, 240 * 4);
 	}
 
 	// single pixel mouse pointer, disappear after 10 seconds unmoved
@@ -430,7 +419,7 @@ TShutdownMode Run(void)
 	}
 
 	// gotoSurf();
-
+	platform.studio->tic->screen_format = TIC_PIXEL_COLOR_BGRA8888;
 	dbg("Studio init ok..\n");
 
 	if (pKeyboard){

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -185,10 +185,10 @@ void screenCopy(CScreenDevice* screen, u32* ts)
 {
 	u32 pitch = screen->GetPitch();
 	u32* buf = screen->GetBuffer();
-	for (int y = 0; y<136;y++)
+	for (int y = 0; y < TIC80_HEIGHT; y++)
 	{
 		u32 *line = ts + ((y+TIC80_OFFSET_TOP)*(TIC80_FULLWIDTH) + TIC80_OFFSET_LEFT);
-		memcpy(buf + (pitch * y), line, 240 * 4);
+		memcpy(buf + (pitch * y), line, TIC80_WIDTH * 4);
 	}
 
 	// single pixel mouse pointer, disappear after 10 seconds unmoved
@@ -198,7 +198,7 @@ void screenCopy(CScreenDevice* screen, u32* ts)
 		buf[midx]= 0xffffff;
 	}
 
-	// memcpy(screen->GetBuffer(), tic->screen, 240*136*4); would have been too good
+	// memcpy(screen->GetBuffer(), tic->screen, TIC80_WIDTH*TIC80_HEIGHT*4); would have been too good
 }
 
 

--- a/src/system/baremetalpi/size.h
+++ b/src/system/baremetalpi/size.h
@@ -1,8 +1,0 @@
-#ifndef _sizes_h
-#define _sizes_h
-
-#define SCREEN_WIDTH 240
-#define SCREEN_HEIGHT 136
-
-#endif
-

--- a/src/system/baremetalpi/stdlib_app.h
+++ b/src/system/baremetalpi/stdlib_app.h
@@ -17,7 +17,7 @@
 #include <circle/exceptionhandler.h>
 #include <circle/interrupt.h>
 #include "customscreen.h"
-#include "size.h"
+#include <tic80.h>
 #include <circle/serial.h>
 #include <circle/timer.h>
 #include <circle/logger.h>
@@ -34,6 +34,8 @@
 #include <circle/startup.h>
 
 #include <circle_glue.h>
+
+#include <tic80.h>
 
 /**
  * Basic Circle Stdlib application that supports GPIO access.
@@ -94,8 +96,7 @@ class CStdlibAppScreen : public CStdlibApp
 public:
         CStdlibAppScreen(const char *kernel)
                 : CStdlibApp (kernel),
-                  mScreen (SCREEN_WIDTH, SCREEN_HEIGHT),
-//                  mScreen (240, 136),
+                  mScreen (TIC80_WIDTH, TIC80_HEIGHT),
 		mSerial(&mInterrupt),
                   mTimer (&mInterrupt),
                   mLogger (LogWarning /*mOptions.GetLogLevel ()*/, &mTimer)

--- a/src/system/baremetalpi/syscore.h
+++ b/src/system/baremetalpi/syscore.h
@@ -9,7 +9,7 @@
 #include <circle/exceptionhandler.h>
 #include <circle/interrupt.h>
 #include "customscreen.h"
-#include "size.h"
+#include <tic80.h>
 #include "utils.h"
 #include <circle/serial.h>
 #include <circle/timer.h>
@@ -45,7 +45,7 @@ static       CDeviceNameService mDeviceNameService;
 static        CNullDevice        mNullDevice;
 static        CExceptionHandler  mExceptionHandler;
 static        CInterruptSystem   mInterrupt;
-static	CScreenDevice      mScreen(SCREEN_WIDTH, SCREEN_HEIGHT);
+static	CScreenDevice      mScreen(TIC80_WIDTH, TIC80_HEIGHT);
 static        CSerialDevice      mSerial(&mInterrupt);
 static        CTimer             mTimer(&mInterrupt);
 static        CLogger		mLogger(LogWarning /*mOptions.GetLogLevel ()*/, &mTimer);
@@ -174,7 +174,7 @@ boolean initializeCore()
 	}
 	else
 	{
-		if (!pMouse->Setup (SCREEN_WIDTH*MOUSE_SENS, SCREEN_HEIGHT*MOUSE_SENS))
+		if (!pMouse->Setup (TIC80_WIDTH*MOUSE_SENS, TIC80_HEIGHT*MOUSE_SENS))
 		{
 			Die("Cannot setup mouse");
 		}

--- a/src/system/sdlgpu.c
+++ b/src/system/sdlgpu.c
@@ -185,7 +185,7 @@ static void setWindowIcon()
 
     u32* pixels = SDL_malloc(Size * Size * sizeof(u32));
 
-    const u32* pal = tic_tool_palette_blit(&platform.studio->config()->cart->bank0.palette);
+    const u32* pal = tic_tool_palette_blit(&platform.studio->config()->cart->bank0.palette, platform.studio->tic->screen_format);
 
     for(s32 j = 0, index = 0; j < Size; j++)
         for(s32 i = 0; i < Size; i++, index++)
@@ -278,7 +278,7 @@ static void initTouchKeyboard()
 
         drawKeyboardLabels(0);
 
-        tic_core_blit(tic);
+        tic_core_blit(tic, tic->screen_format);
 
         platform.keyboard.texture.upPixels = SDL_malloc(TIC80_FULLWIDTH * TIC80_FULLHEIGHT * sizeof(u32));
         if(platform.keyboard.texture.upPixels)
@@ -303,7 +303,7 @@ static void initTouchKeyboard()
 
         drawKeyboardLabels(2);
 
-        tic_core_blit(tic);
+        tic_core_blit(tic, tic->screen_format);
 
         platform.keyboard.texture.downPixels = SDL_malloc(TIC80_FULLWIDTH * TIC80_FULLHEIGHT * sizeof(u32));
         if(platform.keyboard.texture.downPixels)
@@ -335,7 +335,7 @@ static void initTouchGamepad()
 
             const u8* in = platform.studio->tic->ram.vram.screen.data;
             const u8* end = in + sizeof(platform.studio->tic->ram.vram.screen);
-            const u32* pal = tic_tool_palette_blit(&platform.studio->config()->cart->bank0.palette);
+            const u32* pal = tic_tool_palette_blit(&platform.studio->config()->cart->bank0.palette, platform.studio->tic->screen_format);
             const u32 Delta = ((TIC80_FULLWIDTH*sizeof(u32))/sizeof *out - TIC80_WIDTH);
 
             s32 col = 0;
@@ -1150,7 +1150,7 @@ static void blitCursor(const u8* in)
         platform.mouse.src = in;
 
         const u8* end = in + sizeof(tic_tile);
-        const u32* pal = tic_tool_palette_blit(&platform.studio->tic->ram.vram.palette);
+        const u32* pal = tic_tool_palette_blit(&platform.studio->tic->ram.vram.palette, platform.studio->tic->screen_format);
         static u32 data[TIC_SPRITESIZE*TIC_SPRITESIZE];
         u32* out = data;
 

--- a/src/tic.c
+++ b/src/tic.c
@@ -2072,9 +2072,9 @@ static inline void memset4(void *dst, u32 val, u32 dwords)
 #endif
 }
 
-void tic_core_blit_ex(tic_mem* tic, tic_scanline scanline, tic_overline overline, void* data)
+void tic_core_blit_ex(tic_mem* tic, tic_pixel_color_format fmt, tic_scanline scanline, tic_overline overline, void* data)
 {
-    const u32* pal = tic_tool_palette_blit(&tic->ram.vram.palette);
+    const u32* pal = tic_tool_palette_blit(&tic->ram.vram.palette, fmt);
 
     {
         tic_machine* machine = (tic_machine*)tic;
@@ -2084,7 +2084,7 @@ void tic_core_blit_ex(tic_mem* tic, tic_scanline scanline, tic_overline overline
     if(scanline)
     {
         scanline(tic, 0, data);
-        pal = tic_tool_palette_blit(&tic->ram.vram.palette);
+        pal = tic_tool_palette_blit(&tic->ram.vram.palette, fmt);
     }
 
     enum {Top = (TIC80_FULLHEIGHT-TIC80_HEIGHT)/2, Bottom = Top};
@@ -2115,7 +2115,7 @@ void tic_core_blit_ex(tic_mem* tic, tic_scanline scanline, tic_overline overline
         if(scanline && (r < TIC80_HEIGHT-1))
         {
             scanline(tic, r+1, data);
-            pal = tic_tool_palette_blit(&tic->ram.vram.palette);
+            pal = tic_tool_palette_blit(&tic->ram.vram.palette, fmt);
         }
     }
 
@@ -2142,9 +2142,9 @@ static inline void overline(tic_mem* memory, void* data)
         machine->state.ovr.callback(memory, data);
 }
 
-void tic_core_blit(tic_mem* tic)
+void tic_core_blit(tic_mem* tic, tic_pixel_color_format fmt)
 {
-    tic_core_blit_ex(tic, scanline, overline, NULL);
+    tic_core_blit_ex(tic, fmt, scanline, overline, NULL);
 }
 
 u8 tic_api_peek(tic_mem* memory, s32 address)
@@ -2240,6 +2240,7 @@ tic_mem* tic_core_create(s32 samplerate)
         return NULL;
     }
 
+    machine->memory.screen_format = TIC_PIXEL_COLOR_RGBA8888;
     machine->samplerate = samplerate;
     machine->memory.samples.size = samplerate * TIC_STEREO_CHANNELS / TIC80_FRAMERATE * sizeof(s16);
     machine->memory.samples.buffer = malloc(machine->memory.samples.size);

--- a/src/tic.h
+++ b/src/tic.h
@@ -611,3 +611,12 @@ typedef enum
     tic_cursor_hand,
     tic_cursor_ibeam,
 } tic_cursor;
+
+typedef enum {
+    TIC_PIXEL_COLOR_ARGB8888 = (1 << 8) | 32,
+    TIC_PIXEL_COLOR_ABGR8888 = (2 << 8) | 32,
+    TIC_PIXEL_COLOR_RGBA8888 = (3 << 8) | 32,
+    TIC_PIXEL_COLOR_BGRA8888 = (4 << 8) | 32
+} tic_pixel_color_format;
+
+#define TIC_PIXEL_COLOR_DEPTH(fmt) ((fmt) & 0xFF)

--- a/src/tic80.c
+++ b/src/tic80.c
@@ -74,6 +74,7 @@ tic80* tic80_create(s32 samplerate)
         memset(tic80, 0, sizeof(tic80_local));
 
         tic80->memory = tic_core_create(samplerate);
+        tic80->tic.screen_format = tic80->memory->screen_format;
 
         return &tic80->tic;
     }
@@ -112,13 +113,14 @@ TIC80_API void tic80_tick(tic80* tic, const tic80_input* input)
 {
     tic80_local* tic80 = (tic80_local*)tic;
 
+    tic80->memory->screen_format = tic80->tic.screen_format;
     tic80->memory->ram.input = *input;
     
     tic_core_tick_start(tic80->memory);
     tic_core_tick(tic80->memory, &tic80->tickData);
     tic_core_tick_end(tic80->memory);
 
-    tic_core_blit(tic80->memory);
+    tic_core_blit(tic80->memory, tic80->memory->screen_format);
 
     TickCounter++;
 }

--- a/src/ticapi.h
+++ b/src/ticapi.h
@@ -163,6 +163,7 @@ struct tic_mem
     } samples;
 
     u32 screen[TIC80_FULLWIDTH * TIC80_FULLHEIGHT];
+    tic_pixel_color_format screen_format;
 };
 
 tic_mem* tic_core_create(s32 samplerate);
@@ -174,8 +175,8 @@ s32  tic_core_save(const tic_cartridge* rom, u8* buffer);
 void tic_core_tick_start(tic_mem* memory);
 void tic_core_tick(tic_mem* memory, tic_tick_data* data);
 void tic_core_tick_end(tic_mem* memory);
-void tic_core_blit(tic_mem* tic);
-void tic_core_blit_ex(tic_mem* tic, tic_scanline scanline, tic_overline overline, void* data);
+void tic_core_blit(tic_mem* tic, tic_pixel_color_format fmt);
+void tic_core_blit_ex(tic_mem* tic, tic_pixel_color_format fmt, tic_scanline scanline, tic_overline overline, void* data);
 const tic_script_config* tic_core_script_config(tic_mem* memory);
 
 typedef struct

--- a/src/tools.c
+++ b/src/tools.c
@@ -91,7 +91,7 @@ u32 tic_tool_find_closest_color(const tic_rgb* palette, const gif_color* color)
     return closetColor;
 }
 
-u32* tic_tool_palette_blit(const tic_palette* srcpal)
+u32* tic_tool_palette_blit(const tic_palette* srcpal, tic_pixel_color_format fmt)
 {
     static u32 pal[TIC_PALETTE_SIZE];
 
@@ -101,10 +101,32 @@ u32* tic_tool_palette_blit(const tic_palette* srcpal)
 
     while(src != end)
     {
-        *dst++ = src->r;
-        *dst++ = src->g;
-        *dst++ = src->b;
-        *dst++ = 0xff;
+        switch(fmt){
+            case TIC_PIXEL_COLOR_BGRA8888:
+                *dst++ = src->b;
+                *dst++ = src->g;
+                *dst++ = src->r;
+                *dst++ = 0xff;
+                break;
+            case TIC_PIXEL_COLOR_RGBA8888:
+                *dst++ = src->r;
+                *dst++ = src->g;
+                *dst++ = src->b;
+                *dst++ = 0xff;
+                break;
+            case TIC_PIXEL_COLOR_ABGR8888:
+                *dst++ = 0xff;
+                *dst++ = src->b;
+                *dst++ = src->g;
+                *dst++ = src->r;
+                break;
+            case TIC_PIXEL_COLOR_ARGB8888:
+                *dst++ = 0xff;
+                *dst++ = src->r;
+                *dst++ = src->g;
+                *dst++ = src->b;
+                break;
+        }
         src++;
     }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -75,7 +75,7 @@ bool    tic_tool_parse_note(const char* noteStr, s32* note, s32* octave);
 s32     tic_tool_get_pattern_id(const tic_track* track, s32 frame, s32 channel);
 void    tic_tool_set_pattern_id(tic_track* track, s32 frame, s32 channel, s32 id);
 u32     tic_tool_find_closest_color(const tic_rgb* palette, const gif_color* color);
-u32*    tic_tool_palette_blit(const tic_palette* src);
+u32*    tic_tool_palette_blit(const tic_palette* src, tic_pixel_color_format fmt);
 bool    tic_tool_has_ext(const char* name, const char* ext);
 s32     tic_tool_get_track_row_sfx(const tic_track_row* row);
 void    tic_tool_set_track_row_sfx(tic_track_row* row, s32 sfx);


### PR DESCRIPTION
Allows for natively outputting to the buffer in a format different than
the default SDL/Sokol one. This also means that the libretro port now
avoids an additional conversion step.

More or less necessary for the 3DS port.