### PR TITLE
Suggestion: Refactor to avoid naming confusion with core/memory

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -24,6 +24,7 @@
 
 #include "tic.h"
 
+
 // convenience macros to loop languages
 #define FOR_EACH_LANG(ln) for (tic_script_config** conf = Languages ; *conf != NULL; conf++ ) { tic_script_config* ln = *conf;
 #define FOR_EACH_LANG_END }
@@ -840,17 +841,6 @@ struct tic_mem
     tic80_pixel_color_format screen_format;
 };
 
-tic_mem* tic_core_create(s32 samplerate);
-void tic_core_close(tic_mem* memory);
-void tic_core_pause(tic_mem* memory);
-void tic_core_resume(tic_mem* memory);
-void tic_core_tick_start(tic_mem* memory);
-void tic_core_tick(tic_mem* memory, tic_tick_data* data);
-void tic_core_tick_end(tic_mem* memory);
-void tic_core_synth_sound(tic_mem* tic);
-void tic_core_blit(tic_mem* tic);
-void tic_core_blit_ex(tic_mem* tic, tic_blit_callback clb);
-const tic_script_config* tic_core_script_config(tic_mem* memory);
 
 typedef struct
 {

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -636,20 +636,16 @@ void tic_core_blit_ex(tic_core* core, tic_blit_callback clb)
 #undef  UPDBDR
 }
 
-static inline void scanline(tic_mem* memory, s32 row, void* data)
+static inline void scanline(tic_core* core, s32 row, void* data)
 {
-    tic_core* core = (tic_core*)memory;
-
     if (core->state.initialized)
-        core->state.callback.scanline(memory, row, data);
+        core->state.callback.scanline(&core->memory, row, data);
 }
 
-static inline void border(tic_mem* memory, s32 row, void* data)
+static inline void border(tic_core* core, s32 row, void* data)
 {
-    tic_core* core = (tic_core*)memory;
-
     if (core->state.initialized)
-        core->state.callback.border(memory, row, data);
+        core->state.callback.border(&core->memory, row, data);
 }
 
 void tic_core_blit(tic_core* core)

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -403,10 +403,9 @@ s32 tic_api_vbank(tic_mem* tic, s32 bank)
     return prev;
 }
 
-void tic_core_tick(tic_core* tic, tic_tick_data* data)
+void tic_core_tick(tic_core* core, tic_tick_data* data)
 {
-    tic_core* core = (tic_core*)tic;
-    tic_mem* mem = (tic_mem*)tic;
+    tic_mem* mem = (tic_mem*)core;
 
     core->data = data;
 
@@ -415,11 +414,11 @@ void tic_core_tick(tic_core* tic, tic_tick_data* data)
         const char* code = mem->cart.code.data;
 
         bool done = false;
-        const tic_script_config* config = tic_core_script_config(tic);
+        const tic_script_config* config = tic_core_script_config(core);
 
         if (strlen(code))
         {
-            cart2ram(tic);
+            cart2ram(core);
 
             core->state.synced = 0;
             mem->input.data = 0;
@@ -450,7 +449,7 @@ void tic_core_tick(tic_core* tic, tic_tick_data* data)
         else return;
     }
 
-    core->state.tick(tic);
+    core->state.tick(core);
 }
 
 void tic_core_pause(tic_core* core)
@@ -494,24 +493,22 @@ void tic_core_close(tic_core* core)
     free(core);
 }
 
-void tic_core_tick_start(tic_core* memory)
+void tic_core_tick_start(tic_core* core)
 {
-    tic_core_sound_tick_start(memory);
-    tic_core_tick_io(memory);
+    tic_core_sound_tick_start(core);
+    tic_core_tick_io(core);
 
-    tic_core* core = (tic_core*)memory;
     core->state.synced = 0;
 }
 
-void tic_core_tick_end(tic_core* memory)
+void tic_core_tick_end(tic_core* core)
 {
-    tic_core* core = (tic_core*)memory;
     tic80_input* input = &core->memory.ram.input;
 
     core->state.gamepads.previous.data = input->gamepads.data;
     core->state.keyboard.previous.data = input->keyboard.data;
 
-    tic_core_sound_tick_end(memory);
+    tic_core_sound_tick_end(core);
 }
 
 // copied from SDL2

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -659,7 +659,7 @@ void tic_core_blit(tic_mem* tic)
     tic_core_blit_ex(tic, (tic_blit_callback){scanline, border, NULL});
 }
 
