### PR TITLE
sdl: Fix comparision warning

### DIFF
--- a/src/system/sdl/player.c
+++ b/src/system/sdl/player.c
@@ -131,7 +131,7 @@ s32 runCart(void* cart, s32 size)
 					SDL_SCANCODE_S,
 				};
 
-				for (s32 i = 0; i < SDL_arraysize(Keys); i++)
+				for (u32 i = 0; i < SDL_arraysize(Keys); i++)
 				{
 					if (keyboard[Keys[i]])
 					{


### PR DESCRIPTION
``` bash
[100%] Building C object CMakeFiles/player-sdl.dir/src/system/sdl/player.c.o
/home/rob/Documents/TIC-80/src/system/sdl/player.c: In function ‘runCart’:
/home/rob/Documents/TIC-80/src/system/sdl/player.c:134:23: warning: comparison of integer expressions of different signedness: ‘s32’ {aka ‘int’} and ‘long unsigned int’ [-Wsign-compare]
  134 |     for (s32 i = 0; i < SDL_arraysize(Keys); i++)
      |                       ^
```