### PR TITLE
fix dapper builds

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y git cmake libgtk-3-dev \ 
+RUN apt-get update && apt-get install -y g++ git cmake libgtk-3-dev \ 
     libglvnd-dev libglu1-mesa-dev freeglut3-dev libasound2-dev
 WORKDIR ${DAPPER_SOURCE:-/source}
-ENV DAPPER_OUTPUT bin
-ENTRYPOINT ["sh", "-c", "cmake . && make -j4"]
+ENV DAPPER_OUTPUT build/bin
+ENTRYPOINT ["sh", "-c", "cd build; cmake .. && make -j4"]


### PR DESCRIPTION
This changes are now in sync with the manual build instructions. Building successfully in Ubuntu 21.04 and macOS Catalina 10.15.7 (19H524), though the binary executable it's only valid for Linux.

PS: Maybe it is possible to integrate Github actions with this file.