### PR TITLE
Fix loading full-size BINARY chunks

### DIFF
--- a/src/cart.c
+++ b/src/cart.c
@@ -77,7 +77,7 @@ static const u8 Waveforms[] = {0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0
 
 static s32 chunkSize(const Chunk* chunk)
 {
-    return chunk->size == 0 && chunk->type == CHUNK_CODE ? TIC_BANK_SIZE : retro_le_to_cpu16(chunk->size);
+    return chunk->size == 0 && (chunk->type == CHUNK_CODE || chunk->type == CHUNK_BINARY) ? TIC_BANK_SIZE : retro_le_to_cpu16(chunk->size);
 }
 
 void tic_cart_load(tic_cartridge* cart, const u8* buffer, s32 size)


### PR DESCRIPTION
An old note on the wiki mentions a bug that occurred when saving and loading a 65536 byte `CODE` chunk, and this has since been fixed. The bug also applies to `BINARY` chunks, so I've extended the original fix to cover those as well.