### PR TITLE
On Linux, use Ctrl+L to clear the console, per default of other shells

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -3540,8 +3540,14 @@ static void processKeyboard(Console* console)
         else if(keyWasPressed(tic_key_pageup))      processConsolePgUp(console);
         else if(keyWasPressed(tic_key_pagedown))    processConsolePgDown(console);
 
-        if(tic_api_key(tic, tic_key_ctrl) 
-            && keyWasPressed(tic_key_k))
+#       if defined(__TIC_LINUX__)
+            tic_keycode clearKey = tic_key_l;
+#       else
+            tic_keycode clearKey = tic_key_k;
+#       endif
+
+        if(tic_api_key(tic, tic_key_ctrl)
+            && keyWasPressed(clearKey))
         {
             onClsCommand(console);
             return;


### PR DESCRIPTION
Closes #1741.