### PR TITLE
Update to Duktape 2.6.0, and use a shallow clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,7 @@
 [submodule "vendor/duktape"]
 	path = vendor/duktape
 	url = https://github.com/svaarala/duktape-releases.git
+	shallow = true
 [submodule "vendor/giflib"]
 	path = vendor/giflib
 	url = https://github.com/nesbox/giflib.git


### PR DESCRIPTION
Fixes #1323

https://github.com/svaarala/duktape/blob/master/doc/release-notes-v2-6.rst