### PR TITLE
(enh) Music editor: Skip over sharp column when using cursor keys

### DIFF
--- a/src/studio/editors/music.c
+++ b/src/studio/editors/music.c
@@ -280,6 +280,10 @@ static void leftCol(Music* music)
 {
     if (music->tracker.edit.x > 0)
     {
+        // skip sharp column
+        if(music->tracker.edit.x == 2) {
+            music->tracker.edit.x--;
+        }
         music->tracker.edit.x--;
         updateTracker(music);
     }
@@ -289,6 +293,10 @@ static void rightCol(Music* music)
 {
     if (music->tracker.edit.x < TRACKER_COLS - 1)
     {
+        // skip sharp column
+        if(music->tracker.edit.x == 0) {
+            music->tracker.edit.x++;
+        }
         music->tracker.edit.x++;
         updateTracker(music);
     }


### PR DESCRIPTION
Allows toggling of sharp.  I guess technically it doesn't even require you to be in the column...

Resolves #1625.