### PR TITLE
Improve the Zig template

### DIFF
--- a/templates/zig/README.md
+++ b/templates/zig/README.md
@@ -1,6 +1,6 @@
 # ZIG Starter Project Template
 
-This is a ZIG / TIC-80 starter template.  To build it:
+This is a ZIG / TIC-80 starter template.  To build it, ensure you have a recent development release of Zig 0.10, then run:
 
 ```
 zig build

--- a/templates/zig/src/main.zig
+++ b/templates/zig/src/main.zig
@@ -1,34 +1,32 @@
 const tic = @import("tic80.zig");
 
 const TICGuy = struct {
-    x : i32 = 96,
-    y : i32 = 24,
+    x: i32 = 96,
+    y: i32 = 24,
 };
 
-var t : u16 = 0;
-var mascot : TICGuy = .{};
+var t: u16 = 0;
+var mascot: TICGuy = .{};
 
-export fn BOOT() void {
-}
+export fn BOOT() void {}
 
 export fn TIC() void {
     if (tic.btn(0)) {
         mascot.y -= 1;
-    } 
+    }
     if (tic.btn(1)) {
-        mascot.y +=1;
-    } 
+        mascot.y += 1;
+    }
     if (tic.btn(2)) {
         mascot.x -= 1;
-    } 
+    }
     if (tic.btn(3)) {
         mascot.x += 1;
-    } 
+    }
 
     tic.cls(13);
-    tic.spr(@as(i32, 1+t%60/30*2),mascot.x,mascot.y,.{.w=2, .h=2, .transparent=&.{14}, .scale=3});
+    tic.spr(@as(i32, 1 + t % 60 / 30 * 2), mascot.x, mascot.y, .{ .w = 2, .h = 2, .transparent = &.{14}, .scale = 3 });
     _ = tic.print("HELLO WORLD!", 84, 84, .{});
-    
+
     t += 1;
 }
-

--- a/templates/zig/src/main.zig
+++ b/templates/zig/src/main.zig
@@ -12,27 +12,23 @@ export fn BOOT() void {
 }
 
 export fn TIC() void {
-    if (tic.btn(0) != 0) {
+    if (tic.btn(0)) {
         mascot.y -= 1;
     } 
-    if (tic.btn(1) != 0) {
+    if (tic.btn(1)) {
         mascot.y +=1;
     } 
-    if (tic.btn(2) != 0) {
+    if (tic.btn(2)) {
         mascot.x -= 1;
     } 
-    if (tic.btn(3) != 0) {
+    if (tic.btn(3)) {
         mascot.x += 1;
     } 
 
     tic.cls(13);
-    var trans_color = [_]u8 {14};
-    tic.spr(@as(i32, 1+t%60/30*2),mascot.x,mascot.y,&trans_color,1,3,0,0,2,2);
-    _ = tic.print("HELLO WORLD!", 84, 84, 15, true, 1, false);
-
-    // cls(13)
-    // spr()
-    // print("HELLO WORLD!",84,84)
+    tic.spr(@as(i32, 1+t%60/30*2),mascot.x,mascot.y,.{.w=2, .h=2, .transparent=&.{14}, .scale=3});
+    _ = tic.print("HELLO WORLD!", 84, 84, .{});
+    
     t += 1;
 }
 

--- a/templates/zig/src/tic80.zig
+++ b/templates/zig/src/tic80.zig
@@ -210,7 +210,7 @@ const MapArgs = struct {
     h: i32 = 17,
     sx: i32 = 0,
     sy: i32 = 0,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     scale: u8 = 1,
     remap: i32 = -1, // TODO
 };
@@ -249,7 +249,7 @@ pub const Rotate = enum(u2) {
 const SpriteArgs = struct {
     w: i32 = 1,
     h: i32 = 1,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     scale: u8 = 1,
     flip: Flip = Flip.no,
     rotate: Rotate = Rotate.no,
@@ -269,7 +269,7 @@ pub const trib = raw.trib;
 
 const TextriArgs = struct {
     texture_source : TextureSource = TextureSource.TILES,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     z1 : f32 = 0,
     z2 : f32 = 0,
     z3 : f32 = 0,
@@ -293,7 +293,7 @@ const PrintArgs = struct {
 };
 
 const FontArgs = struct {
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     char_width: u8, 
     char_height: u8,
     fixed: bool = false,


### PR DESCRIPTION
As mentioned in https://github.com/nesbox/TIC-80/issues/1784#issuecomment-1171940804, I found a few problems with the current Zig template.

With this PR, there is no longer an example of using the raw API, as I couldn't come up with a suitable structure that supported multiple examples without duplicating tic80.zig. I don't think this is a major issue though, as I imagine most users of the WASM templates will use the wrappers anyway.