### PR TITLE
Show how to build pro version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can download compiled versions for the major operating systems directly from
 To help support TIC-80 development, we have a [PRO Version](https://nesbox.itch.io/tic80).
 This version has a few additional features and binaries can only be downloaded on [our Itch.io page](https://nesbox.itch.io/tic80).
 
-For users who can't spend the money, we made it easy to build the pro version from the source code.
+For users who can't spend the money, we made it easy to build the pro version from the source code. (`cmake .. -DBUILD_PRO=On`)
 
 ### Pro features
 


### PR DESCRIPTION
Is this supposed to be well hidden?  Why would someone building from source (possibly contributing to the project, etc) not want the pro version by default?  Could all the build instructions be updated to build pro or explain how?

This was not clear at all and took me like 10 minutes to figure out.