### PR TITLE
faster drawTile, remove repeat clipping checks

### DIFF
--- a/src/core/draw.c
+++ b/src/core/draw.c
@@ -67,6 +67,15 @@ static void setPixel(tic_core* core, s32 x, s32 y, u8 color)
     tic_api_poke4((tic_mem*)core, y * TIC80_WIDTH + x, color);
 }
 
+static void setPixelFast(tic_core* core, s32 x, s32 y, u8 color)
+{
+    const tic_vram* vram = &core->memory.ram.vram;
+
+    // does not do any CLIP checking, the caller needs to do that first
+
+    tic_api_poke4((tic_mem*)core, y * TIC80_WIDTH + x, color);
+}
+
 static u8 getPixel(tic_core* core, s32 x, s32 y)
 {
     return tic_api_peek4((tic_mem*)core, y * TIC80_WIDTH + x);
@@ -129,7 +138,7 @@ static void drawRectBorder(tic_core* core, s32 x, s32 y, s32 width, s32 height, 
         for(s32 px=sx; px < ex; px++, xx++) \
         { \
             u8 color = mapping[tic_tilesheet_gettilepix(tile, (X), (Y))];\
-            if(color != TRANSPARENT_COLOR) setPixel(core, xx, y, color); \
+            if(color != TRANSPARENT_COLOR) setPixelFast(core, xx, y, color); \
         } \
     } \
     } while(0)


### PR DESCRIPTION
Resolves #1796 .

`drawTile` appears to be taking clipping into account, yet in
setPixel for every single pixel we check the clipping
individually... it seems this is not necessary.

This adds a new `setPixelFast` that avoids the repeat checks.

I see about a 4-5% increase in benchmarks for just sprite draws.
