### PR TITLE
Add receiving intent of ACTION_SEND for Android.

### DIFF
--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -82,10 +82,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
             <!-- Let Android know that we can handle some USB devices and should receive this event -->
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>
+
             <!-- Drop file event -->
             <!--
             <intent-filter>
@@ -94,6 +96,15 @@
                 <data android:mimeType="*/*" />
             </intent-filter>
             -->
+        </activity>
+        <activity android:name=".TICFileReceiver"
+            android:theme="@android:style/Theme.Translucent"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*"/>
+            </intent-filter>
         </activity>
 
         <provider

--- a/build/android/app/src/main/java/com/nesbox/tic/TICFileReceiver.java
+++ b/build/android/app/src/main/java/com/nesbox/tic/TICFileReceiver.java
@@ -1,0 +1,116 @@
+package com.nesbox.tic;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class TICFileReceiver extends Activity {
+    private final static String TAG = "TICFileReceiver";
+    private final static String UserDirName = "TIC-80";
+    private static File UserDirectory;
+
+    @Override
+    protected void onStart()
+    {
+        super.onStart();
+        Log.v(TAG, "onStart");
+
+        /*
+           The function SDL_AndroidGetExternalStoragePath() uses
+           Context::getExternalFilesDir() to get the base directory of TIC-80.
+           When we change it, we also should fix below.
+         */
+        final File baseDir = getApplicationContext().getExternalFilesDir(null);
+        UserDirectory = new File(baseDir, UserDirName);
+
+        final Intent intent = getIntent();
+        if (intent == null) return;
+        final String action = intent.getAction();
+        final String type = intent.getType();
+
+        if (action.equals(Intent.ACTION_SEND) && type != null) {
+            Log.v(TAG, "received intent of type " + type);
+            Uri fileUri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+            if (fileUri != null) {
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        TICFileReceiver.this.finish();
+                    }
+                };
+                final String fileName = SaveFile(fileUri);
+                AlertDialog.Builder builder = new AlertDialog.Builder(this)
+                        .setTitle("TIC-80")
+                        .setPositiveButton("OK", listener);
+                if (fileName != null)
+                    builder.setMessage("File " + fileName + " is saved to user home directory.");
+                else
+                    builder.setMessage("Failed to save file.");
+                builder.create().show();
+            }
+        }
+    }
+
+    private String SaveFile(Uri uri) {
+        final Context context = getApplicationContext();
+        final String scheme = uri.getScheme();
+
+        String path = null;
+        if ("file".equals(scheme)) {
+            path = uri.getPath();
+        } else if("content".equals(scheme)) {
+            ContentResolver contentResolver = context.getContentResolver();
+            Cursor cursor = contentResolver.query(uri, new String[] { MediaStore.MediaColumns.DATA }, null, null, null);
+            if (cursor != null) {
+                cursor.moveToFirst();
+                path = cursor.getString(0);
+                cursor.close();
+            }
+        }
+        if (path == null) return null;
+        final File srcFile = new File(path);
+
+        final String baseFileName = srcFile.getName();
+        File dstFile = new File(UserDirectory, baseFileName);
+        int noConflictIndex = 1;
+        while (dstFile.exists())
+            dstFile = new File(UserDirectory, baseFileName + "_" + noConflictIndex++);
+        if (Copy(uri, dstFile))
+            return dstFile.getName();
+        else
+            return null;
+    }
+
+    private boolean Copy(Uri src, File dst) {
+        final int CopyBufferLength = 1024;
+        ContentResolver resolver = getApplicationContext().getContentResolver();
+        try (InputStream in = resolver.openInputStream(src)) {
+            try (OutputStream out = new FileOutputStream(dst)) {
+                // Transfer bytes from in to out
+                byte[] buf = new byte[CopyBufferLength];
+                int len;
+                while ((len = in.read(buf)) > 0) {
+                    out.write(buf, 0, len);
+                }
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Copying file failed. \n" + e.getMessage());
+            return false;
+        }
+        Log.v(TAG, "Saved file to " + dst.getPath());
+        return true;
+    }
+}


### PR DESCRIPTION
In Android 11 and later, file access from the other app got strict.  Though the PR #1998 enabled to edit exiting file in the home directory of TIC-80, we cannot still put files (PNG files and source code files) from outside of TIC-80.
This PR will enable to place such files in the directory by using intent ACTION_SEND.
![Screenshot_20220807-204929](https://user-images.githubusercontent.com/1162708/183289624-e2b39b39-2834-4912-9d5a-eb214f171b50.png)
![Screenshot_20220807-204941](https://user-images.githubusercontent.com/1162708/183289628-33525399-e737-4b9b-9d6d-fb48e89365b0.png)
The first screenshot is of "Files of Google" app, and the second one is of dialog of TIC-80 when receiving a file.
I confirmed that the app can send both a PNG and a Ruby source code to TIC-80, and that "Google Photo" app can also send a PNG.
I expect this PR might solve #1540 combining with #1998.