### PR TITLE
Add Shift+Return shortcut to the code editor that auto-closes a block

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -91,6 +91,7 @@ typedef struct
     const char* blockStringStart;
     const char* blockStringEnd;
     const char* singleComment;
+    const char* blockEnd;
 
     const char* const * keywords;
     s32 keywordsCount;

--- a/src/api/fennel.c
+++ b/src/api/fennel.c
@@ -200,6 +200,7 @@ tic_script_config FennelSyntaxConfig =
     .blockStringStart   = NULL,
     .blockStringEnd     = NULL,
     .singleComment      = ";",
+    .blockEnd           = NULL,
 
     .keywords           = FennelKeywords,
     .keywordsCount      = COUNT_OF(FennelKeywords),

--- a/src/api/js.c
+++ b/src/api/js.c
@@ -1168,6 +1168,7 @@ const tic_script_config JsSyntaxConfig =
     .blockStringStart   = NULL,
     .blockStringEnd     = NULL,
     .singleComment      = "//",
+    .blockEnd           = "}",
 
     .keywords           = JsKeywords,
     .keywordsCount      = COUNT_OF(JsKeywords),

--- a/src/api/lua.c
+++ b/src/api/lua.c
@@ -1693,6 +1693,7 @@ tic_script_config LuaSyntaxConfig =
     .singleComment      = "--",
     .blockStringStart   = "[[",
     .blockStringEnd     = "]]",
+    .blockEnd           = "end",
 
     .keywords           = LuaKeywords,
     .keywordsCount      = COUNT_OF(LuaKeywords),

--- a/src/api/moonscript.c
+++ b/src/api/moonscript.c
@@ -192,6 +192,7 @@ tic_script_config MoonSyntaxConfig =
     .blockStringStart   = NULL,
     .blockStringEnd     = NULL,
     .singleComment      = "--",
+    .blockEnd           = NULL,
 
     .keywords           = MoonKeywords,
     .keywordsCount      = COUNT_OF(MoonKeywords),

--- a/src/api/mruby.c
+++ b/src/api/mruby.c
@@ -1215,6 +1215,7 @@ const tic_script_config MRubySyntaxConfig =
     .singleComment      = "#",
     .blockStringStart   = NULL,
     .blockStringEnd     = NULL,
+    .blockEnd           = "end",
 
     .keywords           = MRubyKeywords,
     .keywordsCount      = COUNT_OF(MRubyKeywords),

--- a/src/api/squirrel.c
+++ b/src/api/squirrel.c
@@ -1831,6 +1831,7 @@ tic_script_config SquirrelSyntaxConfig =
     .singleComment      = "//",
     .blockStringStart   = "@\"",
     .blockStringEnd     = "\"",
+    .blockEnd           = "}",
 
     .keywords           = SquirrelKeywords,
     .keywordsCount      = COUNT_OF(SquirrelKeywords),

--- a/src/api/wren.c
+++ b/src/api/wren.c
@@ -1699,6 +1699,7 @@ tic_script_config WrenSyntaxConfig =
     .blockStringStart   = NULL,
     .blockStringEnd     = NULL,
     .singleComment      = "//",
+    .blockEnd           = "}",
 
     .keywords           = WrenKeywords,
     .keywordsCount      = COUNT_OF(WrenKeywords),

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -1157,6 +1157,24 @@ static void doTab(Code* code, bool shift, bool crtl)
     else inputSymbolBase(code, '\t');
 }
 
+// Add a block-ending keyword or symbol, and put the cursor in the line between.
+static void newLineAutoClose(Code* code)
+{
+    newLine(code);
+
+    const char* blockEnd = tic_core_script_config(code->tic)->blockEnd;
+    if (blockEnd != NULL)
+    {
+        newLine(code);
+        for(size_t i = 0; i < strlen(blockEnd); i++)
+            inputSymbol(code, blockEnd[i]);
+        upLine(code);
+        goEnd(code);
+    }
+
+    doTab(code, false, true);
+}
+
 static void setFindMode(Code* code)
 {
     if(code->cursor.selection)
@@ -1570,6 +1588,11 @@ static void processKeyboard(Code* code)
         else if(keyWasPressed(tic_key_delete))      deleteWord(code);
         else if(keyWasPressed(tic_key_backspace))   backspaceWord(code);
         else                                        usedKeybinding = false;
+    }
+    else if(shift)
+    {
+        if(keyWasPressed(tic_key_return))   newLineAutoClose(code);
+        else                                usedKeybinding = false;
     }
     else if(alt)
     {


### PR DESCRIPTION
This is a convenience feature shamelessly stolen from PICO-8: when pressing Shift+Return in the code editor, insert an `end` statement, and put the cursor in an indented line in-between. For example, we go from

     for x=0,239 do|

to

    for x=0,239 do
     |
    end

I would love to use this during speedcoding! Is this a welcome feature? Does this PR look alright?