### PR TITLE
Change keybindings in the code editor to resemble bash a bit more.

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1239,7 +1239,7 @@ static void processKeyboard(Code* code)
         if(keyWasPressed(tic_key_left))             leftWord(code);
         else if(keyWasPressed(tic_key_right))       rightWord(code);
         else if(keyWasPressed(tic_key_tab))         doTab(code, shift, ctrl);
-        else if(keyWasPressed(tic_key_a))           selectAll(code);
+        else if(keyWasPressed(tic_key_a) && shift)  selectAll(code);
         else if(keyWasPressed(tic_key_z))           undo(code);
         else if(keyWasPressed(tic_key_y))           redo(code);
         else if(keyWasPressed(tic_key_f))           setCodeMode(code, TEXT_FIND_MODE);
@@ -1250,6 +1250,8 @@ static void processKeyboard(Code* code)
         else if(keyWasPressed(tic_key_end))         goCodeEnd(code);
         else if(keyWasPressed(tic_key_delete))      deleteWord(code);
         else if(keyWasPressed(tic_key_backspace))   backspaceWord(code);
+        else if(keyWasPressed(tic_key_e))           goEnd(code);
+        else if(keyWasPressed(tic_key_a))           goHome(code);
         else                                        usedKeybinding = false;
     }
     else if(alt)


### PR DESCRIPTION
What Changed:
CTRL-A is now the same as HOME
CTRL-E is now the same as END
CTRL-SHIFT-A has the old behavior of CTRL-A, where the whole code is selected.

These changes were made because bash and emacs both use CTRL-A to go to the start of the line, and CTRL-E to go to the end of it. I moved CTRL-A to CTRL-SHIFT-A to still keep _some_ backwards compatibility