### PR TITLE
Fixes for 2 SIGSEGVs when section is NULL

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -787,7 +787,7 @@ static void loadByHash(Console* console, const char* name, const char* hash, con
 {
     console->active = false;
 
-    LoadByHashData loadByHashData = { console, strdup(name), strdup(section), callback, data};
+    LoadByHashData loadByHashData = { console, strdup(name), section ? strdup(section) : NULL, callback, data};
     tic_fs_hashload(console->fs, hash, loadByHashDone, MOVE(loadByHashData));
 }
 
@@ -877,7 +877,7 @@ static void onLoadCommandConfirmed(Console* console)
 
         if (tic_fs_ispubdir(console->fs))
         {
-            LoadPublicCartData loadPublicCartData = { console, strdup(name), NULL, strdup(section) };
+            LoadPublicCartData loadPublicCartData = { console, strdup(name), NULL, section ? strdup(section) : NULL };
             tic_fs_enum(console->fs, compareFilename, fileFound, MOVE(loadPublicCartData));
 
             return;


### PR DESCRIPTION
I ran into these SIGSEGVs when trying to load any cartridge on CentOS Stream 8.
After adding the null checks the cartridges load without a hitch.

#0  0x00007ffff69aa685 in __strlen_avx2 () from /lib64/libc.so.6
#1  0x00007ffff68d6802 in strdup () from /lib64/libc.so.6
#2  0x000000000043bca2 in onLoadCommandConfirmed ()

#0  0x00007ffff69aa685 in __strlen_avx2 () from /lib64/libc.so.6
#1  0x00007ffff68d6802 in strdup () from /lib64/libc.so.6
#2  0x000000000043b8ea in loadByHash ()
