### PR TITLE
Building on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Dd_m3LogOutput=0")
 
 if(UNIX AND NOT APPLE AND NOT EMSCRIPTEN AND NOT ANDROID AND NOT N3DS)
     set(LINUX TRUE)
+
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD")
+        set(FREEBSD TRUE)
+    endif()
 endif()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -436,9 +440,10 @@ macro(MACRO_CORE SCRIPT DEFINE BUILD_DEPRECATED)
 
     add_library(tic80core${SCRIPT} STATIC ${TIC80CORE_SRC})
 
-    # FreeBSD
-    target_include_directories(tic80core${SCRIPT} PRIVATE ${SYSROOT_PATH}/usr/local/include)
-    target_link_directories(tic80core${SCRIPT} PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+    if (FREEBSD)
+        target_include_directories(tic80core${SCRIPT} PRIVATE ${SYSROOT_PATH}/usr/local/include)
+        target_link_directories(tic80core${SCRIPT} PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+    endif()
 
     target_include_directories(tic80core${SCRIPT}
         PRIVATE
@@ -525,9 +530,10 @@ if(BUILD_SDL AND BUILD_PLAYER AND NOT RPI)
 
     add_executable(player-sdl WIN32 ${CMAKE_SOURCE_DIR}/src/system/sdl/player.c)
 
-    # FreeBSD
-    target_include_directories(player-sdl PRIVATE ${SYSROOT_PATH}/usr/local/include)
-    target_link_directories(player-sdl PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+    if (FREEBSD)
+        target_include_directories(player-sdl PRIVATE ${SYSROOT_PATH}/usr/local/include)
+        target_link_directories(player-sdl PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+    endif()
 
     target_include_directories(player-sdl PRIVATE
         ${THIRDPARTY_DIR}/sdl2/include
@@ -1045,9 +1051,10 @@ if(BUILD_SDL)
         target_compile_definitions(tic80 PRIVATE TOUCH_INPUT_SUPPORT)
     endif()
 
-    # FreeBSD
-    target_include_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/include)
-    target_link_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+    if (FREEBSD)
+        target_include_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/include)
+        target_link_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+    endif()
 
     if(RPI)
         target_include_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/include/SDL2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,10 @@ macro(MACRO_CORE SCRIPT DEFINE BUILD_DEPRECATED)
 
     add_library(tic80core${SCRIPT} STATIC ${TIC80CORE_SRC})
 
+    # FreeBSD
+    target_include_directories(tic80core${SCRIPT} PRIVATE ${SYSROOT_PATH}/usr/local/include)
+    target_link_directories(tic80core${SCRIPT} PRIVATE ${SYSROOT_PATH}/usr/local/lib)
+
     target_include_directories(tic80core${SCRIPT}
         PRIVATE
             ${THIRDPARTY_DIR}/moonscript
@@ -520,6 +524,10 @@ endif()
 if(BUILD_SDL AND BUILD_PLAYER AND NOT RPI)
 
     add_executable(player-sdl WIN32 ${CMAKE_SOURCE_DIR}/src/system/sdl/player.c)
+
+    # FreeBSD
+    target_include_directories(player-sdl PRIVATE ${SYSROOT_PATH}/usr/local/include)
+    target_link_directories(player-sdl PRIVATE ${SYSROOT_PATH}/usr/local/lib)
 
     target_include_directories(player-sdl PRIVATE
         ${THIRDPARTY_DIR}/sdl2/include
@@ -1036,6 +1044,10 @@ if(BUILD_SDL)
     if(BUILD_TOUCH_INPUT)
         target_compile_definitions(tic80 PRIVATE TOUCH_INPUT_SUPPORT)
     endif()
+
+    # FreeBSD
+    target_include_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/include)
+    target_link_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/lib)
 
     if(RPI)
         target_include_directories(tic80 PRIVATE ${SYSROOT_PATH}/usr/local/include/SDL2)

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ chmod +x ~/Applications/TIC80dev.app/MacOS/TIC80
 Make sure to update the absolute path to the tic80 binary in the script, or
 update the launch arguments.
 
+## FreeBSD
+run the following commands in the Terminal
+```
+sudo pkg install gcc git cmake ruby libglvnd libglu freeglut mesa-devel mesa-dri alsa-lib
+git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
+cmake ..
+make -j4
+```
+
 # Install instructions
 
 ## Linux

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ cmake ..
 make -j4
 ```
 
+Mesa looks for swrast_dri.so from the wrong path, so also symlink it:
+
+```
+sudo ln -s /usr/local/lib/dri/swrast_dri.so /usr/local/lib/dri-devel/
+```
+
 # Install instructions
 
 ## Linux


### PR DESCRIPTION
These instructions and changes allow to build the project on FreeBSD 13.0-RELEASE-p11.

I tested a few games, and everything seemed to work, including audio.
I could not find where the path to `swrast_dri.so` is defined, so I just added a note to the `README.md` about it.