### PR TITLE
Improvements for language support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ macro(MACRO_CORE SCRIPT DEFINE BUILD_DEPRECATED)
     set(TIC80CORE_DIR ${CMAKE_SOURCE_DIR}/src)
     set(TIC80CORE_SRC
         ${TIC80CORE_DIR}/core/core.c
+        ${TIC80CORE_DIR}/core/languages.c
         ${TIC80CORE_DIR}/core/draw.c
         ${TIC80CORE_DIR}/core/io.c
         ${TIC80CORE_DIR}/core/sound.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,7 @@ set(TIC80STUDIO_SRC
     ${TIC80LIB_DIR}/studio/editors/music.c
     ${TIC80LIB_DIR}/studio/studio.c
     ${TIC80LIB_DIR}/studio/config.c
+    ${TIC80LIB_DIR}/studio/demos.c
     ${TIC80LIB_DIR}/studio/fs.c
     ${TIC80LIB_DIR}/studio/net.c
     ${TIC80LIB_DIR}/ext/md5.c

--- a/include/tic80_config.h
+++ b/include/tic80_config.h
@@ -42,50 +42,6 @@
 #   define TIC_BUILD_WITH_LUA 1
 #endif
 
-#if defined(TIC_BUILD_WITH_LUA)
-#   define TIC_LUA_DEF(macro) macro(lua, ".lua", "--", lua_State)
-#else 
-#   define TIC_LUA_DEF(macro)
-#endif
-
-#if defined(TIC_BUILD_WITH_MOON)
-#   define TIC_MOON_DEF(macro) macro(moon, ".moon", "--", lua_State)
-#else 
-#   define TIC_MOON_DEF(macro)
-#endif
-
-#if defined(TIC_BUILD_WITH_FENNEL)
-#   define TIC_FENNEL_DEF(macro) macro(fennel, ".fnl", ";;", lua_State)
-#else 
-#   define TIC_FENNEL_DEF(macro)
-#endif
-
-#if defined(TIC_BUILD_WITH_JS)
-#   define TIC_JS_DEF(macro) macro(js, ".js", "//", duk_hthread)
-#else 
-#   define TIC_JS_DEF(macro)
-#endif
-
-#if defined(TIC_BUILD_WITH_SQUIRREL)
-#   define TIC_SQUIRREL_DEF(macro) macro(squirrel, ".nut", "//", SQVM)
-#else 
-#   define TIC_SQUIRREL_DEF(macro)
-#endif
-
-#if defined(TIC_BUILD_WITH_WREN)
-#   define TIC_WREN_DEF(macro) macro(wren, ".wren", "//", WrenVM)
-#else 
-#   define TIC_WREN_DEF(macro)
-#endif
-
-#define SCRIPT_LIST(macro) \
-    TIC_LUA_DEF     (macro) \
-    TIC_MOON_DEF    (macro) \
-    TIC_FENNEL_DEF  (macro) \
-    TIC_JS_DEF      (macro) \
-    TIC_SQUIRREL_DEF(macro) \
-    TIC_WREN_DEF    (macro)
-
 #if defined(__APPLE__)
 // TODO: this disables macos config 
 #   include "AvailabilityMacros.h"

--- a/src/api.h
+++ b/src/api.h
@@ -76,10 +76,6 @@ typedef struct
     const char* name;
     const char* fileExtension;
     const char* projectComment;
-    const void* demoRom;
-    const s32   demoRomSize;
-    const void* markRom;
-    const s32   markRomSize;
     struct
     {
         bool(*init)(tic_mem* memory, const char* code);
@@ -103,7 +99,6 @@ typedef struct
     const char* const * keywords;
     s32 keywordsCount;
 } tic_script_config;
-
 
 extern tic_script_config* Languages[];
 

--- a/src/api.h
+++ b/src/api.h
@@ -24,6 +24,11 @@
 
 #include "tic.h"
 
+// convenience macros to loop languages
+#define FOR_EACH_LANG(ln) for (tic_script_config** conf = Languages ; *conf != NULL; conf++ ) { tic_script_config* ln = *conf;
+#define FOR_EACH_LANG_END }
+
+
 typedef struct { u8 index; tic_flip flip; tic_rotate rotate; } RemapResult;
 typedef void(*RemapFunc)(void*, s32 x, s32 y, RemapResult* result);
 
@@ -69,6 +74,12 @@ typedef struct
 typedef struct
 {
     const char* name;
+    const char* fileExtension;
+    const char* projectComment;
+    const void* demoRom;
+    const s32   demoRomSize;
+    const void* markRom;
+    const s32   markRomSize;
     struct
     {
         bool(*init)(tic_mem* memory, const char* code);
@@ -92,6 +103,9 @@ typedef struct
     const char* const * keywords;
     s32 keywordsCount;
 } tic_script_config;
+
+
+extern tic_script_config* Languages[];
 
 typedef struct
 {

--- a/src/api/js.c
+++ b/src/api/js.c
@@ -1099,9 +1099,25 @@ void evalJs(tic_mem* tic, const char* code) {
     printf("TODO: JS eval not yet implemented\n.");
 }
 
-static const tic_script_config JsSyntaxConfig =
+static const u8 JsDemoRom[] =
+{
+    #include "../build/assets/jsdemo.tic.dat"
+};
+
+static const u8 jsmark[] =
+{
+    #include "../build/assets/jsmark.tic.dat"
+};
+
+const tic_script_config JsSyntaxConfig =
 {
     .name               = "js",
+    .fileExtension      = ".js",
+    .projectComment     = "//",
+    .demoRom            = JsDemoRom,
+    .demoRomSize        = sizeof JsDemoRom,
+    .markRom            = jsmark,
+    .markRomSize        = sizeof jsmark,
     .init               = initJavascript,
     .close              = closeJavascript,
     .tick               = callJavascriptTick,

--- a/src/api/js.c
+++ b/src/api/js.c
@@ -36,10 +36,10 @@ static void closeJavascript(tic_mem* tic)
 {
     tic_core* core = (tic_core*)tic;
 
-    if(core->js)
+    if(core->currentVM)
     {
-        duk_destroy_heap(core->js);
-        core->js = NULL;
+        duk_destroy_heap(core->currentVM);
+        core->currentVM = NULL;
     }
 }
 
@@ -921,7 +921,7 @@ static void initDuktape(tic_core* core)
 {
     closeJavascript((tic_mem*)core);
 
-    duk_context* duk = core->js = duk_create_heap(NULL, NULL, NULL, core, NULL);
+    duk_context* duk = core->currentVM = duk_create_heap(NULL, NULL, NULL, core, NULL);
 
     {
         duk_push_global_stash(duk);
@@ -936,8 +936,8 @@ static void initDuktape(tic_core* core)
 
     for (s32 i = 0; i < COUNT_OF(ApiItems); i++)
     {
-        duk_push_c_function(core->js, ApiItems[i].func, ApiItems[i].params);
-        duk_put_global_string(core->js, ApiItems[i].name);
+        duk_push_c_function(core->currentVM, ApiItems[i].func, ApiItems[i].params);
+        duk_put_global_string(core->currentVM, ApiItems[i].name);
     }
 }
 
@@ -946,7 +946,7 @@ static bool initJavascript(tic_mem* tic, const char* code)
     tic_core* core = (tic_core*)tic;
 
     initDuktape(core);
-    duk_context* duktape = core->js;
+    duk_context* duktape = core->currentVM;
 
     if (duk_pcompile_string(duktape, 0, code) != 0 || duk_peval_string(duktape, code) != 0)
     {
@@ -964,7 +964,7 @@ static void callJavascriptTick(tic_mem* tic)
 
     tic_core* core = (tic_core*)tic;
 
-    duk_context* duk = core->js;
+    duk_context* duk = core->currentVM;
 
     if(duk)
     {
@@ -984,7 +984,7 @@ static void callJavascriptTick(tic_mem* tic)
 static void callJavascriptScanlineName(tic_mem* tic, s32 row, void* data, const char* name)
 {
     tic_core* core = (tic_core*)tic;
-    duk_context* duk = core->js;
+    duk_context* duk = core->currentVM;
 
     if(duk_get_global_string(duk, name))
     {
@@ -1013,7 +1013,7 @@ static void callJavascriptBorder(tic_mem* tic, s32 row, void* data)
 static void callJavascriptOverline(tic_mem* tic, void* data)
 {
     tic_core* core = (tic_core*)tic;
-    duk_context* duk = core->js;
+    duk_context* duk = core->currentVM;
 
     if(duk_get_global_string(duk, OVR_FN))
     {
@@ -1099,25 +1099,11 @@ void evalJs(tic_mem* tic, const char* code) {
     printf("TODO: JS eval not yet implemented\n.");
 }
 
-static const u8 JsDemoRom[] =
-{
-    #include "../build/assets/jsdemo.tic.dat"
-};
-
-static const u8 jsmark[] =
-{
-    #include "../build/assets/jsmark.tic.dat"
-};
-
 const tic_script_config JsSyntaxConfig =
 {
     .name               = "js",
     .fileExtension      = ".js",
     .projectComment     = "//",
-    .demoRom            = JsDemoRom,
-    .demoRomSize        = sizeof JsDemoRom,
-    .markRom            = jsmark,
-    .markRomSize        = sizeof jsmark,
     .init               = initJavascript,
     .close              = closeJavascript,
     .tick               = callJavascriptTick,

--- a/src/api/lua.c
+++ b/src/api/lua.c
@@ -1611,9 +1611,24 @@ static void evalLua(tic_mem* tic, const char* code) {
     }
 }
 
-static const tic_script_config LuaSyntaxConfig = 
+static const u8 LuaDemoRom[] =
+{
+    #include "../build/assets/luademo.tic.dat"
+};
+static const u8 LuaMarkRom[] =
+{
+    #include "../build/assets/luamark.tic.dat"
+};
+
+tic_script_config LuaSyntaxConfig = 
 {
     .name               = "lua",
+    .fileExtension      = ".lua",
+    .projectComment     = "--",
+    .demoRom               = LuaDemoRom,
+    .demoRomSize           = sizeof LuaDemoRom,
+    .markRom               = LuaMarkRom,
+    .markRomSize           = sizeof LuaMarkRom,
     .init               = initLua,
     .close              = closeLua,
     .tick               = callLuaTick,
@@ -1784,9 +1799,26 @@ static const tic_outline_item* getMoonOutline(const char* code, s32* size)
     return items;
 }
 
-static const tic_script_config MoonSyntaxConfig = 
+static const u8 MoonDemoRom[] =
+{
+    #include "../build/assets/moondemo.tic.dat"
+};
+static const u8 MoonMarkRom[] =
+{
+    #include "../build/assets/moonmark.tic.dat"
+};
+
+
+
+tic_script_config MoonSyntaxConfig = 
 {
     .name               = "moon",
+    .fileExtension      = ".moon",
+    .projectComment     = "--",
+    .demoRom            = MoonDemoRom,
+    .demoRomSize        = sizeof MoonDemoRom,
+    .markRom            = MoonMarkRom,
+    .markRomSize        = sizeof MoonMarkRom,
     .init               = initMoonscript,
     .close              = closeLua,
     .tick               = callLuaTick,
@@ -1964,10 +1996,26 @@ static void evalFennel(tic_mem* tic, const char* code) {
     }
 }
 
+static const u8 FennelDemoRom[] =
+{
+    #include "../build/assets/fenneldemo.tic.dat"
+};
+/* does not exists
+static const u8 FennelMarkRom[] =
+{
+    #include "../build/assets/fennelmark.tic.dat"
+};
+*/
 
-static const tic_script_config FennelSyntaxConfig =
+tic_script_config FennelSyntaxConfig =
 {
     .name               = "fennel",
+    .fileExtension      = ".fnl",
+    .projectComment     = ";;",
+    .demoRom            = FennelDemoRom,
+    .demoRomSize        = sizeof FennelDemoRom,
+    .markRom            = NULL,
+    .markRomSize        = 0,
     .init               = initFennel,
     .close              = closeLua,
     .tick               = callLuaTick,

--- a/src/api/squirrel.c
+++ b/src/api/squirrel.c
@@ -1751,9 +1751,25 @@ void evalSquirrel(tic_mem* tic, const char* code) {
     sq_settop(vm, 0);
 }
 
-static const tic_script_config SquirrelSyntaxConfig = 
+static const u8 SquirrelDemoRom[] =
+{
+    #include "../build/assets/squirreldemo.tic.dat"
+};
+
+static const u8 squirrelmark[] =
+{
+    #include "../build/assets/squirrelmark.tic.dat"
+};
+
+tic_script_config SquirrelSyntaxConfig = 
 {
     .name               = "squirrel",
+    .fileExtension      = ".nut",
+    .projectComment     = "//",
+    .demoRom            = SquirrelDemoRom,
+    .demoRomSize        = sizeof SquirrelDemoRom,
+    .markRom            = squirrelmark,
+    .markRomSize        = sizeof squirrelmark,
     .init               = initSquirrel,
     .close              = closeSquirrel,
     .tick               = callSquirrelTick,

--- a/src/api/wren.c
+++ b/src/api/wren.c
@@ -1609,9 +1609,25 @@ static void evalWren(tic_mem* tic, const char* code)
     wrenInterpret(core->wren, "main", code);
 }
 
-static const tic_script_config WrenSyntaxConfig = 
+static const u8 WrenDemoRom[] =
+{
+    #include "../build/assets/wrendemo.tic.dat"
+};
+
+static const u8 wrenmark[] =
+{
+    #include "../build/assets/wrenmark.tic.dat"
+};
+
+tic_script_config WrenSyntaxConfig = 
 {
     .name               = "wren",
+    .fileExtension      = ".wren",
+    .projectComment     = "//",
+    .demoRom            = WrenDemoRom,
+    .demoRomSize        = sizeof WrenDemoRom,
+    .markRom            = wrenmark,
+    .markRomSize        = sizeof wrenmark,
     .init               = initWren,
     .close              = closeWren,
     .tick               = callWrenTick,

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -162,12 +162,8 @@ typedef struct
 {
     tic_mem memory; // it should be first
 
-    struct
-    {
-#define SCRIPT_DEF(name, _, __, vm) struct vm* name;
-    SCRIPT_LIST(SCRIPT_DEF)
-#undef SCRIPT_DEF
-    };
+    void* currentVM;
+    tic_script_config* currentScript;
 
     struct
     {

--- a/src/core/languages.c
+++ b/src/core/languages.c
@@ -1,0 +1,20 @@
+#include <stddef.h>
+#include "api.h"
+
+extern tic_script_config JsSyntaxConfig;
+extern tic_script_config LuaSyntaxConfig;
+extern tic_script_config MoonSyntaxConfig;
+extern tic_script_config FennelSyntaxConfig;
+extern tic_script_config SquirrelSyntaxConfig;
+extern tic_script_config WrenSyntaxConfig;
+
+tic_script_config* Languages[] = {
+&LuaSyntaxConfig, 
+&JsSyntaxConfig,
+&MoonSyntaxConfig, 
+&FennelSyntaxConfig, 
+&SquirrelSyntaxConfig,
+&WrenSyntaxConfig,
+NULL};
+
+

--- a/src/core/languages.c
+++ b/src/core/languages.c
@@ -1,20 +1,55 @@
 #include <stddef.h>
 #include "api.h"
 
+#if defined(TIC_BUILD_WITH_JS)
 extern tic_script_config JsSyntaxConfig;
+#endif
+
+#if defined (TIC_BUILD_WITH_LUA)
 extern tic_script_config LuaSyntaxConfig;
+#endif
+
+#if defined(TIC_BUILD_WITH_MOON)
 extern tic_script_config MoonSyntaxConfig;
+#endif
+
+#if defined(TIC_BUILD_WITH_FENNEL)
 extern tic_script_config FennelSyntaxConfig;
+#endif
+
+#if defined(TIC_BUILD_WITH_SQUIRREL)
 extern tic_script_config SquirrelSyntaxConfig;
+#endif
+
+#if defined(TIC_BUILD_WITH_WREN)
 extern tic_script_config WrenSyntaxConfig;
+#endif
 
 tic_script_config* Languages[] = {
-&LuaSyntaxConfig, 
-&JsSyntaxConfig,
-&MoonSyntaxConfig, 
-&FennelSyntaxConfig, 
-&SquirrelSyntaxConfig,
-&WrenSyntaxConfig,
-NULL};
 
+	#if defined (TIC_BUILD_WITH_LUA)
+	&LuaSyntaxConfig,
+	#endif
+
+	#if defined(TIC_BUILD_WITH_JS)
+	&JsSyntaxConfig,
+	#endif
+
+	#if defined(TIC_BUILD_WITH_MOON)
+	&MoonSyntaxConfig,
+	#endif
+
+	#if defined(TIC_BUILD_WITH_FENNEL)
+	&FennelSyntaxConfig,
+	#endif
+
+	#if defined(TIC_BUILD_WITH_SQUIRREL)
+	&SquirrelSyntaxConfig,
+	#endif
+
+	#if defined(TIC_BUILD_WITH_WREN)
+	&WrenSyntaxConfig,
+	#endif
+
+	NULL};
 

--- a/src/studio/demos.c
+++ b/src/studio/demos.c
@@ -134,17 +134,14 @@ tic_script_config_extra SquirrelSyntaxConfigExtra =
 
 tic_script_config_extra* getConfigExtra(const tic_script_config* config)
 {
-    printf("getConfigExtra %s", config->name);
 
     for (tic_script_config_extra** conf = LanguagesExtra ; *conf != NULL; conf++ ) { 
         tic_script_config_extra* ln = *conf;
         if (strcmp(config->name, ln->name) == 0)
         {
-            printf("Found extra: %s", ln->name);
             return ln;
         }
     }
-    printf("NOT Found extra");
     return NULL;
 }
 
@@ -163,6 +160,9 @@ tic_script_config_extra* LanguagesExtra[] = {
 #endif
 #if defined(TIC_BUILD_WITH_SQUIRREL)
    &SquirrelSyntaxConfigExtra,
+#endif
+#if defined(TIC_BUILD_WITH_JS)
+   &JsSyntaxConfigExtra,
 #endif
    NULL
 };

--- a/src/studio/demos.c
+++ b/src/studio/demos.c
@@ -1,0 +1,170 @@
+#include <string.h>
+#include <stddef.h>
+#include <stdio.h>
+#include "demos.h"
+#include "api.h"
+
+#if defined (TIC_BUILD_WITH_LUA)
+static const u8 LuaDemoRom[] =
+{
+    #include "../build/assets/luademo.tic.dat"
+};
+static const u8 LuaMarkRom[] =
+{
+    #include "../build/assets/luamark.tic.dat"
+};
+tic_script_config_extra LuaSyntaxConfigExtra =
+{
+    .name                  = "lua",
+    .demoRom               = LuaDemoRom,
+    .demoRomSize           = sizeof LuaDemoRom,
+    .markRom               = LuaMarkRom,
+    .markRomSize           = sizeof LuaMarkRom,
+};
+#endif
+
+#if defined (TIC_BUILD_WITH_MOON)
+static const u8 MoonDemoRom[] =
+{
+    #include "../build/assets/moondemo.tic.dat"
+};
+static const u8 MoonMarkRom[] =
+{
+    #include "../build/assets/moonmark.tic.dat"
+};
+tic_script_config_extra MoonSyntaxConfigExtra =
+{
+    .name               = "moon",
+    .demoRom            = MoonDemoRom,
+    .demoRomSize        = sizeof MoonDemoRom,
+    .markRom            = MoonMarkRom,
+    .markRomSize        = sizeof MoonMarkRom,
+};
+#endif
+
+#if defined (TIC_BUILD_WITH_FENNEL)
+static const u8 FennelDemoRom[] =
+{
+    #include "../build/assets/fenneldemo.tic.dat"
+};
+/* does not exists
+static const u8 FennelMarkRom[] =
+{
+    #include "../build/assets/fennelmark.tic.dat"
+};
+*/
+
+tic_script_config_extra FennelSyntaxConfigExtra =
+{
+    .name               = "fennel",
+    .demoRom            = FennelDemoRom,
+    .demoRomSize        = sizeof FennelDemoRom,
+    .markRom            = NULL,
+    .markRomSize        = 0,
+};
+#endif
+
+
+#if defined(TIC_BUILD_WITH_JS)
+
+static const u8 JsDemoRom[] =
+{
+    #include "../build/assets/jsdemo.tic.dat"
+};
+
+static const u8 jsmark[] =
+{
+    #include "../build/assets/jsmark.tic.dat"
+};
+
+tic_script_config_extra JsSyntaxConfigExtra =
+{
+    .name               = "js",
+    .demoRom            = JsDemoRom,
+    .demoRomSize        = sizeof JsDemoRom,
+    .markRom            = jsmark,
+    .markRomSize        = sizeof jsmark,
+};
+
+#endif
+
+#if defined(TIC_BUILD_WITH_WREN)
+
+static const u8 WrenDemoRom[] =
+{
+    #include "../build/assets/wrendemo.tic.dat"
+};
+
+static const u8 wrenmark[] =
+{
+    #include "../build/assets/wrenmark.tic.dat"
+};
+
+tic_script_config_extra WrenSyntaxConfigExtra =
+{
+    .name               = "wren",
+    .demoRom            = WrenDemoRom,
+    .demoRomSize        = sizeof WrenDemoRom,
+    .markRom            = wrenmark,
+    .markRomSize        = sizeof wrenmark,
+};
+
+#endif
+
+#if defined (TIC_BUILD_WITH_SQUIRREL)
+static const u8 SquirrelDemoRom[] =
+{
+    #include "../build/assets/squirreldemo.tic.dat"
+};
+
+static const u8 squirrelmark[] =
+{
+    #include "../build/assets/squirrelmark.tic.dat"
+};
+tic_script_config_extra SquirrelSyntaxConfigExtra =
+{
+    .name               = "squirrel",
+    .demoRom            = SquirrelDemoRom,
+    .demoRomSize        = sizeof SquirrelDemoRom,
+    .markRom            = squirrelmark,
+    .markRomSize        = sizeof squirrelmark,
+};
+#endif
+
+
+tic_script_config_extra* getConfigExtra(const tic_script_config* config)
+{
+    printf("getConfigExtra %s", config->name);
+
+    for (tic_script_config_extra** conf = LanguagesExtra ; *conf != NULL; conf++ ) { 
+        tic_script_config_extra* ln = *conf;
+        if (strcmp(config->name, ln->name) == 0)
+        {
+            printf("Found extra: %s", ln->name);
+            return ln;
+        }
+    }
+    printf("NOT Found extra");
+    return NULL;
+}
+
+tic_script_config_extra* LanguagesExtra[] = {
+#if defined(TIC_BUILD_WITH_LUA)
+   &LuaSyntaxConfigExtra,
+#endif
+#if defined(TIC_BUILD_WITH_MOON)
+   &MoonSyntaxConfigExtra,
+#endif
+#if defined(TIC_BUILD_WITH_FENNEL)
+   &FennelSyntaxConfigExtra,
+#endif
+#if defined(TIC_BUILD_WITH_WREN)
+   &WrenSyntaxConfigExtra,
+#endif
+#if defined(TIC_BUILD_WITH_SQUIRREL)
+   &SquirrelSyntaxConfigExtra,
+#endif
+   NULL
+};
+
+

--- a/src/studio/demos.h
+++ b/src/studio/demos.h
@@ -7,7 +7,6 @@ typedef struct
     const s32   demoRomSize;
     const void* markRom;
     const s32   markRomSize;
-    const tic_script_demo* demos[];
 } tic_script_config_extra;
 
 

--- a/src/studio/demos.h
+++ b/src/studio/demos.h
@@ -1,0 +1,16 @@
+#include "api.h"
+
+typedef struct
+{
+    const char* name;
+    const void* demoRom;
+    const s32   demoRomSize;
+    const void* markRom;
+    const s32   markRomSize;
+    const tic_script_demo* demos[];
+} tic_script_config_extra;
+
+
+extern tic_script_config_extra* LanguagesExtra[];
+
+tic_script_config_extra* getConfigExtra(const tic_script_config* config);

--- a/src/studio/project.c
+++ b/src/studio/project.c
@@ -22,7 +22,7 @@
 
 #include "project.h"
 #include "tools.h"
-
+#include "api.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -120,28 +120,25 @@ static char* saveBinarySection(char* ptr, const char* comment, const char* tag, 
     return ptr;
 }
 
-static const struct Ext{const char* name; const char* comment;} ExtList[] =
-{
-#define SCRIPT_DEF(_, ext, comment, ...) {ext, comment},
-    SCRIPT_LIST(SCRIPT_DEF)
-#undef SCRIPT_DEF
-};
-
 static const char* projectComment(const char* name)
 {
-    FOR(const struct Ext*, ext, ExtList)
-        if(tic_tool_has_ext(name, ext->name))
-            return ext->comment;
-
-    return ExtList->comment;
+    FOR_EACH_LANG(ln)
+    {
+        if(tic_tool_has_ext(name, ln->fileExtension))
+            return ln->projectComment;
+    }
+    FOR_EACH_LANG_END
+    return Languages[0]->projectComment;
 }
 
 bool tic_project_ext(const char* name)
 {
-    FOR(const struct Ext*, ext, ExtList)
-        if(tic_tool_has_ext(name, ext->name))
+    FOR_EACH_LANG(ln)
+    {
+        if(tic_tool_has_ext(name, ln->fileExtension))
             return true;
-
+    }
+    FOR_EACH_LANG_END
     return false;
 }
 

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1386,48 +1386,6 @@ static void onInstallDemosCommand(Console* console)
         }
 #endif
 
-#if defined(TIC_BUILD_WITH_LUA)
-        static const u8 luamark[] =
-        {
-            #include "../build/assets/luamark.tic.dat"
-        };
-#endif
-
-#if defined(TIC_BUILD_WITH_MOON)
-        static const u8 moonmark[] =
-        {
-            #include "../build/assets/moonmark.tic.dat"
-        };
-#endif
-
-#if defined(TIC_BUILD_WITH_FENNEL)
-        static const u8 fennelmark[] =
-        {
-            #include "../build/assets/luamark.tic.dat"
-        };
-#endif
-
-#if defined(TIC_BUILD_WITH_JS)
-        static const u8 jsmark[] =
-        {
-            #include "../build/assets/jsmark.tic.dat"
-        };
-#endif
-
-#if defined(TIC_BUILD_WITH_SQUIRREL)
-        static const u8 squirrelmark[] =
-        {
-            #include "../build/assets/squirrelmark.tic.dat"
-        };
-#endif
-
-#if defined(TIC_BUILD_WITH_WREN)
-        static const u8 wrenmark[] =
-        {
-            #include "../build/assets/wrenmark.tic.dat"
-        };
-#endif
-
         static const char* Bunny = "bunny";
 
         tic_fs_makedir(fs, Bunny);

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -138,11 +138,7 @@ static const struct SpecRow {const char* section; const char* info;} SpecText1[]
     {"SPRITES", "256 8x8 tiles and 256 8x8 sprites."},
     {"MAP",     "240x136 cells, 1920x1088 pixels."},
     {"SOUND",   "4 channels with configurable waveforms."},
-    {"CODE",    "64KB of"
-#define         SCRIPT_DEF(name, ...) " "#name
-                SCRIPT_LIST(SCRIPT_DEF)
-#undef          SCRIPT_DEF
-                "."
+    {"CODE",    "64KB of $LANG_NAMES$.",
     },
 };
 
@@ -202,25 +198,85 @@ struct CommandDesc
     char* src;
 };
 
-typedef enum
-{
-#define SCRIPT_DEF(name, ...) name##_script,
-    SCRIPT_LIST(SCRIPT_DEF)
-#undef SCRIPT_DEF
-} ScriptLang;
-
-static const struct Script{ScriptLang lang; const char* name;} Scripts[] = 
-{
-#define SCRIPT_DEF(name, ...) {name##_script, #name},
-    SCRIPT_LIST(SCRIPT_DEF)
-#undef SCRIPT_DEF
-};
-
 static const char* PngExt = PNG_EXT;
 
 #if defined(__EMSCRIPTEN__)
 #define CAN_ADDGET_FILE 1
 #endif
+
+
+// You must free the result if result is non-NULL. TODO: find a better place for this function?
+char *str_replace(char *orig, char *rep, char *with) {
+    char *result; // the return string
+    char *ins;    // the next insert point
+    char *tmp;    // varies
+    int len_rep;  // length of rep (the string to remove)
+    int len_with; // length of with (the string to replace rep with)
+    int len_front; // distance between rep and end of last rep
+    int count;    // number of replacements
+
+    // sanity checks and initialization
+    if (!orig || !rep)
+        return NULL;
+    len_rep = strlen(rep);
+    if (len_rep == 0)
+        return NULL; // empty rep causes infinite loop during count
+    if (!with)
+        with = "";
+    len_with = strlen(with);
+
+    // count the number of replacements needed
+    ins = orig;
+    for (count = 0; tmp = strstr(ins, rep); ++count) {
+        ins = tmp + len_rep;
+    }
+
+    tmp = result = malloc(strlen(orig) + (len_with - len_rep) * count + 1);
+
+    if (!result)
+        return NULL;
+
+    // first time through the loop, all the variable are set correctly
+    // from here on,
+    //    tmp points to the end of the result string
+    //    ins points to the next occurrence of rep in orig
+    //    orig points to the remainder of orig after "end of rep"
+    while (count--) {
+        ins = strstr(orig, rep);
+        len_front = ins - orig;
+        tmp = strncpy(tmp, orig, len_front) + len_front;
+        tmp = strcpy(tmp, with) + len_with;
+        orig += len_front + len_rep; // move to next "end of rep"
+    }
+    strcpy(tmp, orig);
+    return result;
+}
+
+static char* replaceHelpTokens(const char* text)
+{
+    char langnames[10240] = {0};
+    char langextensions[10240] = {0};
+    char langnamespipe[10240] = {0};
+    FOR_EACH_LANG(ln)
+        strcat(langnames, ln->name);
+        strcat(langnames, " ");
+
+        strcat(langextensions, ln->fileExtension);
+        strcat(langextensions, " ");
+
+        strcat(langnamespipe, ln->name);
+        strcat(langnamespipe, "|");
+    FOR_EACH_LANG_END
+
+
+    char* replaced1 = str_replace(text, "$LANG_NAMES$", langnames);
+    char* replaced2 = str_replace(replaced1, "$LANG_EXTENSIONS$", langextensions);
+    char* replaced3 = str_replace(replaced2, "$LANG_NAMES_PIPE$", langnamespipe);
+    free(replaced2);
+    free(replaced1);
+    return replaced3;
+}
+
 
 static const char* getName(const char* name, const char* ext)
 {
@@ -549,21 +605,22 @@ static void loadCartSection(Console* console, const tic_cartridge* cart, const c
         memcpy(&tic->cart, cart, sizeof(tic_cartridge));
 }
 
-static const char* getDemoCartPath(ScriptLang script)
+static const char* getDemoCartPath(char* path, tic_script_config* script)
 {
-    static const char* Paths[] = 
-    {
-#define SCRIPT_DEF(name, ...) [name##_script] = TIC_LOCAL_VERSION "default_" #name ".tic",
-        SCRIPT_LIST(SCRIPT_DEF)
-#undef  SCRIPT_DEF
-    };
+    printf("Demo cart path of %s: ", script->name);
+    strcpy(path, TIC_LOCAL_VERSION "default_");
+    strcat(path, script->name);
+    strcat(path, ".tic");
 
-    return Paths[script];
+    printf("%s\n", path);
+
+    return path;
 }
 
-static void* getDemoCart(Console* console, ScriptLang script, s32* size)
+static void* getDemoCart(Console* console, tic_script_config* script, s32* size)
 {
-    const char* path = getDemoCartPath(script);
+    char path[1024];
+    getDemoCartPath(path, script);
 
     {
         void* data = tic_fs_loadroot(console->fs, path, size);
@@ -571,96 +628,8 @@ static void* getDemoCart(Console* console, ScriptLang script, s32* size)
         if(data && *size)
             return data;
     }
-
-    const u8* demo = NULL;
-    s32 romSize = 0;
-
-    switch(script)
-    {
-#if defined(TIC_BUILD_WITH_LUA)
-    case lua_script:
-        {
-            static const u8 LuaDemoRom[] =
-            {
-                #include "../build/assets/luademo.tic.dat"
-            };
-
-            demo = LuaDemoRom;
-            romSize = sizeof LuaDemoRom;
-        }
-        break;
-#endif
-
-#if defined(TIC_BUILD_WITH_MOON)
-    case moon_script:
-        {
-            static const u8 MoonDemoRom[] =
-            {
-                #include "../build/assets/moondemo.tic.dat"
-            };
-
-            demo = MoonDemoRom;
-            romSize = sizeof MoonDemoRom;
-        }
-        break;
-#endif
-
-#if defined(TIC_BUILD_WITH_FENNEL)
-    case fennel_script:
-        {
-            static const u8 FennelDemoRom[] =
-            {
-                #include "../build/assets/fenneldemo.tic.dat"
-            };
-
-            demo = FennelDemoRom;
-            romSize = sizeof FennelDemoRom;
-        }
-        break;
-#endif
-
-#if defined(TIC_BUILD_WITH_JS)
-    case js_script:
-        {
-            static const u8 JsDemoRom[] =
-            {
-                #include "../build/assets/jsdemo.tic.dat"
-            };
-
-            demo = JsDemoRom;
-            romSize = sizeof JsDemoRom;
-        }
-        break;
-#endif
-
-#if defined(TIC_BUILD_WITH_WREN)
-    case wren_script:
-        {
-            static const u8 WrenDemoRom[] =
-            {
-                #include "../build/assets/wrendemo.tic.dat"
-            };
-
-            demo = WrenDemoRom;
-            romSize = sizeof WrenDemoRom;
-        }
-        break;
-#endif
-
-#if defined(TIC_BUILD_WITH_SQUIRREL)
-    case squirrel_script:
-        {
-            static const u8 SquirrelDemoRom[] =
-            {
-                #include "../build/assets/squirreldemo.tic.dat"
-            };
-
-            demo = SquirrelDemoRom;
-            romSize = sizeof SquirrelDemoRom;
-        }
-        break;
-#endif
-    }
+    const u8* demo = script->demoRom;
+    s32 romSize = script->demoRomSize;
 
     u8* data = calloc(1, sizeof(tic_cartridge));
 
@@ -684,7 +653,7 @@ static void setCartName(Console* console, const char* name, const char* path)
         strcpy(console->rom.path, path);
 }
 
-static void onLoadDemoCommandConfirmed(Console* console, ScriptLang script)
+static void onLoadDemoCommandConfirmed(Console* console, tic_script_config* script)
 {
     void* data = NULL;
     s32 size = 0;
@@ -692,7 +661,9 @@ static void onLoadDemoCommandConfirmed(Console* console, ScriptLang script)
     console->showGameMenu = false;
 
     {
-        const char* name = getCartName(getDemoCartPath(script));
+        char path[1024];
+        getDemoCartPath(path, script);
+        const char* name = getCartName(path);
         setCartName(console, name, tic_fs_path(console->fs, name));
     }
 
@@ -1001,13 +972,13 @@ static void confirmCommand(Console* console, const char** text, s32 rows, Confir
     }
 }
 
-typedef void(*LoadDemoConfirmCallback)(Console* console, ScriptLang script);
+typedef void(*LoadDemoConfirmCallback)(Console* console, tic_script_config* script);
 
 typedef struct
 {
     Console* console;
     LoadDemoConfirmCallback callback;
-    ScriptLang script;
+    tic_script_config* script;
 } LoadDemoConfirmData;
 
 static void onLoadDemoConfirm(bool yes, void* data)
@@ -1023,7 +994,7 @@ static void onLoadDemoConfirm(bool yes, void* data)
     free(demoData);
 }
 
-static void onLoadDemoCommand(Console* console, ScriptLang script)
+static void onLoadDemoCommand(Console* console, tic_script_config* script)
 {
     if(studioCartChanged())
     {
@@ -1066,8 +1037,9 @@ static void onLoadCommand(Console* console)
     }
 }
 
-static void loadDemo(Console* console, ScriptLang script)
+static void loadDemo(Console* console, tic_script_config* script)
 {
+    if (script == NULL) script = Languages[0]; // can be called with null, meaning first language (Lua)
     s32 size = 0;
     u8* data = getDemoCart(console, script, &size);
 
@@ -1092,12 +1064,13 @@ static void onNewCommandConfirmed(Console* console)
     {
         const char* param = console->desc->params->key;
 
-        FOR(const struct Script*, script, Scripts)
-            if(strcmp(param, script->name) == 0)
+        FOR_EACH_LANG(ln)
+            if(strcmp(param, ln->name) == 0)
             {
-                loadDemo(console, script->lang);
+                loadDemo(console, ln);
                 done = true;
             }
+        FOR_EACH_LANG_END
 
         if(!done)
         {
@@ -1455,26 +1428,26 @@ static void onInstallDemosCommand(Console* console)
         };
 #endif
 
-        static const struct Mark {const char* name; const u8* data; s32 size;} Marks[] =
-        {
-#define     SCRIPT_DEF(name, ...) {#name "mark.tic", name ## mark, sizeof name ## mark},
-            SCRIPT_LIST(SCRIPT_DEF)
-#undef      SCRIPT_DEF
-        };
-
         static const char* Bunny = "bunny";
 
         tic_fs_makedir(fs, Bunny);
         tic_fs_changedir(fs, Bunny);
 
-        FOR(const struct Mark*, mark, Marks)
+        FOR_EACH_LANG(ln)
         {
-            tic_fs_save(fs, mark->name, data, tic_tool_unzip(data, sizeof(tic_cartridge), mark->data, mark->size), true);
-            printFront(console, Bunny);
-            printFront(console, "/");
-            printFront(console, mark->name);
-            printLine(console);
+            if (ln->markRom != NULL) { // having a Mark is not mandatory
+                char cartname[1024];
+                strcpy(cartname, ln->name);
+                strcat(cartname, "mark.tic");
+
+                tic_fs_save(fs, cartname, data, tic_tool_unzip(data, sizeof(tic_cartridge), ln->markRom, ln->markRomSize), true);
+                printFront(console, Bunny);
+                printFront(console, "/");
+                printFront(console, cartname);
+                printLine(console);
+            }
         }
+	FOR_EACH_LANG_END
 
         tic_fs_dirback(fs);
     }
@@ -1522,9 +1495,10 @@ static void onConfigCommand(Console* console)
                 onLoadDemoCommand(console, 0);
             else
             {
-                FOR(const struct Script*, script, Scripts)
+                FOR_EACH_LANG(script)
                     if (strcmp(console->desc->params[1].key, script->name) == 0)
-                        onLoadDemoCommand(console, script->lang);
+                        onLoadDemoCommand(console, script);
+                FOR_EACH_LANG_END
             }
         }
         else
@@ -2520,11 +2494,7 @@ static struct Command
         "new",
         NULL,
         "creates a new `Hello World` cartridge.",
-        "new ["
-#define SCRIPT_DEF(name, ...) #name "|"
-        SCRIPT_LIST(SCRIPT_DEF)
-#undef  SCRIPT_DEF       
-        "...]",
+        "new [$LANG_NAMES_PIPE$...]",
         onNewCommand
     },
     {
@@ -2541,10 +2511,7 @@ static struct Command
     {
         "save",
         NULL,
-        "save cartridge to the local filesystem, use "
-#define SCRIPT_DEF(_, ext, ...) ext " "
-        SCRIPT_LIST(SCRIPT_DEF)
-#undef  SCRIPT_DEF
+        "save cartridge to the local filesystem, use $LANG_EXTENSIONS$"
         "cart extension to save it in text format (PRO feature).", 
         "save <cart>",
         onSaveCommand
@@ -2922,12 +2889,16 @@ static void printUsage(Console* console, const char* command)
         if(strcmp(command, cmd->name) == 0)
         {
             consolePrint(console, "\n---=== COMMAND ===---\n", tic_color_green);
-            printBack(console, cmd->help);
+            char* helpReplaced = replaceHelpTokens(cmd->help);
+            printBack(console, helpReplaced);
+            free(helpReplaced);
 
             if(cmd->usage)
             {
                 printFront(console, "\n\nusage: ");
-                printBack(console, cmd->usage);
+                char* usageReplaced = replaceHelpTokens(cmd->usage);
+                printBack(console, usageReplaced);
+                free(usageReplaced);
             }
 
             printLine(console);
@@ -3046,8 +3017,10 @@ static void onHelp_spec(Console* console)
     FOR(const struct SpecRow*, row, SpecText1)
     {
 #define OFFSET 8
-        sprintf(buf, "%-" DEF2STR(OFFSET) "s%s\n", row->section, row->info);
+        char* rowReplaced = replaceHelpTokens(row->info);
+        sprintf(buf, "%-" DEF2STR(OFFSET) "s%s\n", row->section, rowReplaced);
         consolePrintOffset(console, buf, tic_color_grey, OFFSET);
+        free(rowReplaced);
 #undef  OFFSET
     }
 }

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -27,6 +27,7 @@
 #include "studio/config.h"
 #include "ext/png.h"
 #include "zip.h"
+#include "studio/demos.h"
 
 #if defined(TIC80_PRO)
 #include "studio/project.h"
@@ -607,12 +608,12 @@ static void loadCartSection(Console* console, const tic_cartridge* cart, const c
 
 static const char* getDemoCartPath(char* path, tic_script_config* script)
 {
-    printf("Demo cart path of %s: ", script->name);
+    //printf("Demo cart path of %s: ", script->name);
     strcpy(path, TIC_LOCAL_VERSION "default_");
     strcat(path, script->name);
     strcat(path, ".tic");
 
-    printf("%s\n", path);
+    //printf("%s\n", path);
 
     return path;
 }
@@ -628,8 +629,10 @@ static void* getDemoCart(Console* console, tic_script_config* script, s32* size)
         if(data && *size)
             return data;
     }
-    const u8* demo = script->demoRom;
-    s32 romSize = script->demoRomSize;
+    tic_script_config_extra* ex = getConfigExtra(script);
+
+    const u8* demo = ex->demoRom;
+    s32 romSize = ex->demoRomSize;
 
     u8* data = calloc(1, sizeof(tic_cartridge));
 
@@ -1393,12 +1396,13 @@ static void onInstallDemosCommand(Console* console)
 
         FOR_EACH_LANG(ln)
         {
-            if (ln->markRom != NULL) { // having a Mark is not mandatory
+            tic_script_config_extra* ex = getConfigExtra(ln);
+            if (ex->markRom != NULL) { // having a Mark is not mandatory
                 char cartname[1024];
                 strcpy(cartname, ln->name);
                 strcat(cartname, "mark.tic");
 
-                tic_fs_save(fs, cartname, data, tic_tool_unzip(data, sizeof(tic_cartridge), ln->markRom, ln->markRomSize), true);
+                tic_fs_save(fs, cartname, data, tic_tool_unzip(data, sizeof(tic_cartridge), ex->markRom, ex->markRomSize), true);
                 printFront(console, Bunny);
                 printFront(console, "/");
                 printFront(console, cartname);


### PR DESCRIPTION
Developments for discussion #1289.

Changes: there's now a new file "languages.c", this is the designed place to "glue" all languages together. It defines a "Languages" global array of tic_script_config where all enabled languages go.

tic_script_config has been augmented with stuff that was defined in other places, like file extensions, demo and bunny mark cartridges, etc. (every implementation defines the new fields).

Most of the accesses with SCRIPT_LIST has been removed in favour of a loop on Languages (for which a macro is provided).

The static help text problem has been resolved by inserting placeholders in the static text and replacing them with a dynamic strings at runtime. It's terribly inefficient but since we're talking of a handful of lines, it should be ok. At least it works for now, maybe it can be improved in some way later.

The only remaining place where SCRIPT_LIST exists is in the definition of the vms in tic_core. This is my next step, but since is more delicate i'll do it in a different PR.

Some remaining languages switches (BUILD_WITH_JS etc) lives in console.c where demos are defined. Those could be moved to the appropriate tic_script_config too, if you're ok.
