### PR TITLE
Add "code" to the import usage documentation

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1523,7 +1523,7 @@ static void onConsoleImportCommand(Console* console, const char* param)
     if(error)
     {
         printBack(console, "\nusage:\nimport (");
-        printFront(console, "tiles sprites map screen");
+        printFront(console, "code map screen sprites tiles");
         printBack(console, ") file");
         commandDone(console);
     }


### PR DESCRIPTION
Looked like `code` was missing from the import list, so I've opted to add it and alphabetize the list.