### PR TITLE
Wren TIC.btn fixes

### DIFF
--- a/src/api/wren.c
+++ b/src/api/wren.c
@@ -268,7 +268,7 @@ static void wren_btn(WrenVM* vm)
     }
     else if (top == 2)
     {
-        s32 index = getWrenNumber(vm, 1) & 0xf;
+        s32 index = getWrenNumber(vm, 1) & 0x1f;
         wrenSetSlotBool(vm, 0, core->memory.ram.input.gamepads.data & (1 << index));
     }
     

--- a/src/api/wren.c
+++ b/src/api/wren.c
@@ -42,6 +42,7 @@ static bool loaded = false;
 
 static char const* tic_wren_api = "\n\
 class TIC {\n\
+    foreign static btn()\n\
     foreign static btn(id)\n\
     foreign static btnp(id)\n\
     foreign static btnp(id, hold, period)\n\
@@ -263,7 +264,7 @@ static void wren_btn(WrenVM* vm)
 
     if (top == 1)
     {
-        wrenSetSlotBool(vm, 0, core->memory.ram.input.gamepads.data);
+        wrenSetSlotDouble(vm, 0, core->memory.ram.input.gamepads.data);
     }
     else if (top == 2)
     {
@@ -1214,6 +1215,7 @@ static void wren_fset(WrenVM* vm)
 
 static WrenForeignMethodFn foreignTicMethods(const char* signature)
 {
+    if (strcmp(signature, "static TIC.btn()"                    ) == 0) return wren_btn;
     if (strcmp(signature, "static TIC.btn(_)"                   ) == 0) return wren_btn;
     if (strcmp(signature, "static TIC.btnp(_)"                  ) == 0) return wren_btnp;
     if (strcmp(signature, "static TIC.btnp(_,_,_)"              ) == 0) return wren_btnp;


### PR DESCRIPTION
# The fixes

Two fixes for the Wren's API

1. `TIC.btn()` was not defined in Wren and had the wrong return value
2. `TIC.btn(_)` was mixing controllers 1 & 3, 2 & 4

### `TIC.btn()`

Fixed 2 problems:

1. The handler `wren_btn` was checking for this call but it was not declared as part of the `TIC` class and it was not defined in `foreignTicMethods`
2. The handler `wren_btn` was setting the return value to `bool` instead of `double`

### `TIC.btn(_)`

The button index _bitmask_ was `0xf` instead of `0x1f`, this made tat gamepad 3 returned value for gamepad 1 and gamepad 4 returned value for gamepad 2.