### PR TITLE
fix path problems with baremeta #1541

### DIFF
--- a/src/studio/fs.c
+++ b/src/studio/fs.c
@@ -570,8 +570,8 @@ bool tic_fs_isdir(tic_fs* fs, const char* name)
 #if defined(BAREMETALPI)
     dbg("fsIsDirSync %s\n", name);
     FILINFO s;
-
-    FRESULT res = f_stat(name, &s);
+    const char* path = tic_fs_path(fs, name);
+    FRESULT res = f_stat(path, &s);
     if (res != FR_OK) return false;
 
     return s.fattrib & AM_DIR;
@@ -912,7 +912,8 @@ void tic_fs_makedir(tic_fs* fs, const char* name)
     // TODO BAREMETALPI
     dbg("makeDir %s\n", name);
 
-    char* path = strdup(name);
+    const FsString* pathString = tic_fs_path(fs, name);
+    char* path = strdup(pathString);
     if (path && *path) {                      // make sure result has at least
       if (path[strlen(path) - 1] == '/')    // one character
             path[strlen(path) - 1] = 0;


### PR DESCRIPTION
It was missing some passages throu tic_fs_path to normalize the path.  I've tested it and it seems ok now.