### PR TITLE
#714: fix crackling audio.

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -709,6 +709,7 @@ void tic_core_tick_start(tic_mem* memory);
 void tic_core_tick(tic_mem* memory, tic_tick_data* data);
 void tic_core_tick_end(tic_mem* memory);
 void tic_core_blit(tic_mem* tic);
+void tic_core_synthesize_sound(tic_mem* tic);
 
 void tic_core_blit_ex(tic_mem* tic, tic_blit_callback clb);
 const tic_script_config* tic_core_script_config(tic_mem* memory);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -28,6 +28,7 @@
 
 #define CLOCKRATE (255<<13)
 #define TIC_DEFAULT_COLOR 15
+#define TIC_SOUND_RINGBUF_LEN 6 // in worst case, this induces ~ 6 tick delay i.e. 100 ms
 
 typedef struct
 {
@@ -126,6 +127,15 @@ typedef struct
         tic_sound_register_data left[TIC_SOUND_CHANNELS];
         tic_sound_register_data right[TIC_SOUND_CHANNELS];
     } registers;
+
+    struct
+    {
+        tic_sound_register registers[TIC_SOUND_CHANNELS];
+        tic_stereo_volume stereo;
+    } sound_ringbuf[TIC_SOUND_RINGBUF_LEN];
+
+    u32 sound_ringbuf_head;
+    u32 sound_ringbuf_tail;
 
     struct
     {

--- a/src/core/sound.c
+++ b/src/core/sound.c
@@ -512,14 +512,15 @@ void tic_api_sfx(tic_mem* memory, s32 index, s32 note, s32 octave, s32 duration,
     setSfxChannelData(memory, index, note, octave, duration, channel, left, right, speed);
 }
 
-static void stereo_tick_end(tic_mem* memory, tic_sound_register_data* registers, blip_buffer_t* blip, u8 stereoRight)
+static void stereo_synthesize(tic_core* core, tic_sound_register_data* registers, blip_buffer_t* blip, u8 stereoRight)
 {
     enum { EndTime = CLOCKRATE / TIC80_FRAMERATE };
+    s32 bufpos = (core->state.sound_ringbuf_tail + TIC_SOUND_RINGBUF_LEN - 1) % TIC_SOUND_RINGBUF_LEN;
     for (s32 i = 0; i < TIC_SOUND_CHANNELS; ++i)
     {
-        u8 volume = tic_tool_peek4(&memory->ram.stereo.data, stereoRight + i * 2);
+        u8 volume = tic_tool_peek4(&core->state.sound_ringbuf[bufpos].stereo, stereoRight + i * 2);
 
-        const tic_sound_register* reg = &memory->ram.registers[i];
+        const tic_sound_register* reg = &core->state.sound_ringbuf[bufpos].registers[i];
         tic_sound_register_data* data = registers + i;
 
         FLAT4(reg->waveform.data)
@@ -530,6 +531,26 @@ static void stereo_tick_end(tic_mem* memory, tic_sound_register_data* registers,
     }
 
     blip_end_frame(blip, EndTime);
+}
+
+void tic_core_synthesize_sound(tic_mem* memory)
+{
+    tic_core* core = (tic_core*)memory;
+
+    // synthesize sound using the register values found from the tail of the ring buffer
+    stereo_synthesize(core, core->state.registers.left, core->blip.left, 0);
+    stereo_synthesize(core, core->state.registers.right, core->blip.right, 1);
+
+    blip_read_samples(core->blip.left, core->memory.samples.buffer, core->samplerate / TIC80_FRAMERATE, TIC_STEREO_CHANNELS);
+    blip_read_samples(core->blip.right, core->memory.samples.buffer + 1, core->samplerate / TIC80_FRAMERATE, TIC_STEREO_CHANNELS);
+
+    // if the head has advanced, we can advance the tail too. Otherwise, we just
+    // keep synthesizing audio using the last known register values, so at least we don't get crackles
+    if (core->state.sound_ringbuf_tail != core->state.sound_ringbuf_head) {
+        // note: we assume storing a 32 bit integer is atomic, that should hold on pretty much any modern processor
+        // assuming it is aligned in memory (which it should be)
+        core->state.sound_ringbuf_tail = (core->state.sound_ringbuf_tail + 1) % TIC_SOUND_RINGBUF_LEN;
+    }
 }
 
 void tic_core_sound_tick_start(tic_mem* memory)
@@ -556,9 +577,13 @@ void tic_core_sound_tick_end(tic_mem* memory)
 {
     tic_core* core = (tic_core*)memory;
 
-    stereo_tick_end(memory, core->state.registers.left, core->blip.left, 0);
-    stereo_tick_end(memory, core->state.registers.right, core->blip.right, 1);
+    // instead of synthesizing the sound right away, push the sound registers to the head of a ring buffer
+    core->state.sound_ringbuf[core->state.sound_ringbuf_head].stereo = memory->ram.stereo;
+    memcpy(&core->state.sound_ringbuf[core->state.sound_ringbuf_head], &memory->ram.registers, sizeof(tic_sound_register[4]));
 
-    blip_read_samples(core->blip.left, core->memory.samples.buffer, core->samplerate / TIC80_FRAMERATE, TIC_STEREO_CHANNELS);
-    blip_read_samples(core->blip.right, core->memory.samples.buffer + 1, core->samplerate / TIC80_FRAMERATE, TIC_STEREO_CHANNELS);
+    if (core->state.sound_ringbuf_head != (core->state.sound_ringbuf_tail + TIC_SOUND_RINGBUF_LEN - 2) % TIC_SOUND_RINGBUF_LEN) {
+        // note: we assume storing a 32 bit integer is atomic, that should hold on pretty much any modern processor
+        // assuming it is aligned in memory (which it should be)
+        core->state.sound_ringbuf_head = (core->state.sound_ringbuf_head + 1) % TIC_SOUND_RINGBUF_LEN;
+    }
 }

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -331,6 +331,7 @@ const char* studioExportSfx(s32 index, const char* filename)
             {
                 tic_core_tick_start(tic);
                 tic_core_tick_end(tic);
+                tic_core_synthesize_sound(tic);
 
                 wave_write(tic->samples.buffer, tic->samples.size / sizeof(s16));
             }
@@ -379,6 +380,7 @@ const char* studioExportMusic(s32 track, const char* filename)
                     tic->ram.registers[i].volume = 0;
 
             tic_core_tick_end(tic);
+            tic_core_synthesize_sound(tic);
 
             wave_write(tic->samples.buffer, tic->samples.size / sizeof(s16));
         }


### PR DESCRIPTION
Previously, the sound registers were used to synthesize fixed amount of sound after every TIC() and this was pushed to SDL. The problem with this approach was crackling if TIC() takes too long to reach 60Hz. In this fix, the sound registers are instead pushed to a ring buffer and the audio is synthesized in SDL callback, to render audio. If the ring buffer does not have enough values, the sound synthesis uses the last good values from the ring buffer, so the music slows down yes, but at least it does not crackle.

The corollary to this is that calling tic_core_tick_end(tic) is not enough during the Studio sound export; one should also call tic_core_synthesize_sound which does the job of pulling the sound registers from the tail of the ring buffer and doing the sound synthesis.

The ring buffer is kept short on purpose, because if there slight desync between the TIC() frequency and sound frequency, the TIC() frequency might run faster and delay might build up. So, the ring buffer length sets a maximum on the delay that this technique can create.

Just to note that you might want to experiment with TIC_SOUND_RINGBUF_LEN and SDL_AudioSpec.samples to get good amount of buffering, without significant delays, and not too much overhead. SDL_AudioSpec.samples controls how many times a second the callback is called and presumably there's a small overhead with each call.

This fix also btw probably fixes the complaints about the sound getting desynchronized with the video; the short ring buffer ensures that the audio can never be too much out of sync with the video.