### PR TITLE
[WIP] Advanced tab-completion for the console

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1296,17 +1296,17 @@ static void finishAutocompleteAndFreeData(void* data) {
 
 static void autocompleteFiles(AutocompleteData* data)
 {
-    tic_fs_enum(data->console->fs, addFilenameToAutocomplete, finishAutocompleteAndFreeData, MOVE(data));
+    tic_fs_enum(data->console->fs, addFilenameToAutocomplete, finishAutocompleteAndFreeData, MOVE(*data));
 }
 
 static void autocompleteDirs(AutocompleteData* data)
 {
-    tic_fs_enum(data->console->fs, addDirToAutocomplete, finishAutocompleteAndFreeData, MOVE(data));
+    tic_fs_enum(data->console->fs, addDirToAutocomplete, finishAutocompleteAndFreeData, MOVE(*data));
 }
 
 static void autocompleteFilesAndDirs(AutocompleteData* data)
 {
-    tic_fs_enum(data->console->fs, addFileAndDirToAutocomplete, finishAutocompleteAndFreeData, MOVE(data));
+    tic_fs_enum(data->console->fs, addFileAndDirToAutocomplete, finishAutocompleteAndFreeData, MOVE(*data));
 }
 
 static void autocompleteConfig(AutocompleteData* data)
@@ -2965,6 +2965,8 @@ static void autocompleteHelp(AutocompleteData* data)
 #define TIC_API_DEF(name, def, help, ...) addAutocompleteOption(data, #name);
     API_LIST(TIC_API_DEF)
 #undef TIC_API_DEF
+
+    finishAutocomplete(data);
 }
 
 
@@ -3241,6 +3243,8 @@ static void processConsoleTab(Console* console)
                         AutocompleteData data = { console, .incompleteWord = secondParam };
                         data.options = malloc(CONSOLE_BUFFER_SCREEN);
                         data.commonPrefix = malloc(CONSOLE_BUFFER_SCREEN);
+                        data.options[0] = '\0';
+                        data.commonPrefix[0] = '\0';
                         Commands[i].autocomplete2(&data);
                     }
                 } else {
@@ -3248,6 +3252,8 @@ static void processConsoleTab(Console* console)
                         AutocompleteData data = { console, .incompleteWord = param };
                         data.options = malloc(CONSOLE_BUFFER_SCREEN);
                         data.commonPrefix = malloc(CONSOLE_BUFFER_SCREEN);
+                        data.options[0] = '\0';
+                        data.commonPrefix[0] = '\0';
                         Commands[i].autocomplete1(&data);
                     }
                 }
@@ -3260,6 +3266,8 @@ static void processConsoleTab(Console* console)
         AutocompleteData data = { console, incompleteWord: input };
         data.options = malloc(CONSOLE_BUFFER_SCREEN);
         data.commonPrefix = malloc(CONSOLE_BUFFER_SCREEN);
+        data.options[0] = '\0';
+        data.commonPrefix[0] = '\0';
         for(s32 i = 0; i < COUNT_OF(Commands); i++)
         {
             addAutocompleteOption(&data, Commands[i].name);

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2664,6 +2664,7 @@ static const char HelpUsage[] = "help [<text>"
         "upload file to the browser local storage.",                                    \
         NULL,                                                                           \
         onAddCommand,                                                                   \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("get",                                                                        \
@@ -2671,26 +2672,29 @@ static const char HelpUsage[] = "help [<text>"
         "download file from the browser local storage.",                                \
         "get <file>",                                                                   \
         onGetCommand,                                                                   \
-        autocompleteFiles)                                                              \
+        autocompleteFiles,                                                              \
+        NULL)                                                                           \
 
 #else
 #define ADDGET_FILE(macro)
 #endif
 
