### PR TITLE
No need for a heading

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+
 
 ## Our Pledge
 


### PR DESCRIPTION
We do not need a heading at the very top of our markdown file. We could get rid of it.