### PR TITLE
Add metainfo and fix case typo in desktop category.

### DIFF
--- a/build/linux/com.tic80.TIC_80.metainfo.xml
+++ b/build/linux/com.tic80.TIC_80.metainfo.xml
@@ -10,15 +10,18 @@
         <p>
            TIC-80 is a free and open source fantasy computer for making, playing
            and sharing tiny games.
-
+        </p>
+        <p>
            With TIC-80 you get built-in tools for development: code, sprites, maps,
            sound editors and the command line, which is enough to create a mini
            retro game.
-
+        </p>
+        <p>
            Games are packaged into a cartridge file, which can be easily distributed.
            TIC-80 works on all popular platforms. This means your cartridge can be
            played in any device.
-
+        </p>
+        <p>
            To make a retro styled game, the whole process of creation and execution
            takes place under some technical limitations: 240x136 pixel display,
            16 color palette, 256 8x8 color sprites, 4 channel sound, etc.

--- a/build/linux/com.tic80.TIC_80.metainfo.xml
+++ b/build/linux/com.tic80.TIC_80.metainfo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <id>com.tic80.TIC_80</id>
+    <launchable type="desktop-id">com.tic80.TIC_80.desktop</launchable>
+    <name>TIC-80</name>
+    <summary>Fantasy computer for making, playing and sharing tiny games</summary>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>MIT</project_license>
+    <description>
+        <p>
+           TIC-80 is a free and open source fantasy computer for making, playing
+           and sharing tiny games.
+
+           With TIC-80 you get built-in tools for development: code, sprites, maps,
+           sound editors and the command line, which is enough to create a mini
+           retro game.
+
+           Games are packaged into a cartridge file, which can be easily distributed.
+           TIC-80 works on all popular platforms. This means your cartridge can be
+           played in any device.
+
+           To make a retro styled game, the whole process of creation and execution
+           takes place under some technical limitations: 240x136 pixel display,
+           16 color palette, 256 8x8 color sprites, 4 channel sound, etc.
+        </p>
+    </description>
+    <url type="homepage">https://tic80.com/</url>
+    <url type="help">https://github.com/nesbox/TIC-80/wiki</url>
+    <url type="bugtracker">https://github.com/nesbox/TIC-80/issues</url>
+    <developer_name>Vadim Grigoruk (Nesbox)</developer_name>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk0OC5wbmc=/original/MWImMk.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk0OS5wbmc=/original/4CvLUI.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk1MC5wbmc=/original/BXXpTd.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk1Mi5wbmc=/original/vQB%2F%2BB.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk1My5wbmc=/original/%2BgfNqb.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk1NC5wbmc=/original/Dde0yu.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://img.itch.zone/aW1hZ2UvODQxMTUvNDI5NDk1NS5wbmc=/original/ZsfgBO.png</image>
+        </screenshot>
+    </screenshots>
+    <content_rating type="oars-1.1"/>
+    <releases>
+        <release version="1.0.2164" date="2022-05-02">
+        </release>
+    </releases>
+</component>

--- a/build/linux/tic80.desktop.in
+++ b/build/linux/tic80.desktop.in
@@ -6,6 +6,6 @@ Exec=tic80 %U
 Icon=tic80
 Terminal=false
 Type=Application
-Categories=education
+Categories=Education
 MimeType=application/x-tic80-item;
 GenericName=TIC-80


### PR DESCRIPTION
Hi,
This PR adds metainfo file which contain information that might be useful to end user such as description, links, screenshots, etc. It is useful when TIC-80 is put is an app store such as Flathub for Linux which display these infos.
I name it as `com.tic80.TIC_80.metainfo.xml` so it would conform to reverse DNS scheme and dash is replace with underscore as recommended here:
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#file-naming

I change the `Categories=education` in desktop file to` Categories=Education` because it is case-sensitive as mention here: 
https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry

I would also like to submit TIC-80 to Flathub, which allow linux user to install it very easily, let me know what you think.
https://flathub.org/home
Thanks.