### PR TITLE
gitignore: Ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ build/.local/
 build/*.dir/
 build/x64/
 build/linux/tic80.desktop
+build/compile_commands.json


### PR DESCRIPTION
After building, compile_commands.json ends up showing in git status. This change ignores that file.