### PR TITLE
add MacOS application instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ cmake ..
 make -j4
 ```
 
+to create application icon for development version
+```
+mkdir -p ~/Applications/TIC80dev.app/Contents/{MacOS,Resources}
+cp -f macosx/tic80.plist ~/Applications/TIC80dev.app/Contents/Info.plist
+cp -f macosx/tic80.icns ~/Applications/TIC80dev.app/Contents/Resources
+cat > ~/Applications/TIC80dev.app/MacOS/TIC80dev <<EOF
+#!/bin/sh
+exec /Users/nesbox/projects/TIC-80/build/bin/tic80 --skip --scale 2 >/dev/null
+EOF
+chmod +x ~/Applications/TIC80dev.app/MacOS/TIC80
+```
+Make sure to update the absolute path to the tic80 binary in the script, or
+update the launch arguments.
+
 # Install instructions
 
 ## Linux


### PR DESCRIPTION
Sup,

I am playing around with MacOS as well and launching the development version is a bit weird via Spotlight (it creates a terminal window by default). So here are instructions for hackers who would like to launch it conviniently.

I tested this on my latest MacOS (Monterey is it called?) and I noticed you guys provide also a DMG which installs as "tic-80" so I renamed this to be "TIC-80dev" so people can have both stable and dev versions installed and switch between each other.

Cheers.