### PR TITLE
Baremetal RPI: added Squirrel language which was previously disabled.

### DIFF
--- a/build/baremetalpi/Makefile
+++ b/build/baremetalpi/Makefile
@@ -29,6 +29,7 @@ LIBS :=  \
  	$(TIC80LIB)/liblua.a \
 	$(TIC80LIB)/libzip.a \
 	$(TIC80LIB)/libblipbuf.a \
+	$(TIC80LIB)/libsquirrel.a \
 	$(TIC80LIB)/libwren.a \
 	$(TIC80LIB)/libargparse.a \
 	$(TIC80LIB)/libwave_writer.a \

--- a/build/baremetalpi/toolchain.cmake
+++ b/build/baremetalpi/toolchain.cmake
@@ -26,13 +26,15 @@ get_filename_component(ARM_TOOLCHAIN_DIR ${BINUTILS_PATH} DIRECTORY)
 # removed squirrel language as it doesn't seem to compile under arm. Needs investigation.
 #    More investigation: Squirrel builds correcly but the linked give these kinds of error:
 #    arm-none-eabi-ld: error: kernel8-32.elf uses VFP register arguments, ../../build/lib/libsquirrel.a(sqapi.cpp.obj) does not
-
+#    Even more investigation: turns out i was only setting CMAKE_C_FLAGS and not CMAKE_CXX_FLAGS. So C++ stuff was building without arm/rpi proper flags, VFP-related-stuff in particular.
+#    Now squirrel works.
 # Ideally should use the CFLAGS defined in circle build files, not hardwire them here too.
 # For RPI2
 #set(CMAKE_C_FLAGS " -DMINIZ_NO_TIME -DTIC_BUILD_WITH_FENNEL -DTIC_BUILD_WITH_MOON -DTIC_BUILD_WITH_JS -DTIC_BUILD_WITH_WREN -DTIC_BUILD_WITH_LUA -DLUA_32BITS -std=c99 -march=armv7-a+neon-vfpv4  -D AARCH=32 -D __circle__ -D BAREMETALPI  --specs=nosys.specs -O3 -mabi=aapcs -marm  -mfloat-abi=hard -mfpu=neon-vfpv4  -D__DYNAMIC_REENT__")
 # For RPI3
 # investigate -funsafe-math-optimizations and -march=armv8-a+crc -mcpu=cortex-a53
-set(CMAKE_C_FLAGS " -DMINIZ_NO_TIME -DTIC_BUILD_WITH_FENNEL -DTIC_BUILD_WITH_MOON -DTIC_BUILD_WITH_JS -DTIC_BUILD_WITH_WREN -DTIC_BUILD_WITH_LUA -DLUA_32BITS -std=c99 -march=armv8-a  -D AARCH=32 -mtune=cortex-a53  -D __circle__ -D BAREMETALPI  --specs=nosys.specs -O3 -marm -mfloat-abi=hard -mfpu=neon-fp-armv8 -funsafe-math-optimizations -D__DYNAMIC_REENT__")
+set(CMAKE_C_FLAGS " -DMINIZ_NO_TIME -DLUA_32BITS -std=c99 -march=armv8-a  -D AARCH=32 -mtune=cortex-a53  -D __circle__ -D BAREMETALPI  --specs=nosys.specs -O3 -marm -mfloat-abi=hard -mfpu=neon-fp-armv8 -funsafe-math-optimizations -D__DYNAMIC_REENT__")
+set(CMAKE_CXX_FLAGS " -DMINIZ_NO_TIME -DLUA_32BITS -march=armv8-a  -D AARCH=32 -mtune=cortex-a53  -D __circle__ -D BAREMETALPI  --specs=nosys.specs -O3 -marm -mfloat-abi=hard -mfpu=neon-fp-armv8 -funsafe-math-optimizations -D__DYNAMIC_REENT__")
 
 set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})


### PR DESCRIPTION
Hi there, when i added Baremetal RPI i left out Squirrel becouse the toolkit was having trouble linking C++ stuff. I checked this again and found the problem: i simply wasn't setting C++ compiler flags (only C ones).

Now the baremetal version include all languages, and also any future C++ dependency we add will be able to work.