### PR TITLE
Clip mouse values in SDL and Sokol

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -524,14 +524,30 @@ static void processMouse()
 #if defined(CRT_SHADER_SUPPORT)
         if(crtMonitorEnabled())
         {
-            if(rect.w) input->mouse.x = (mx - rect.x) * TIC80_FULLWIDTH / rect.w;
-            if(rect.h) input->mouse.y = (my - rect.y) * TIC80_FULLHEIGHT / rect.h;
+            if(rect.w) {
+                int temp_x = (mx - rect.x) * TIC80_FULLWIDTH / rect.w;
+                if (temp_x < 0) temp_x = 0; else if (temp_x >= TIC80_FULLWIDTH) temp_x = TIC80_FULLWIDTH-1; // clip: 0 to TIC80_FULLWIDTH-1
+                input->mouse.x = temp_x;
+            }
+            if(rect.h) {
+                int temp_y = (my - rect.y) * TIC80_FULLHEIGHT / rect.h;
+                if (temp_y < 0) temp_y = 0; else if (temp_y >= TIC80_FULLHEIGHT) temp_y = TIC80_FULLHEIGHT-1; // clip: 0 to TIC80_FULLHEIGHT-1
+                input->mouse.y = temp_y;
+            }
         }
         else
-#endif            
+#endif
         {
-            if(rect.w) input->mouse.x = (mx - rect.x) * TIC80_WIDTH / rect.w + TIC80_OFFSET_LEFT;
-            if(rect.h) input->mouse.y = (my - rect.y) * TIC80_HEIGHT / rect.h + TIC80_OFFSET_TOP;
+            if (rect.w) {
+                int temp_x = (mx - rect.x) * TIC80_WIDTH / rect.w + TIC80_OFFSET_LEFT;
+                if (temp_x < 0) temp_x = 0; else if (temp_x >= TIC80_FULLWIDTH) temp_x = TIC80_FULLWIDTH-1; // clip: 0 to TIC80_FULLWIDTH-1
+                input->mouse.x = temp_x;
+            }
+            if (rect.h) {
+                int temp_y = (my - rect.y) * TIC80_HEIGHT / rect.h + TIC80_OFFSET_TOP;
+                if (temp_y < 0) temp_y = 0; else if (temp_y >= TIC80_FULLHEIGHT) temp_y = TIC80_FULLHEIGHT-1; // clip: 0 to TIC80_FULLHEIGHT-1
+                input->mouse.y = temp_y;
+            }
         }
     }
 

--- a/src/system/sokol/sokol.c
+++ b/src/system/sokol/sokol.c
@@ -356,8 +356,16 @@ static void app_input(const sapp_event* event)
             struct {s32 x, y, w, h;}rect;
             sokol_calc_viewport(&rect.x, &rect.y, &rect.w, &rect.h);
 
-            if(rect.w) input->mouse.x = ((s32)event->mouse_x - rect.x) * TIC80_FULLWIDTH / rect.w;
-            if(rect.h) input->mouse.y = ((s32)event->mouse_y - rect.y) * TIC80_FULLHEIGHT / rect.h;
+            if (rect.w) {
+                int temp_x = ((s32)event->mouse_x - rect.x) * TIC80_FULLWIDTH / rect.w
+                if (temp_x < 0) temp_x = 0; else if (temp_x >= TIC80_FULLWIDTH) temp_x = TIC80_FULLWIDTH-1; // clip: 0 to TIC80_FULLWIDTH-1
+                input->mouse.x = temp_x;
+            }
+            if (rect.h) {
+                int temp_y = ((s32)event->mouse_y - rect.y) * TIC80_FULLHEIGHT / rect.h;
+                if (temp_y < 0) temp_y = 0; else if (temp_y >= TIC80_FULLHEIGHT) temp_y = TIC80_FULLHEIGHT-1; // clip: 0 to TIC80_FULLHEIGHT-1
+                input->mouse.y = temp_y;
+            }
         }
         break;
     case SAPP_EVENTTYPE_MOUSE_DOWN: 


### PR DESCRIPTION
As I noted in issue https://github.com/nesbox/TIC-80/issues/559#issuecomment-770119463, mouse values wrapped around when moving the mouse towards the edges of the screen, especially in fullscreen.

The problem is that the mouse's x/y values are stored as 8bit after being written in RAM.

One possible fix is to clip the values _before_ writing them into RAM, which is what I did here. The mouse's x values are now clipped to a range of 0 to TIC80_FULLWIDTH-1 (and 0 to TIC80_FULLHEIGHT-1 for y) before written into ram.

This is basically identical to the clipping/checking already done in n3ds and in libretro:
https://github.com/nesbox/TIC-80/blob/acddaaad3ae5f5f403db9f1a69872697fb49efb5/src/system/n3ds/main.c#L497-L508
https://github.com/nesbox/TIC-80/blob/acddaaad3ae5f5f403db9f1a69872697fb49efb5/src/system/libretro/tic80_libretro.c#L480-L492

What this means for the mouse api is that `mouse()` now returns x values of -8 to 247 (which is 8px outside of the 0-239 range) and y values of -4 to 139 (which is 4px outside of the 0-135 range).