### PR TITLE
sdl: Fix warnings of string.h missing

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -25,6 +25,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 #if defined(CRT_SHADER_SUPPORT)


### PR DESCRIPTION
This change fixes a few implicit declaration warnings in the SDL player.

```
[ 97%] Building C object CMakeFiles/tic80.dir/src/system/sdl/main.c.o
src/system/sdl/main.c: In function ‘tic_sys_poll’:
src/system/sdl/main.c:1141:16: warning: implicit declaration of function ‘strlen’ [-Wimplicit-function-declaration]
 1141 |             if(strlen(event.text.text) == 1)
      |                ^~~~~~
src/system/sdl/main.c:1141:16: warning: incompatible implicit declaration of built-in function ‘strlen’
src/system/sdl/main.c:1001:1: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
 1000 |         #include "keycodes.inl"
  +++ |+#include <string.h>
 1001 |     };
src/system/sdl/main.c: In function ‘getAppFolder’:
src/system/sdl/main.c:1301:9: warning: implicit declaration of function ‘strcpy’ [-Wimplicit-function-declaration]
 1301 |         strcpy(appFolder, path);
      |         ^~~~~~
src/system/sdl/main.c:1301:9: warning: incompatible implicit declaration of built-in function ‘strcpy’
src/system/sdl/main.c:1301:9: note: include ‘<string.h>’ or provide a declaration of ‘strcpy’
```