### PR TITLE
Pump events once per loop, fixes #1506

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1016,7 +1016,7 @@ void tic_sys_poll()
 
     // Workaround for freeze on fullscreen under macOS #819
     SDL_PumpEvents();
-    while(SDL_PollEvent(&event))
+    while(SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) == 1)
     {
         switch(event.type)
         {


### PR DESCRIPTION
Fix for #1506 inspired by the following commit from SDL : https://github.com/libsdl-org/SDL/commit/ce8261dd6da0f1588ed608f392632252c7a5e693

As I understand it, the polling loop gets a crowd of events to process on focus gained and the queue may be topped up with more incoming events everytime SDL_PollEvents is called as it invokes SDL_PumpEvents under the hood, until the processing is finally able to catch up (and it may not). 

This commit changes the pump strategy to avoid topping up the event queue, seems to do the trick.