### PR TITLE
Fix eval command

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2318,7 +2318,8 @@ static void onEvalCommand(Console* console)
     if (script_config->eval)
     {
         if(console->desc->count)
-            script_config->eval(console->tic, console->desc->params->key);
+            script_config->eval(console->tic,
+                                console->desc->src+strlen(console->desc->command));
         else printError(console, "nothing to eval");
     }
     else

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -453,6 +453,7 @@ static void commandDoneLine(Console* console, bool newLine)
     clearSelection(console);
 
     FREE(console->desc->src);
+    FREE(console->desc->command);
     FREE(console->desc->params);
 
     memset(console->desc, 0, sizeof(CommandDesc));
@@ -3100,11 +3101,12 @@ static void onHelpCommand(Console* console)
     commandDone(console);
 }
 
-static CommandDesc parseCommand(const char* command)
+static CommandDesc parseCommand(const char* input)
 {
-    CommandDesc desc = {.src = strdup(command)};
+    CommandDesc desc = {.src = strdup(input),
+                        .command = strdup(input)};
 
-    char* token = desc.command = strtok(desc.src, " ");
+    char* token = strtok(desc.command, " ");
 
     while((token = strtok(NULL, " ")))
     {


### PR DESCRIPTION
This fixes issue #800.

I am not 100% sure this is in line with the original intent of the fields, and I have very little C experience!

The CommandDesc struct has two relevant fields here: src and
command. The src field is supposed to contain the source of the entire
input while the command field is supposed to contain just the name of
the command being invoked; aka everything before the first space.

We would start with input like this:

    eval trace("hello" .. "world")

What we want is:

   src: eval trace("hello" .. "world")
   command: eval

The src field was set to a copy of the input, and then the command
field was set to running strtok on src to find the first space. But
even though strtok returns what looks like a string, it's actually
just pointing to the same copy of src which now happens to have been
terminated right where the first space used to be.

So what we got was just:

   src: eval
   command: eval

The fix is to copy the input into src and command fields separately
and only call strtok on command, allowing src to be left alone.