-// macro(name, alt, help, usage, handler)
+// macro(name, alt, help, usage, handler, autocomplete for first param, for second param)
 #define COMMANDS_LIST(macro)                                                            \
     macro("help",                                                                       \
         NULL,                                                                           \
         "show help info about commands/api/...",                                        \
         HelpUsage,                                                                      \
         onHelpCommand,                                                                  \
-        autocompleteHelp)                                                               \
+        autocompleteHelp,                                                               \
+        NULL)                                                                           \
                                                                                         \
     macro("exit",                                                                       \
         "quit",                                                                         \
         "exit the application.",                                                        \
         NULL,                                                                           \
         onExitCommand,                                                                  \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("new",                                                                        \
@@ -2698,7 +2702,8 @@ static const char HelpUsage[] = "help [<text>"
         "creates a new `Hello World` cartridge.",                                       \
         "new <$LANG_NAMES_PIPE$>",                                                      \
         onNewCommand,                                                                   \
-        autocompleteLanguages)                                                          \
+        autocompleteLanguages,                                                          \
+        NULL)                                                                           \
                                                                                         \
     macro("load",                                                                       \
         NULL,                                                                           \
@@ -2707,7 +2712,8 @@ static const char HelpUsage[] = "help [<text>"
         "you can also load just the section (sprites, map etc) from another cart.",     \
         "load <cart> [code" TIC_SYNC_LIST(SECTION_DEF) "]",                             \
         onLoadCommand,                                                                  \
-        autocompleteFiles)                                                              \
+        autocompleteFiles,                                                              \
+        NULL)                                                                           \
                                                                                         \
     macro("save",                                                                       \
         NULL,                                                                           \
@@ -2715,13 +2721,15 @@ static const char HelpUsage[] = "help [<text>"
         "cart extension to save it in text format (PRO feature).",                      \
         "save <cart>",                                                                  \
         onSaveCommand,                                                                  \
-        autocompleteFiles)                                                              \
+        autocompleteFiles,                                                              \
+        NULL)                                                                           \
                                                                                         \
     macro("run",                                                                        \
         NULL,                                                                           \
         "run current cart / project.",                                                  \
         NULL,                                                                           \
         onRunCommand,                                                                   \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("resume",                                                                     \
@@ -2729,6 +2737,7 @@ static const char HelpUsage[] = "help [<text>"
         "resume last run cart / project.",                                              \
         NULL,                                                                           \
         onResumeCommand,                                                                \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("eval",                                                                       \
@@ -2736,6 +2745,7 @@ static const char HelpUsage[] = "help [<text>"
         "run code provided code.",                                                      \
         NULL,                                                                           \
         onEvalCommand,                                                                  \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("dir",                                                                        \
@@ -2743,20 +2753,23 @@ static const char HelpUsage[] = "help [<text>"
         "show list of local files.",                                                    \
         NULL,                                                                           \
         onDirCommand,                                                                   \
-        autocompleteDirs)                                                               \
+        autocompleteDirs,                                                               \
+        NULL)                                                                           \
                                                                                         \
     macro("cd",                                                                         \
         NULL,                                                                           \
         "change directory.",                                                            \
         "\ncd <path>\ncd /\ncd ..",                                                     \
         onChangeDirectory,                                                              \
-        autocompleteDirs)                                                               \
+        autocompleteDirs,                                                               \
+        NULL)                                                                           \
                                                                                         \
     macro("mkdir",                                                                      \
         NULL,                                                                           \
         "make a directory.",                                                            \
         "mkdir <name>",                                                                 \
         onMakeDirectory,                                                                \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("folder",                                                                     \
@@ -2764,6 +2777,7 @@ static const char HelpUsage[] = "help [<text>"
         "open working directory in OS.",                                                \
         NULL,                                                                           \
         onFolderCommand,                                                                \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("export",                                                                     \
@@ -2775,7 +2789,8 @@ static const char HelpUsage[] = "help [<text>"
         "\nexport [" EXPORT_CMD_LIST(EXPORT_CMD_DEF) "...] "                            \
         "<file> [" EXPORT_KEYS_LIST(EXPORT_KEYS_DEF) "...]" ,                           \
         onExportCommand,                                                                \
-        autocompleteExport)                                                             \
+        autocompleteExport,                                                             \
+        autocompleteFiles)                                                              \
                                                                                         \
     macro("import",                                                                     \
         NULL,                                                                           \
@@ -2783,20 +2798,23 @@ static const char HelpUsage[] = "help [<text>"
         "\nimport [" IMPORT_CMD_LIST(IMPORT_CMD_DEF) "...] "                            \
         "<file> [" IMPORT_KEYS_LIST(IMPORT_KEYS_DEF) "...]",                            \
         onImportCommand,                                                                \
-        autocompleteImport)                                                             \
+        autocompleteImport,                                                             \
+        autocompleteFiles)                                                              \
                                                                                         \
     macro("del",                                                                        \
         NULL,                                                                           \
         "delete from the filesystem.",                                                  \
         "del <file|folder>",                                                            \
         onDelCommand,                                                                   \
-        autocompleteFilesAndDirs)                                                       \
+        autocompleteFilesAndDirs,                                                       \
+        NULL)                                                                           \
                                                                                         \
     macro("cls",                                                                        \
         "clear",                                                                        \
         "clear console screen.",                                                        \
         NULL,                                                                           \
         onClsCommand,                                                                   \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("demo",                                                                       \
@@ -2804,6 +2822,7 @@ static const char HelpUsage[] = "help [<text>"
         "install demo carts to the current directory.",                                 \
         NULL,                                                                           \
         onInstallDemosCommand,                                                          \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("config",                                                                     \
@@ -2813,13 +2832,15 @@ static const char HelpUsage[] = "help [<text>"
         "use `default` to edit default cart template.",                                 \
         "config [reset|default]",                                                       \
         onConfigCommand,                                                                \
-        autocompleteConfig)                                                             \
+        autocompleteConfig,                                                             \
+        NULL)                                                                           \
                                                                                         \
     macro("surf",                                                                       \
         NULL,                                                                           \
         "open carts browser.",                                                          \
         NULL,                                                                           \
         onSurfCommand,                                                                  \
+        NULL,                                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("menu",                                                                       \
@@ -2836,12 +2857,13 @@ static struct Command
     const char* help;
     const char* usage;
     void(*handler)(Console*);
-    void(*autocomplete)(AutocompleteData*);
+    void(*autocomplete1)(AutocompleteData*);
+    void(*autocomplete2)(AutocompleteData*);
 
 } Commands[] =
 {
-#define COMMANDS_DEF(name, alt, help, usage, handler, autocomplete) \
-    {name, alt, help, usage, handler, autocomplete},
+#define COMMANDS_DEF(name, alt, help, usage, handler, autocomplete1, autocomplete2) \
+    {name, alt, help, usage, handler, autocomplete1, autocomplete2},
     COMMANDS_LIST(COMMANDS_DEF)
 #undef COMMANDS_DEF
 };
@@ -3195,18 +3217,32 @@ static void processConsoleTab(Console* console)
 
     if(param)
     {
+        // Autocomplete command's parameters.
         param++;
+        char* secondParam = strchr(param, ' ');
+        if (secondParam)
+            secondParam++;
 
         for(s32 i = 0; i < COUNT_OF(Commands); i++)
         {
             bool commandMatches = strncmp(Commands[i].name, input, param-input-1) == 0 ||
                                   (Commands[i].alt && strncmp(Commands[i].alt, input, param-input-1) == 0);
 
-            if (commandMatches && Commands[i].autocomplete)
+            if (commandMatches)
             {
-                AutocompleteData data = { console, incompleteWord: param };
-                Commands[i].autocomplete(&data);
-                finishAutocomplete(&data);
+                if (secondParam) {
+                    if (Commands[i].autocomplete2) {
+                        AutocompleteData data = { console, incompleteWord: secondParam };
+                        Commands[i].autocomplete2(&data);
+                        finishAutocomplete(&data);
+                    }
+                } else {
+                    if (Commands[i].autocomplete1) {
+                        AutocompleteData data = { console, incompleteWord: param };
+                        Commands[i].autocomplete1(&data);
+                        finishAutocomplete(&data);
+                    }
+                }
             }
         }
     }

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1234,6 +1234,7 @@ static void finishAutocomplete(const AutocompleteData* data)
         {
             provideHint(data->console, data->options);
         }
+        processConsoleEnd(data->console);
         insertInputText(data->console, data->commonPrefix+strlen(data->incompleteWord));
 
         if (justOneOptionLeft)
@@ -3247,8 +3248,12 @@ static void processConsoleTab(Console* console)
 
         for(s32 i = 0; i < COUNT_OF(Commands); i++)
         {
-            bool commandMatches = strncmp(Commands[i].name, input, param-input-1) == 0 ||
-                                  (Commands[i].alt && strncmp(Commands[i].alt, input, param-input-1) == 0);
+            s32 commandLen = param-input-1;
+            bool commandMatches = (strlen(Commands[i].name) == commandLen &&
+                                       strncmp(Commands[i].name, input, commandLen) == 0) ||
+                                  (Commands[i].alt &&
+                                      strlen(Commands[i].name) == commandLen &&
+                                      strncmp(Commands[i].alt, input, commandLen) == 0);
 
             if (commandMatches)
             {

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1174,9 +1174,9 @@ typedef struct
     char* incompleteWord; // Original word that's being completed.
     char* options; // Options to show to the user.
     char* commonPrefix; // Common prefix of all options.
-} AutocompleteData;
+} TabCompleteData;
 
-static void addAutocompleteOption(AutocompleteData* data, const char* option)
+static void addTabCompleteOption(TabCompleteData* data, const char* option)
 {
     if (strstr(option, data->incompleteWord) == option)
     {
@@ -1206,7 +1206,7 @@ static void addAutocompleteOption(AutocompleteData* data, const char* option)
     }
 }
 
-// Used to show autocomplete options, for example.
+// Used to show tab-complete options, for example.
 static void provideHint(Console* console, const char* hint)
 {
     char* input = malloc(CONSOLE_BUFFER_SCREEN);
@@ -1220,7 +1220,7 @@ static void provideHint(Console* console, const char* hint)
     free(input);
 }
 
-static void finishAutocomplete(const AutocompleteData* data)
+static void finishTabComplete(const TabCompleteData* data)
 {
     bool anyOptions = strlen(data->options) > 0;
     if (anyOptions) {
@@ -1244,78 +1244,78 @@ static void finishAutocomplete(const AutocompleteData* data)
     free(data->commonPrefix);
 }
 
-static void autocompleteLanguages(AutocompleteData* data)
+static void tabCompleteLanguages(TabCompleteData* data)
 {
     FOR_EACH_LANG(ln)
-        addAutocompleteOption(data, ln->name);
+        addTabCompleteOption(data, ln->name);
     FOR_EACH_LANG_END
-    finishAutocomplete(data);
+    finishTabComplete(data);
 }
 
-static void autocompleteExport(AutocompleteData* data)
+static void tabCompleteExport(TabCompleteData* data)
 {
-#define EXPORT_CMD_DEF(name) addAutocompleteOption(data, #name);
+#define EXPORT_CMD_DEF(name) addTabCompleteOption(data, #name);
     EXPORT_CMD_LIST(EXPORT_CMD_DEF)
 #undef  EXPORT_CMD_DEF
-    finishAutocomplete(data);
+    finishTabComplete(data);
 }
 
-static void autocompleteImport(AutocompleteData* data)
+static void tabCompleteImport(TabCompleteData* data)
 {
-#define IMPORT_CMD_DEF(name) addAutocompleteOption(data, #name);
+#define IMPORT_CMD_DEF(name) addTabCompleteOption(data, #name);
     IMPORT_CMD_LIST(IMPORT_CMD_DEF)
 #undef  IMPORT_CMD_DEF
-    finishAutocomplete(data);
+    finishTabComplete(data);
 }
 
-static bool addFileAndDirToAutocomplete(const char* name, const char* title, const char* hash, s32 id, void* data, bool dir)
+static bool addFileAndDirToTabComplete(const char* name, const char* title, const char* hash, s32 id, void* data, bool dir)
 {
-    addAutocompleteOption(data, name);
+    addTabCompleteOption(data, name);
 
     return true;
 }
 
-static bool addFilenameToAutocomplete(const char* name, const char* title, const char* hash, s32 id, void* data, bool dir)
+static bool addFilenameToTabComplete(const char* name, const char* title, const char* hash, s32 id, void* data, bool dir)
 {
     if (!dir)
-        addAutocompleteOption(data, name);
+        addTabCompleteOption(data, name);
 
     return true;
 }
 
-static bool addDirToAutocomplete(const char* name, const char* title, const char* hash, s32 id, void* data, bool dir)
+static bool addDirToTabComplete(const char* name, const char* title, const char* hash, s32 id, void* data, bool dir)
 {
     if (dir)
-        addAutocompleteOption(data, name);
+        addTabCompleteOption(data, name);
 
     return true;
 }
 
-static void finishAutocompleteAndFreeData(void* data) {
-    finishAutocomplete((const AutocompleteData *) data);
+static void finishTabCompleteAndFreeData(void* data) {
+    finishTabComplete((const TabCompleteData *) data);
     free(data);
 }
 
-static void autocompleteFiles(AutocompleteData* data)
+static void tabCompleteFiles(TabCompleteData* data)
 {
-    tic_fs_enum(data->console->fs, addFilenameToAutocomplete, finishAutocompleteAndFreeData, MOVE(*data));
+    tic_fs_enum(data->console->fs, addFilenameToTabComplete, finishTabCompleteAndFreeData, MOVE(*data));
 }
 
-static void autocompleteDirs(AutocompleteData* data)
+static void tabCompleteDirs(TabCompleteData* data)
 {
-    tic_fs_enum(data->console->fs, addDirToAutocomplete, finishAutocompleteAndFreeData, MOVE(*data));
+    tic_fs_enum(data->console->fs, addDirToTabComplete, finishTabCompleteAndFreeData, MOVE(*data));
 }
 
-static void autocompleteFilesAndDirs(AutocompleteData* data)
+static void tabCompleteFilesAndDirs(TabCompleteData* data)
 {
-    tic_fs_enum(data->console->fs, addFileAndDirToAutocomplete, finishAutocompleteAndFreeData, MOVE(*data));
+    tic_fs_enum(data->console->fs, addFileAndDirToTabComplete, finishTabCompleteAndFreeData, MOVE(*data));
 }
 
-static void autocompleteConfig(AutocompleteData* data)
+static void tabCompleteConfig(TabCompleteData* data)
 {
-    addAutocompleteOption(data, "reset");
-    addAutocompleteOption(data, "default");
-    finishAutocomplete(data);
+    addTabCompleteOption(data, "reset");
+    addTabCompleteOption(data, "default");
+    finishTabComplete(data);
 }
 
 typedef struct
@@ -2707,7 +2707,7 @@ static void onGetCommand(Console* console)
 #endif
 
 // Declare this here to resolve a cyclic dependency with COMMANDS_LIST.
-static void autocompleteHelp(AutocompleteData* data);
+static void tabCompleteHelp(TabCompleteData* data);
 
 static const char HelpUsage[] = "help [<text>"
 #define HELP_CMD_DEF(name) "|" #name
@@ -2736,21 +2736,21 @@ static const char HelpUsage[] = "help [<text>"
         "download file from the browser local storage.",                                \
         "get <file>",                                                                   \
         onGetCommand,                                                                   \
-        autocompleteFiles,                                                              \
+        tabCompleteFiles,                                                               \
         NULL)                                                                           \
 
 #else
 #define ADDGET_FILE(macro)
 #endif
 
-// macro(name, alt, help, usage, handler, autocomplete for first param, for second param)
+// macro(name, alt, help, usage, handler, tab-complete for first param, for second param)
 #define COMMANDS_LIST(macro)                                                            \
     macro("help",                                                                       \
         NULL,                                                                           \
         "show help info about commands/api/...",                                        \
         HelpUsage,                                                                      \
         onHelpCommand,                                                                  \
-        autocompleteHelp,                                                               \
+        tabCompleteHelp,                                                                \
         NULL)                                                                           \
                                                                                         \
     macro("exit",                                                                       \
@@ -2766,7 +2766,7 @@ static const char HelpUsage[] = "help [<text>"
         "creates a new `Hello World` cartridge.",                                       \
         "new <$LANG_NAMES_PIPE$>",                                                      \
         onNewCommand,                                                                   \
-        autocompleteLanguages,                                                          \
+        tabCompleteLanguages,                                                           \
         NULL)                                                                           \
                                                                                         \
     macro("load",                                                                       \
@@ -2776,7 +2776,7 @@ static const char HelpUsage[] = "help [<text>"
         "you can also load just the section (sprites, map etc) from another cart.",     \
         "load <cart> [code" TIC_SYNC_LIST(SECTION_DEF) "]",                             \
         onLoadCommand,                                                                  \
-        autocompleteFiles,                                                              \
+        tabCompleteFiles,                                                               \
         NULL)                                                                           \
                                                                                         \
     macro("save",                                                                       \
@@ -2785,7 +2785,7 @@ static const char HelpUsage[] = "help [<text>"
         "cart extension to save it in text format (PRO feature).",                      \
         "save <cart>",                                                                  \
         onSaveCommand,                                                                  \
-        autocompleteFiles,                                                              \
+        tabCompleteFiles,                                                               \
         NULL)                                                                           \
                                                                                         \
     macro("run",                                                                        \
@@ -2825,7 +2825,7 @@ static const char HelpUsage[] = "help [<text>"
         "change directory.",                                                            \
         "\ncd <path>\ncd /\ncd ..",                                                     \
         onChangeDirectory,                                                              \
-        autocompleteDirs,                                                               \
+        tabCompleteDirs,                                                                \
         NULL)                                                                           \
                                                                                         \
     macro("mkdir",                                                                      \
@@ -2853,8 +2853,8 @@ static const char HelpUsage[] = "help [<text>"
         "\nexport [" EXPORT_CMD_LIST(EXPORT_CMD_DEF) "...] "                            \
         "<file> [" EXPORT_KEYS_LIST(EXPORT_KEYS_DEF) "...]" ,                           \
         onExportCommand,                                                                \
-        autocompleteExport,                                                             \
-        autocompleteFiles)                                                              \
+        tabCompleteExport,                                                              \
+        tabCompleteFiles)                                                               \
                                                                                         \
     macro("import",                                                                     \
         NULL,                                                                           \
@@ -2862,15 +2862,15 @@ static const char HelpUsage[] = "help [<text>"
         "\nimport [" IMPORT_CMD_LIST(IMPORT_CMD_DEF) "...] "                            \
         "<file> [" IMPORT_KEYS_LIST(IMPORT_KEYS_DEF) "...]",                            \
         onImportCommand,                                                                \
-        autocompleteImport,                                                             \
-        autocompleteFiles)                                                              \
+        tabCompleteImport,                                                              \
+        tabCompleteFiles)                                                               \
                                                                                         \
     macro("del",                                                                        \
         NULL,                                                                           \
         "delete from the filesystem.",                                                  \
         "del <file|folder>",                                                            \
         onDelCommand,                                                                   \
-        autocompleteFilesAndDirs,                                                       \
+        tabCompleteFilesAndDirs,                                                        \
         NULL)                                                                           \
                                                                                         \
     macro("cls",                                                                        \
@@ -2896,7 +2896,7 @@ static const char HelpUsage[] = "help [<text>"
         "use `default` to edit default cart template.",                                 \
         "config [reset|default]",                                                       \
         onConfigCommand,                                                                \
-        autocompleteConfig,                                                             \
+        tabCompleteConfig,                                                              \
         NULL)                                                                           \
                                                                                         \
     macro("surf",                                                                       \
@@ -2921,13 +2921,13 @@ static struct Command
     const char* help;
     const char* usage;
     void(*handler)(Console*);
-    void(*autocomplete1)(AutocompleteData*);
-    void(*autocomplete2)(AutocompleteData*);
+    void(*tabComplete1)(TabCompleteData*);
+    void(*tabComplete2)(TabCompleteData*);
 
 } Commands[] =
 {
-#define COMMANDS_DEF(name, alt, help, usage, handler, autocomplete1, autocomplete2) \
-    {name, alt, help, usage, handler, autocomplete1, autocomplete2},
+#define COMMANDS_DEF(name, alt, help, usage, handler, tabComplete1, tabComplete2) \
+    {name, alt, help, usage, handler, tabComplete1, tabComplete2},
     COMMANDS_LIST(COMMANDS_DEF)
 #undef COMMANDS_DEF
 };
@@ -2953,22 +2953,22 @@ static struct ApiItem {const char* name; const char* def; const char* help;} Api
 
 typedef struct ApiItem ApiItem;
 
-static void autocompleteHelp(AutocompleteData* data)
+static void tabCompleteHelp(TabCompleteData* data)
 {
-#define HELP_CMD_DEF(name) addAutocompleteOption(data, #name);
+#define HELP_CMD_DEF(name) addTabCompleteOption(data, #name);
     HELP_CMD_LIST(HELP_CMD_DEF)
 #undef  HELP_CMD_DEF
 
     for(s32 i = 0; i < COUNT_OF(Commands); i++)
     {
-        addAutocompleteOption(data, Commands[i].name);
+        addTabCompleteOption(data, Commands[i].name);
     }
 
-#define TIC_API_DEF(name, def, help, ...) addAutocompleteOption(data, #name);
+#define TIC_API_DEF(name, def, help, ...) addTabCompleteOption(data, #name);
     API_LIST(TIC_API_DEF)
 #undef TIC_API_DEF
 
-    finishAutocomplete(data);
+    finishTabComplete(data);
 }
 
 
@@ -3220,8 +3220,8 @@ static void onExport_help(Console* console, const char* param, const char* name,
     }
 }
 