-tic_mem* tic_core_create(s32 samplerate)
+tic_core* tic_core_create(s32 samplerate)
 {
     tic_core* core = (tic_core*)malloc(sizeof(tic_core));
     memset(core, 0, sizeof(tic_core));
@@ -689,5 +689,5 @@ tic_mem* tic_core_create(s32 samplerate)
 
     tic_api_reset(&core->memory);
 
-    return &core->memory;
+    return core;
 }

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -553,9 +553,8 @@ static inline tic_vram* vbank1(tic_core* core)
 
 static inline void updpal(tic_core* core, tic_blitpal* pal0, tic_blitpal* pal1)
 {
-    tic_mem* mem = (tic_mem*)core;
-    *pal0 = tic_tool_palette_blit(&vbank0(core)->palette, mem->screen_format);
-    *pal1 = tic_tool_palette_blit(&vbank1(core)->palette, mem->screen_format);
+    *pal0 = tic_tool_palette_blit(&vbank0(core)->palette, core->memory.screen_format);
+    *pal1 = tic_tool_palette_blit(&vbank1(core)->palette, core->memory.screen_format);
 }
 
 static inline void updbdr(tic_mem* tic, s32 row, u32* ptr, tic_blit_callback clb, tic_blitpal* pal0, tic_blitpal* pal1)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -211,13 +211,13 @@ void tic_core_sound_tick_end(tic_mem* memory);
 
 
 tic_core* tic_core_create(s32 samplerate);
-void tic_core_close(tic_mem* memory);
-void tic_core_pause(tic_mem* memory);
-void tic_core_resume(tic_mem* memory);
-void tic_core_tick_start(tic_mem* memory);
-void tic_core_tick(tic_mem* memory, tic_tick_data* data);
-void tic_core_tick_end(tic_mem* memory);
-void tic_core_synth_sound(tic_mem* tic);
-void tic_core_blit(tic_mem* tic);
-void tic_core_blit_ex(tic_mem* tic, tic_blit_callback clb);
-const tic_script_config* tic_core_script_config(tic_mem* memory);
+void tic_core_close(tic_core* memory);
+void tic_core_pause(tic_core* memory);
+void tic_core_resume(tic_core* memory);
+void tic_core_tick_start(tic_core* memory);
+void tic_core_tick(tic_core* memory, tic_tick_data* data);
+void tic_core_tick_end(tic_core* memory);
+void tic_core_synth_sound(tic_core* tic);
+void tic_core_blit(tic_core* tic);
+void tic_core_blit_ex(tic_core* tic, tic_blit_callback clb);
+const tic_script_config* tic_core_script_config(tic_core* memory);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -193,7 +193,7 @@ typedef struct
 
 } tic_core;
 
-void tic_core_tick_io(tic_mem* memory);
+void tic_core_tick_io(tic_core* memory);
 void tic_core_sound_tick_start(tic_mem* memory);
 void tic_core_sound_tick_end(tic_mem* memory);
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -208,3 +208,16 @@ void tic_core_sound_tick_end(tic_mem* memory);
     OVR_COMPAT(CORE, 1);                            \
     tic_api_cls(&CORE->memory, 0);                  \
     SCOPE(OVR_COMPAT(CORE, MACROVAR(_bank_)))
+
+
+tic_core* tic_core_create(s32 samplerate);
+void tic_core_close(tic_mem* memory);
+void tic_core_pause(tic_mem* memory);
+void tic_core_resume(tic_mem* memory);
+void tic_core_tick_start(tic_mem* memory);
+void tic_core_tick(tic_mem* memory, tic_tick_data* data);
+void tic_core_tick_end(tic_mem* memory);
+void tic_core_synth_sound(tic_mem* tic);
+void tic_core_blit(tic_mem* tic);
+void tic_core_blit_ex(tic_mem* tic, tic_blit_callback clb);
+const tic_script_config* tic_core_script_config(tic_mem* memory);

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -132,22 +132,20 @@ tic_point tic_api_mouse(tic_mem* memory)
         : (tic_point){memory->ram.input.mouse.x - TIC80_OFFSET_LEFT, memory->ram.input.mouse.y - TIC80_OFFSET_TOP};
 }
 
