### PR TITLE
#1253: Load cart by hash

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1476,7 +1476,43 @@ static void onGameMenuCommand(Console* console)
 
 static void onSurfCommand(Console* console)
 {
-    gotoSurf();
+    if(console->desc->count == 0)
+    {
+        gotoSurf();
+    }
+    else if(console->desc->count == 1)
+    {
+        const char*   = console->desc->params->key;
+
+        bool is_hash = strlen(hash) == 32;
+        if (is_hash)
+        {
+            const char* name = strdup(hash);
+            loadByHash(console, name, hash, NULL, NULL, NULL);
+            commandDone(console);
+        }
+        else
+        {
+            s32 id = (s32)strtol(hash, NULL, 10);
+            if (id > 0)
+            {
+                // TODO
+                printError(console, "\nerror: TODO load cart by numeric id");
+                commandDone(console);
+            }
+            else
+            {
+                printError(console, "\nerror: invalid cart id.");
+                commandDone(console);
+            }
+        }
+    }
+    else
+    {
+        printError(console, "\nerror: too many parameters.");
+        printUsage(console, console->desc->command);
+        commandDone(console);
+    }
 }
 
 static void loadExt(Console* console, const char* path)


### PR DESCRIPTION
This PR adds an optional parameter to the `surf` command. This allows you to open cartridges directly from the *Console*, using their unique identifier (numeric id or hash).

**TODO**
- [x] load by hash (`surf d02a74c75d80c9bc3b0721ee6f6c83ab`)
- [ ] load by numeric id (`surf 636`)
- [ ] update usage message for the `surf` command

Fixes #1253