-AutocompleteData newAutocompleteData(Console* console, char* incompleteWord) {
-    AutocompleteData data = { console, .incompleteWord = incompleteWord };
+TabCompleteData newTabCompleteData(Console* console, char* incompleteWord) {
+    TabCompleteData data = { console, .incompleteWord = incompleteWord };
     data.options = malloc(CONSOLE_BUFFER_SCREEN);
     data.commonPrefix = malloc(CONSOLE_BUFFER_SCREEN);
     data.options[0] = '\0';
@@ -3237,7 +3237,7 @@ static void processConsoleTab(Console* console)
 
     if(param)
     {
-        // Autocomplete command's parameters.
+        // Tab-complete command's parameters.
         param++;
         char* secondParam = strchr(param, ' ');
         if (secondParam)
@@ -3255,14 +3255,14 @@ static void processConsoleTab(Console* console)
             if (commandMatches)
             {
                 if (secondParam) {
-                    if (Commands[i].autocomplete2) {
-                        AutocompleteData data = newAutocompleteData(console, secondParam);
-                        Commands[i].autocomplete2(&data);
+                    if (Commands[i].tabComplete2) {
+                        TabCompleteData data = newTabCompleteData(console, secondParam);
+                        Commands[i].tabComplete2(&data);
                     }
                 } else {
-                    if (Commands[i].autocomplete1) {
-                        AutocompleteData data = newAutocompleteData(console, param);
-                        Commands[i].autocomplete1(&data);
+                    if (Commands[i].tabComplete1) {
+                        TabCompleteData data = newTabCompleteData(console, param);
+                        Commands[i].tabComplete1(&data);
                     }
                 }
             }
@@ -3270,15 +3270,15 @@ static void processConsoleTab(Console* console)
     }
     else
     {
-        // Autocomplete commands.
-        AutocompleteData data = newAutocompleteData(console, input);
+        // Tab-complete commands.
+        TabCompleteData data = newTabCompleteData(console, input);
         for(s32 i = 0; i < COUNT_OF(Commands); i++)
         {
-            addAutocompleteOption(&data, Commands[i].name);
+            addTabCompleteOption(&data, Commands[i].name);
             if (Commands[i].alt)
-                addAutocompleteOption(&data, Commands[i].alt);
+                addTabCompleteOption(&data, Commands[i].alt);
         }
-        finishAutocomplete(&data);
+        finishTabComplete(&data);
     }
 }
 

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1180,32 +1180,29 @@ static void addAutocompleteOption(AutocompleteData* data, const char* option)
 {
     if (strstr(option, data->incompleteWord) == option)
     {
+        // Possibly reduce the common prefix of all possible options.
+        if (strlen(data->options) == 0)
+        {
+            // This is the first option to be added. Initialize the prefix.
+            strncpy(data->commonPrefix, option, CONSOLE_BUFFER_SCREEN);
+        }
+        else
+        {
+            // Only leave the longest common prefix.
+            char* tmpCommonPrefix = data->commonPrefix;
+            char* tmpOption = (char*) option;
+
+            while (*tmpCommonPrefix && *tmpOption && *tmpCommonPrefix == *tmpOption) {
+                tmpCommonPrefix++;
+                tmpOption++;
+            }
+
+            *tmpCommonPrefix = 0;
+        }
+
         // The option matches the incomplete word, add it to the list.
         strncat(data->options, option, CONSOLE_BUFFER_SCREEN);
         strncat(data->options, " ", CONSOLE_BUFFER_SCREEN);
-
-        // Possibly reduce the common prefix of all possible options.
-        if (strlen(data->incompleteWord) > 0)
-        {
-            if (strlen(data->commonPrefix) == 0)
-            {
-                // This is the first option to be added. Initialize the prefix.
-                strncpy(data->commonPrefix, option, CONSOLE_BUFFER_SCREEN);
-            }
-            else
-            {
-                // Only leave the longest common prefix.
-                char* tmpCommonPrefix = data->commonPrefix;
-                char* tmpOption = (char*) option;
-
-                while (*tmpCommonPrefix && *tmpOption && *tmpCommonPrefix == *tmpOption) {
-                    tmpCommonPrefix++;
-                    tmpOption++;
-                }
-
-                *tmpCommonPrefix = 0;
-            }
-        }
     }
 }
 

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2911,7 +2911,9 @@ static const char HelpUsage[] = "help [<text>"
         NULL,                                                                           \
         "show game menu where you can setup video, sound and input options.",           \
         NULL,                                                                           \
-        onGameMenuCommand)                                                              \
+        onGameMenuCommand,                                                              \
+        NULL,                                                                           \
+        NULL)                                                                           \
     ADDGET_FILE(macro)
 
 static struct Command

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1147,16 +1147,16 @@ typedef struct
 {
     Console* console;
     char* incompleteWord; // Original word that's being completed.
-    char options[CONSOLE_BUFFER_SIZE]; // Options to show to the user.
-    char commonPrefix[CONSOLE_BUFFER_SIZE]; // Common prefix of all options.
+    char options[CONSOLE_BUFFER_SCREEN]; // Options to show to the user.
+    char commonPrefix[CONSOLE_BUFFER_SCREEN]; // Common prefix of all options.
 } AutocompleteData;
 
 static void addAutocompleteOption(AutocompleteData* data, const char* option)
 {
     if (strstr(option, data->incompleteWord) == option)
     {
-        strncat(data->options, option, CONSOLE_BUFFER_SIZE);
-        strncat(data->options, " ", CONSOLE_BUFFER_SIZE);
+        strncat(data->options, option, CONSOLE_BUFFER_SCREEN);
+        strncat(data->options, " ", CONSOLE_BUFFER_SCREEN);
 
         // Possibly reduce the common prefix of all possible options.
         if (strlen(data->incompleteWord) > 0)
@@ -1164,7 +1164,7 @@ static void addAutocompleteOption(AutocompleteData* data, const char* option)
             if (strlen(data->commonPrefix) == 0)
             {
                 // This is the first option to be added. Initialize the prefix.
-                strncpy(data->commonPrefix, option, CONSOLE_BUFFER_SIZE);
+                strncpy(data->commonPrefix, option, CONSOLE_BUFFER_SCREEN);
             }
             else
             {
@@ -3178,8 +3178,8 @@ static void insertInputText(Console* console, const char* text)
 // Used to show autocomplete options, for example.
 static void provideHint(Console* console, const char* hint)
 {
-    char* input = malloc(CONSOLE_BUFFER_SIZE);
-    strncpy(input, console->input.text, CONSOLE_BUFFER_SIZE);
+    char* input = malloc(CONSOLE_BUFFER_SCREEN);
+    strncpy(input, console->input.text, CONSOLE_BUFFER_SCREEN);
 
     printLine(console);
     printBack(console, hint);


### PR DESCRIPTION
I'd appreciate code review/feedback/help on this! I'm building better tab-completion, which is aware of the different commands. It knows how to complete files, directories, help topics, commands, and the import/export types:

![vid22](https://user-images.githubusercontent.com/81277/153750601-5f2e764f-5a22-4c9c-b222-ab9ad28b714a.gif)

Implementation notes:

- Console commands get two callbacks for autocompleting their first/second option. Both can be null when they don't take parameters.
- An `AutocompleteData` struct keeps track of the word the user is trying to tab-complete, the options that have been gathered so far, as a string, and the longest common prefix of all options, in order to add it to the typed command later.
- An `addAutocompleteOption` adds a possible completion option to the struct.
- In the end `finishAutocomplete` is called to actually perform the tab-completion, its shows all options and expands the typed command.

Questions/things to do:

- [x] The code keeps track of the available options in a `char*` of size `CONSOLE_BUFFER_SIZE`. That seems excessive, but I'm not sure which other maximum size to pick?
- [ ] Would it be good to sort the available options? Is there already some code sorting string arrays in the codebase?
- [x] Why is other code dealing with `tic_fs_enum` using `MOVE` to pass the data object? I should probably do that, as well? But I don't understand why. -> it's an async function
- [x] When using `cd tic80.com` and `load w<tab>`, TIC-80 crashes in `addAutocompleteOption`. I guess this could be related. -> It was!
- [x] There are probably edge cases in finding the longest common prefix when completing from an empty string. Right now, line 1162 can't differentiate between not having seen any option, or the situation where options had nothing in common already. Would need an additional flag or something? -> Checking the list of options so far works!
- [ ] Looks like the Windows builds are failing right now.
    ```
    D:\a\TIC-80\TIC-80\src\studio\screens\console.c(3188): error C2065: 'incompleteWord': undeclared identifier [D:\a\TIC-80\TIC-80\build\tic80studio.vcxproj]
    D:\a\TIC-80\TIC-80\src\studio\screens\console.c(3188): error C2059: syntax error: ':' [D:\a\TIC-80\TIC-80\build\tic80studio.vcxproj]
    ```