### PR TITLE
Enable scrolling Code Editor by key-combinations like Ctrl-P and Ctrl-N.

### DIFF
--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -1626,11 +1626,9 @@ static void processKeyboard(Code* code)
                 goNextBookmark(code, code->src);
         }
     }
-    else usedKeybinding = false;
-
-
-    if(ctrl || alt)
+    else if(ctrl || alt)
     {
+        bool ctrlHandled = true;
         if(ctrl)
         {
             if(keyWasPressed(code->studio, tic_key_tab))        doTab(code, shift, ctrl);
@@ -1648,14 +1646,17 @@ static void processKeyboard(Code* code)
             else if(keyWasPressed(code->studio, tic_key_slash)) commentLine(code);
             else if(keyWasPressed(code->studio, tic_key_home))  goCodeHome(code);
             else if(keyWasPressed(code->studio, tic_key_end))   goCodeEnd(code);
-            else usedKeybinding = false;
+            else ctrlHandled = false;
         }
 
+        bool ctrlAltHandled = true;
         if(keyWasPressed(code->studio, tic_key_left))           leftWord(code);
         else if(keyWasPressed(code->studio, tic_key_right))     rightWord(code);
         else if(keyWasPressed(code->studio, tic_key_delete))    deleteWord(code);
         else if(keyWasPressed(code->studio, tic_key_backspace)) backspaceWord(code);
-        else usedKeybinding = false;
+        else ctrlAltHandled = false;
+
+        usedKeybinding = (ctrlHandled || ctrlAltHandled);
     }
     else
     {


### PR DESCRIPTION
In Code Editor, we can scroll the the code with cursor keys.
For example, if the cursor is at the end line of the screen and if we press down arrow key,
the code will scroll up.
We also can move the cursory by pressing several key-combinations like Ctrl-P, Ctrl-N, Ctrl-E, Alt-Left, Alt-Right.
On the other hand, the key-combinations does not scroll up/down.
This PR will enable the scrolling with the key-combinations.