### PR TITLE
Do not default to the first available language for new carts.

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1115,8 +1115,8 @@ static void onNewCommandConfirmed(Console* console)
     }
     else
     {
-        loadDemo(console, 0);
-        done = true;
+        printError(console, "\nerror: choose a language for the new cart.");
+        printUsage(console, console->desc->command);
     }
 
     if(done) printBack(console, "\nnew cart has been created");
@@ -2549,7 +2549,7 @@ static const char HelpUsage[] = "help [<text>"
     macro("new",                                                                        \
         NULL,                                                                           \
         "creates a new `Hello World` cartridge.",                                       \
-        "new [$LANG_NAMES_PIPE$]",                                                      \
+        "new <$LANG_NAMES_PIPE$>",                                                      \
         onNewCommand)                                                                   \
                                                                                         \
     macro("load",                                                                       \


### PR DESCRIPTION
Since we have so many different languages, wouldn't it be nice to encourage users to experiment with each of them and find out whatever fits them the most instead of defaulting to Lua?

We could either not have a default language at all (this "patch") or put some reminder that other options are available to try as well.