### PR TITLE
When listing language options in the spec, use "x, y, or z" format

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -261,15 +261,23 @@ static char* replaceHelpTokens(const char* text)
     char langnames[10240] = {0};
     char langextensions[10240] = {0};
     char langnamespipe[10240] = {0};
+
     FOR_EACH_LANG(ln)
+        bool isLast = *(conf+1) == NULL;
+        bool isSecondToLast = *(conf+2) == NULL;
+
         strcat(langnames, ln->name);
-        strcat(langnames, " ");
+        if (!isLast)
+            strcat(langnames, ", ");
+        if (isSecondToLast)
+            strcat(langnames, "or ");
 
         strcat(langextensions, ln->fileExtension);
         strcat(langextensions, " ");
 
         strcat(langnamespipe, ln->name);
-        strcat(langnamespipe, "|");
+        if (!isLast)
+            strcat(langnamespipe, "|");
     FOR_EACH_LANG_END
 
 
@@ -2540,7 +2548,7 @@ static const char HelpUsage[] = "help [<text>"
     macro("new",                                                                        \
         NULL,                                                                           \
         "creates a new `Hello World` cartridge.",                                       \
-        "new [$LANG_NAMES_PIPE$...]",                                                   \
+        "new [$LANG_NAMES_PIPE$]",                                                      \
         onNewCommand)                                                                   \
                                                                                         \
     macro("load",                                                                       \


### PR DESCRIPTION
I noticed that there was a space behind each language option, leading to an improper-looking list in the CODE section of `help spec`. Before:

![screen10](https://user-images.githubusercontent.com/81277/146463175-48fcce9c-037f-4aa8-9bfc-5418b5471617.gif)

After:

![screen9](https://user-images.githubusercontent.com/81277/146463190-b995b8aa-bb7b-43b9-a266-5fa7733dea27.gif)

Also seems to fix the indentation, I didn't touch that. Implemented in the most straightforward way I could think of, does that seem alright?

Also removes the last "|..." in `help new`, as I don't think there are other options, right? Before:

![screen12](https://user-images.githubusercontent.com/81277/146463504-636df204-5a0a-460e-bcaa-a5381da84756.gif)

After:

![screen11](https://user-images.githubusercontent.com/81277/146463510-10307ccd-2ebe-40a0-80f9-b30cef2cfa3f.gif)