### PR TITLE
Adjust scroll of console when a command spills to the next line.

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -327,7 +327,8 @@ static void scrollConsole(Console* console)
         console->cursor.pos.y--;
     }
 
-    s32 minScroll = console->cursor.pos.y - CONSOLE_BUFFER_HEIGHT + 1;
+    size_t inputLines = (console->cursor.pos.x + console->input.pos) / CONSOLE_BUFFER_WIDTH;
+    s32 minScroll = console->cursor.pos.y + inputLines - CONSOLE_BUFFER_HEIGHT + 1;
     if(console->scroll.pos < minScroll)
         console->scroll.pos = minScroll;
 }
@@ -3307,6 +3308,7 @@ static void processConsoleTab(Console* console)
         }
         finishTabComplete(&data);
     }
+    scrollConsole(console);
 }
 
 static void toUpperStr(char* str)


### PR DESCRIPTION
When we enter a command with many parameters in console, the input line may overflow to the next line often.  If this happened at the bottom of the screen, the screen should scroll up, or we cannot see what we are entering unless we explicitly scroll up using mouse.
I think this PR will fix the issue by adjusting the scroll.