### PR TITLE
Replace a right single apostrophe in the API help with an apostrophe

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -316,7 +316,7 @@ enum
         "This function will draw the desired area of the map to a specified screen position.\n"                         \
         "For example, map(5,5,12,10,0,0) will draw a 12x10 section of the map, "                                        \
         "starting from map co-ordinates (5,5) to screen position (0,0).\n"                                              \
-        "The map function’s last parameter is a powerful callback function "                                            \
+        "The map function's last parameter is a powerful callback function "                                            \
         "for changing how map cells (sprites) are drawn when map is called.\n"                                          \
         "It can be used to rotate, flip and replace sprites while the game is running.\n"                               \
         "Unlike mset, which saves changes to the map, this special function can be used to create "                     \


### PR DESCRIPTION
The former doesn't render correctly when "help map" is issued in the console.