### PR TITLE
Fix MinGW build, do not add msvc specific flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,7 +575,7 @@ if (USE_CURL)
 
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
 
-    if(WIN32)
+    if(WIN32 AND NOT MINGW)
         set(CURL_STATIC_CRT ON CACHE BOOL "")
     endif()
 


### PR DESCRIPTION
Not sure if this will impact other functionality, I did try surf after I built this and it looks like it worked fine. 