### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest releases are supported and may receive security updates.
+If you aren't using the latest stable version, please upgrade.
+
+| Version    | Status   | Supported          |
+| ---------- | -------- | ------------------ |
+| 1.0.x-dev  | Alpha    | :white_check_mark: |
+| 0.90.x     | Stable   | :white_check_mark: |
+| 0.80.x     |          | :x:                |
+| 0.70.x     | Obsolete | :x:                |
+| < 0.70     | Obsolete | :x:                |
+
+## Reporting a Vulnerability
+
+Please open a [new GitHub issue](https://github.com/nesbox/TIC-80/issues/new) to report a vulnerability.
+
+If you feel your vulnerability is serious and should not
+be publically disclosed you may reach out via email:
+
+grigoruk@gmail.com


### PR DESCRIPTION
I went to see what our security policy was, and we didn't have one, so this is a beginning.  I just used the default template and filled in the very basics.

Not sure if you'd prefer a nicer email like `security@tic80.com`?  

Also is there any reason someone should still be running 0.80 or 0.70?  Could we mark anything below 0.90 as obsolete?  This also has wiki implications as we don't need to mention "added in version 0.2" if someone isn't using version 0.1 anymore, etc...