### PR TITLE
Fix using full path as cart name when loading cart

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2994,7 +2994,7 @@ static void tick(Console* console)
 
 static inline bool isslash(char c)
 {
-    return c == '/' && c == '\\';
+    return c == '/' || c == '\\';
 }
 
 static bool cmdLoadCart(Console* console, const char* path)
@@ -3011,7 +3011,7 @@ static bool cmdLoadCart(Console* console, const char* path)
         {
             const char* ptr = path + strlen(path);
             while(ptr > path && !isslash(*ptr))--ptr;
-            cartName = ptr;
+            cartName = ptr + isslash(*ptr);
         }
 
         setCartName(console, cartName, path);


### PR DESCRIPTION
Since a39a206 (File Sytem refactoring, 2020-02-02) using cmdLoadCart()
results in a cart name containing the full path passed instead of only
the basename.

Fix by making it possible for isslash() to return true ("warning C6288:
Incorrect operator: mutual inclusion over && is always zero. Did you
intent [sic] to use || instead?"), and skipping copying of a path
separator.