### PR TITLE
fixes #1163 (0.80 beta) time() always returns 0 when built with sokol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,11 @@ build/windows/tic80.rc
 *.ninja
 tic80.sublime-workspace
 build/*.tic
+build/*.vcxproj
+build/*.vcxproj.filters
+build/*.vcxproj.user
+build/CMakeDoxyfile.in
+build/*.sln
+build/.local/
+build/*.dir/
+build/x64/

--- a/src/player/sokol.c
+++ b/src/player/sokol.c
@@ -41,6 +41,8 @@ static void app_init(void)
     }
 
     sokol_gfx_init(TIC80_FULLWIDTH, TIC80_FULLHEIGHT, 1, 1, false, false);
+
+    stm_setup();
 }
 
 static tic80_input tic_input;

--- a/src/system/sokol.c
+++ b/src/system/sokol.c
@@ -78,12 +78,12 @@ static void freeClipboardText(const char* text)
 
 static u64 getPerformanceCounter()
 {
-    return 0;
+    return stm_now();
 }
 
 static u64 getPerformanceFrequency()
 {
-    return 1000;
+    return 1000000000;
 }
 
 static void* httpGetSync(const char* url, s32* size)
@@ -163,6 +163,8 @@ static System systemInterface =
 static void app_init(void)
 {
     sokol_gfx_init(TIC80_FULLWIDTH, TIC80_FULLHEIGHT, 1, 1, false, true);
+
+    stm_setup();
 
     platform.audio.samples = calloc(sizeof platform.audio.samples[0], saudio_sample_rate() / TIC80_FRAMERATE * TIC_STEREO_CHANNELS);
 }


### PR DESCRIPTION
This allows the function `time` to return valid values by implementing `getPerformanceCounter` and `getPerformanceFrequency`:
https://github.com/drako0812/TIC-80/blob/42f685cc3d0b06036a756017644f48c68462ebd1/src/system/sokol.c#L79-L87

I don't like how I had to return a raw value for `getPerformanceFrequency`, but `sokol_time` doesn't provide a convenient way to query this information.

It seems to work just fine, but I'm not 100% sure I put the call to `stm_setup` in the right spots.

Currently `stm_setup` is called:
here
https://github.com/drako0812/TIC-80/blob/42f685cc3d0b06036a756017644f48c68462ebd1/src/system/sokol.c#L167
and here
https://github.com/drako0812/TIC-80/blob/42f685cc3d0b06036a756017644f48c68462ebd1/src/player/sokol.c#L45

Also the modifications to `.gitignore` could be reverted, those were just to prevent staging various files creating by the way I went about building TIC-80.