### PR TITLE
Fixed Squirrel's print function fixed flag

### DIFF
--- a/src/api/squirrel.c
+++ b/src/api/squirrel.c
@@ -1151,7 +1151,7 @@ static SQInteger squirrel_print(HSQUIRRELVM vm)
                 if(top >= 6)
                 {
                     SQBool b = SQFalse;
-                    sq_getbool(vm, 5, &b);
+                    sq_getbool(vm, 6, &b);
                     fixed = (b != SQFalse);
 
                     if(top >= 7)


### PR DESCRIPTION
The "fixed" flag was being read from arguments 5, where it actually is in arguments 6.