### PR TITLE
squirrel: Fix mouse() from returning null values

### DIFF
--- a/src/api/squirrel.c
+++ b/src/api/squirrel.c
@@ -1420,7 +1420,7 @@ static SQInteger squirrel_mouse(HSQUIRRELVM vm)
 
     const tic80_mouse* mouse = &core->memory.ram.input.mouse;
 
-    sq_newarray(vm, 7);
+    sq_newarray(vm, 0);
 
     {
         tic_point pos = tic_api_mouse((tic_mem*)core);


### PR DESCRIPTION
Looks like Squirrel's `push` methods will append to the array. Since the array was initialized with `7`, the values were already initialized as null, and the mouse values were appended to the end. This fixes that.

Fixes #1718