### PR TITLE
fix: prevent cartridges hijacking keyboard events

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -510,12 +510,14 @@ void tic_core_tick_start(tic_mem* memory)
     tic_core_sound_tick_start(memory);
     tic_core_tick_io(memory);
 
-    // SECURITY: preserve the system keyboard input state (and restore it
-    // post-tick, see below) to prevent user cartridges from being able to
-    // corrupt and take control of the keyboard in nefarious ways.
+    // SECURITY: preserve the system keyboard/game controller input state
+    // (and restore it post-tick, see below) to prevent user cartridges
+    // from being able to corrupt and take control of the inputs in
+    // nefarious ways.
     //
     // Related: https://github.com/nesbox/TIC-80/issues/1785
     core->state.keyboard.now.data = core->memory.ram.input.keyboard.data;
+    core->state.gamepads.now.data = core->memory.ram.input.gamepads.data;
 
     core->state.synced = 0;
 }
@@ -528,8 +530,9 @@ void tic_core_tick_end(tic_mem* memory)
     core->state.gamepads.previous.data = input->gamepads.data;
     // SECURITY: we do not use `memory.ram.input` here because it is
     // untrustworthy since the cartridge could have modified it to 
-    // inject artificial keyboard events.
+    // inject artificial keyboard/gamepad events.
     core->state.keyboard.previous.data = core->state.keyboard.now.data;
+    core->state.gamepads.previous.data = core->state.gamepads.now.data;
 
     tic_core_sound_tick_end(memory);
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -101,6 +101,7 @@ typedef struct
     struct
     {
         tic80_gamepads previous;
+        tic80_gamepads now;
 
         u32 holds[sizeof(tic80_gamepads) * BITS_IN_BYTE];
     } gamepads;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -108,6 +108,7 @@ typedef struct
     struct 
     {
         tic80_keyboard previous;
+        tic80_keyboard now;
 
         u32 holds[tic_keys_count];
     } keyboard;

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -1991,6 +1991,9 @@ static void renderStudio()
         tic_core_tick_start(tic);
     }
 
+    // SECURITY: It's important that this comes before `tick` and not after
+    // to prevent misbehaving cartridges from having an opportunity to
+    // tamper with the keyboard input.
     processShortcuts();
 
     // clear screen for all the modes except the Run mode


### PR DESCRIPTION
Resolves #1785.

This fix captures the current (`input.ram.keyboard`) state in
`tick_start` and immediately restores it in `tick_end`. This
prevents cartridges from injecting corrupt "previous" states
into the keyboard state engine that could be used to hijack
keyboard input.

When we trust `input.ram.keyboard` after user code has run
we open ourselves up to a cartridge:

- repeating keyboard events by fake "lifting" a key
  (which is still held by the user, then registering as
  separate repeating keypress/releases until the user
  finally releases the key)
- preventing key up events by fake "holding" a key
  (this prevents the state engine from ever seeing the
  key release).

---

Originally this was a lot larger, but I figured it was going to be too hard to review and certify with just a glance.   This takes your "don't let someone modify KEYBOARD" idea and simplifies it to preserving rather than protecting.  We preserve the "now" state during a tick and then restore it immediately afterwards, vs trusting whatever (potentially incorrect) state could be present in the RAM.

Since the real problem is making sure the integrity of KEYBOARD state is guaranteed for "system" bits, this does so by making sure that immediate after `pre-tick` the "now" state is restored, guaranteeing that:

- historic keyboard state is never corrupted in the first place (fixing the bug)
- KEYBOARD state is guaranteed to be accurate immediately pre-tick because we haven't run any user code yet that could alter it

I hope this is clear.  If you have any questions, ask.

---

I'm still open to doing a larger refactor here, but I thought this was pretty clean.  The only gotcha is that code like `handleShortcuts()` must be run before the user code, and I've added a comment to that effect:

- pretick
- Studio handles keystrokes (KEYBOARD is guaranteed correct here)
- tick (user code)
- post tick