### PR TITLE
(enh) speed up poke4 API hot path

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -481,7 +481,7 @@ enum
         2,                                                                                                              \
         0,                                                                                                              \
         void,                                                                                                           \
-        tic_mem*, s32 address, u8 value)                                                                                \
+        tic_mem*, u32 address, u8 value)                                                                                \
                                                                                                                         \
                                                                                                                         \
     macro(memcpy,                                                                                                       \

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -108,9 +108,14 @@ void tic_api_poke2(tic_mem* memory, s32 address, u8 value)
     tic_api_poke(memory, address, value, 2);
 }
 
-void tic_api_poke4(tic_mem* memory, s32 address, u8 value)
+// This is a hot path and used by almost all our internal drawing code so
+// it gains a real 10-15% performance boost from not going thru the same
+// `tic_api_poke` abstraction as the other poke* API calls do.
+void tic_api_poke4(tic_mem* memory, u32 address, u8 value)
 {
-    tic_api_poke(memory, address, value, 4);
+    const u8* ram = (u8*)&memory->ram;
+    enum{RamBits = sizeof(tic_ram) * BITS_IN_BYTE};
+    if(address < RamBits / 4) return tic_tool_poke4(ram, address, value);
 }
 
 void tic_api_memcpy(tic_mem* memory, s32 dst, s32 src, s32 size)

--- a/src/core/draw.c
+++ b/src/core/draw.c
@@ -159,11 +159,11 @@ static void drawTile(tic_core* core, tic_tileptr* tile, s32 x, s32 y, u8* colors
         y += sy;
         x += sx;
         switch (orientation) {
+        case 0b000: DRAW_TILE_BODY(px, py); break;
         case 0b100: DRAW_TILE_BODY(py, px); break;
         case 0b110: DRAW_TILE_BODY(REVERT(py), px); break;
         case 0b101: DRAW_TILE_BODY(py, REVERT(px)); break;
         case 0b111: DRAW_TILE_BODY(REVERT(py), REVERT(px)); break;
-        case 0b000: DRAW_TILE_BODY(px, py); break;
         case 0b010: DRAW_TILE_BODY(px, REVERT(py)); break;
         case 0b001: DRAW_TILE_BODY(REVERT(px), py); break;
         case 0b011: DRAW_TILE_BODY(REVERT(px), REVERT(py)); break;


### PR DESCRIPTION
This is a hot path and used by almost all our internal drawing code so
it gains a real 13% performance boost from not going thru the same
`tic_api_poke` abstraction as the other poke* API calls do.

Related: #1739.

All of these should really be `u32` in my mind (and then we avoid the `<` comparison... but I wasn't seeing a measurable speed difference so I tried to go for "smallest change".  I did change the order of the `switch` in drawTile, but that could just be my imagination.  It doesn't hurt though.

_I can make them all u32 for consistency if you'd like, just let me know._

Before:

![Screen Shot 2022-01-08 at 10 52 20 AM](https://user-images.githubusercontent.com/6473/148650895-bf0363e9-026e-4293-ba59-c9fca9fdaafd.png)

After:

![Screen Shot 2022-01-08 at 10 59 50 AM](https://user-images.githubusercontent.com/6473/148651045-639d3ea2-1d42-4c35-ac62-b7bc097f51a3.png)


Here is a run showing 17.7% increase in rendering - 13-14% was more typical in my testing. We see the uptick in almost all the draw functions because they all route thru `poke4`.