-void tic_core_tick_io(tic_mem* tic)
+void tic_core_tick_io(tic_core* core)
 {
-    tic_core* core = (tic_core*)tic;
-
     // process gamepads mapping
-    u8* keycodes = tic->ram.mapping.data;
+    u8* keycodes = core->memory.ram.mapping.data;
     for(s32 i = 0; i < sizeof(tic_mapping); ++i)
-        if(keycodes[i] && tic_api_key(tic, keycodes[i]))
-            tic->ram.input.gamepads.data |= 1 << i;
+        if(keycodes[i] && tic_api_key(&core->memory, keycodes[i]))
+            core->memory.ram.input.gamepads.data |= 1 << i;
 
     // process gamepad
     for (s32 i = 0; i < COUNT_OF(core->state.gamepads.holds); i++)
     {
         u32 mask = 1 << i;
         u32 prevDown = core->state.gamepads.previous.data & mask;
-        u32 down = tic->ram.input.gamepads.data & mask;
+        u32 down = core->memory.ram.input.gamepads.data & mask;
 
         u32* hold = &core->state.gamepads.holds[i];
         if (prevDown && prevDown == down) (*hold)++;
@@ -158,7 +156,7 @@ void tic_core_tick_io(tic_mem* tic)
     for (s32 i = 0; i < tic_keys_count; i++)
     {
         bool prevDown = isKeyPressed(&core->state.keyboard.previous, i);
-        bool down = isKeyPressed(&tic->ram.input.keyboard, i);
+        bool down = isKeyPressed(&core->memory.ram.input.keyboard, i);
 
         u32* hold = &core->state.keyboard.holds[i];
 

--- a/src/core/sound.c
+++ b/src/core/sound.c
@@ -531,7 +531,7 @@ static void stereo_synthesize(tic_core* core, tic_sound_register_data* registers
     blip_end_frame(blip, EndTime);
 }
 
-void tic_core_synth_sound(tic_mem* memory)
+void tic_core_synth_sound(tic_core* memory)
 {
     tic_core* core = (tic_core*)memory;
 

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "code.h"
+#include "core/core.h"
 #include "ext/history.h"
 
 #include <ctype.h>

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -29,6 +29,7 @@
 #include "ext/png.h"
 #include "zip.h"
 #include "studio/demos.h"
+#include "core/core.h"
 
 #if defined(TIC80_PRO)
 #include "studio/project.h"

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -457,23 +457,23 @@ bool anyKeyWasPressed()
 #if defined(BUILD_EDITORS)
 tic_tiles* getBankTiles()
 {
-    return &impl.studio.tic->cart.banks[impl.bank.index.sprites].tiles;
+    return &impl.studio.tic->memory.cart.banks[impl.bank.index.sprites].tiles;
 }
 
 tic_map* getBankMap()
 {
-    return &impl.studio.tic->cart.banks[impl.bank.index.map].map;
+    return &impl.studio.tic->memory.cart.banks[impl.bank.index.map].map;
 }
 
 tic_palette* getBankPalette(bool vbank)
 {
-    tic_bank* bank = &impl.studio.tic->cart.banks[impl.bank.index.sprites];
+    tic_bank* bank = &impl.studio.tic->memory.cart.banks[impl.bank.index.sprites];
     return vbank ? &bank->palette.vbank1 : &bank->palette.vbank0;
 }
 
 tic_flags* getBankFlags()
 {
-    return &impl.studio.tic->cart.banks[impl.bank.index.sprites].flags;
+    return &impl.studio.tic->memory.cart.banks[impl.bank.index.sprites].flags;
 }
 #endif
 
@@ -1493,7 +1493,7 @@ static void initModules()
 
 static void updateHash()
 {
-    md5(&impl.studio.tic->cart, sizeof(tic_cartridge), impl.cart.hash.data);
+    md5(&impl.studio.tic->memory.cart, sizeof(tic_cartridge), impl.cart.hash.data);
 }
 
 static void updateMDate()
@@ -1558,7 +1558,7 @@ void studioRomLoaded()
 bool studioCartChanged()
 {
     CartHash hash;
-    md5(&impl.studio.tic->cart, sizeof(tic_cartridge), hash.data);
+    md5(&impl.studio.tic->memory.cart, sizeof(tic_cartridge), hash.data);
 
     return memcmp(hash.data, impl.cart.hash.data, sizeof(CartHash)) != 0;
 }
@@ -1963,8 +1963,8 @@ static void renderStudio()
         switch(impl.mode)
         {
         case TIC_RUN_MODE:
-            sfx = &impl.studio.tic->ram.sfx;
-            music = &impl.studio.tic->ram.music;
+            sfx = &tic->ram.sfx;
+            music = &tic->ram.music;
             break;
         case TIC_START_MODE:
         case TIC_MENU_MODE:
@@ -1985,7 +1985,7 @@ static void renderStudio()
 
         // restore mapping in all the modes except Run mode
         if(impl.mode != TIC_RUN_MODE)
-            impl.studio.tic->ram.mapping = getConfig()->options.mapping;
+            tic->ram.mapping = getConfig()->options.mapping;
 
         tic_core_tick_start(tic);
     }

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "api.h"
+#include "core/core.h"
 #include "version.h"
 
 #if defined(TIC80_PRO)
@@ -136,7 +137,7 @@ typedef struct
 
 typedef struct
 {
-    tic_mem* tic;
+    tic_core* tic;
     bool quit;
 
     void (*tick)();

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -305,7 +305,7 @@ static void setWindowIcon()
     u32* pixels = SDL_malloc(Size * Size * sizeof(u32));
     SCOPE(SDL_free(pixels))
     {
-        tic_blitpal pal = tic_tool_palette_blit(&platform.studio->config()->cart->bank0.palette.vbank0, platform.studio->tic->screen_format);
+        tic_blitpal pal = tic_tool_palette_blit(&platform.studio->config()->cart->bank0.palette.vbank0, platform.studio->tic->memory.screen_format);
 
         for(s32 j = 0, index = 0; j < Size; j++)
             for(s32 i = 0; i < Size; i++, index++)

--- a/src/tic.c
+++ b/src/tic.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include <tic80.h>
+#include "core/core.h"
 #include "api.h"
 #include "tools.h"
 #include "cart.h"
@@ -71,7 +72,7 @@ tic80* tic80_create(s32 samplerate)
     {
         memset(tic80, 0, sizeof(tic80_local));
 
-        tic80->memory = tic_core_create(samplerate);
+        tic80->memory = (tic_core*)tic_core_create(samplerate);
         tic80->tic.screen_format = tic80->memory->screen_format;
 
         return &tic80->tic;


### PR DESCRIPTION
Here is just a *little* work I did... and this would be a much larger endeavor... but I don't want to invest the time unless you're 100% behind this... basically the single starter goal would be to clean up all the "what object are we passing" confusion. We could start with only obvious places like `core.c` (ignoring the API functions for now)... ie, code like this:

```c
void tic_core_close(tic_mem* memory)
{
    tic_core* core = (tic_core*)memory;

    core->state.initialized = false;

    tic_close_current_vm(core);

    blip_delete(core->blip.left);
    blip_delete(core->blip.right);

    free(memory->samples.buffer);
    free(core);
}
```

What is confusing here:

- This code is in the `core.c` file, yes does not work with cores.
- This is a "TICCore" "class" function (in C terms) because of it's `tic_core_*` naming, yet it takes a `tic_mem*` as input.
- It mostly doesn't care about `tic_mem*` at all, using only a single field.
- ...instead casting it to `tic_core*` and using that the entire time...

IE, this would be much more clearly written as:

```c
void tic_core_close(tic_core* core)
{
    core->state.initialized = false;

    tic_close_current_vm(core);

    blip_delete(core->blip.left);
    blip_delete(core->blip.right);

    free(core->memory.samples.buffer);
    free(core);
}
```

IE, this is:

- a `tic_core_*` (TICCore) "class" function
- it takes a `tic_core *` as input
- it does actual work on that `tic_core *`
- enclosed in `core.c`... where it should be 

---

This same logic would apply to every `tic_core_*` function, etc... I didn't dig fully into fixing the naming here but we'd also apply consistent naming everywhere:

- `core` would refer to `tic_core` instances, etc
- `mem` would refer to `tic_mem` instance, etc

The generic `tic` would be used much less as it's ambiguous about what it holds (state? core? data? mem?)