### PR TITLE
override some scale settings; finer-grained SDL init

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -2367,7 +2367,7 @@ bool studio_alive(Studio* studio)
     return studio->alive;
 }
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder)
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale)
 {
     setbuf(stdout, NULL);
 
@@ -2483,6 +2483,13 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
     tic_fs_makedir(studio->fs, TIC_LOCAL_VERSION);
     
     initConfig(studio->config, studio, studio->fs);
+
+    if (studio->config->data.uiScale > maxscale)
+    {
+        printf("Overriding specified uiScale of %i; the maximum your screen will accommodate is %i", studio->config->data.uiScale, maxscale);
+        studio->config->data.uiScale = maxscale;
+    }
+
     initStart(studio->start, studio, args.cart);
     initRunMode(studio);
 

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -149,7 +149,7 @@ void studio_exit(Studio* studio);
 void studio_delete(Studio* studio);
 const StudioConfig* studio_config(Studio* studio);
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder);
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale);
 
 #ifdef __cplusplus
 }

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -382,7 +382,7 @@ TShutdownMode Run(void)
         char* argv[] = { &arg0[0], NULL };
         int argc = 1;
         malloc(88);
-        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80");
+        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX);
         malloc(99);
 
     }
@@ -394,7 +394,7 @@ TShutdownMode Run(void)
         char* argv[] = { &arg0[0], &arg1[0], NULL };
         int argc = 2;
         dbg("Without keyboard\n");
-        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80");
+        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX);
     }
     dbg("studio_create OK\n");
 

--- a/src/system/n3ds/main.c
+++ b/src/system/n3ds/main.c
@@ -570,7 +570,7 @@ int main(int argc, char **argv) {
     n3ds_draw_init();
     n3ds_keyboard_init(&platform.keyboard);
 
-    platform.studio = studio_create(argc_used, argv_used, AUDIO_FREQ, TIC80_PIXEL_COLOR_ABGR8888, "./");
+    platform.studio = studio_create(argc_used, argv_used, AUDIO_FREQ, TIC80_PIXEL_COLOR_ABGR8888, "./", INT32_MAX);
 
     n3ds_sound_init(AUDIO_FREQ);
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1662,10 +1662,62 @@ static void emsGpuTick()
 
 #endif
 
+s32 determineMaximumScale()
+{
+    SDL_DisplayMode current;
+    int result = SDL_GetCurrentDisplayMode(0, &current);
+    s32 maxScale;
+
+    if (result != 0)
+    {
+        SDL_Log("Unable to SDL_GetCurrentDisplayMode: %s", SDL_GetError());
+        return INT32_MAX;
+    }
+
+    int maxScaleByW = current.w / TIC80_WIDTH;
+    int maxScaleByH = current.h / TIC80_HEIGHT;
+
+    if (maxScaleByW < maxScaleByW)
+    {
+        maxScale = maxScaleByW;
+    }
+    else
+    {
+        maxScale = maxScaleByH;
+    }
+
+    if (maxScale <= 1)
+    {
+        return 1;
+    }
+    else
+    {
+        return maxScale;
+    }
+}
+
 static s32 start(s32 argc, char **argv, const char* folder)
 {
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
-    platform.studio = studio_create(argc, argv, TIC80_SAMPLERATE, SCREEN_FORMAT, folder);
+    int result = SDL_Init(SDL_INIT_VIDEO);
+    if (result != 0)
+    {
+        SDL_Log("Unable to initialize SDL Video: %i, %s\n", result, SDL_GetError());
+        return result;
+    }
+
+    result = SDL_Init(SDL_INIT_AUDIO);
+    if (result != 0)
+    {
+        SDL_Log("Unable to initialize SDL Audio: %i, %s\n", result, SDL_GetError());
+    }
+
+    result = SDL_Init(SDL_INIT_JOYSTICK);
+    if (result != 0)
+    {
+        SDL_Log("Unable to initialize SDL Joystick: %i, %s\n", result, SDL_GetError());
+    }
+
+    platform.studio = studio_create(argc, argv, TIC80_SAMPLERATE, SCREEN_FORMAT, folder, determineMaximumScale());
 
     SCOPE(studio_delete(platform.studio))
     {

--- a/src/system/sokol/sokol.c
+++ b/src/system/sokol/sokol.c
@@ -404,7 +404,7 @@ sapp_desc sokol_main(s32 argc, char* argv[])
     platform.audio.desc.num_channels = TIC80_SAMPLE_CHANNELS;
     saudio_setup(&platform.audio.desc);
 
-    platform.studio = studio_create(argc, argv, saudio_sample_rate(), TIC80_PIXEL_COLOR_RGBA8888, "./");
+    platform.studio = studio_create(argc, argv, saudio_sample_rate(), TIC80_PIXEL_COLOR_RGBA8888, "./", INT32_MAX);
 
     if(studio_config(platform.studio)->cli)
     {


### PR DESCRIPTION
# Problem

TIC-80's uiScale currently defaults to 4. This turns out to be a poor choice for everybody's favorite maybe-still-supported platform, the PocketC.H.I.P., which lacks a screen large enough to accommodate it.

For whatever reason (maybe [issue 1904](https://github.com/nesbox/TIC-80/issues/1904)?), recent TIC-80 builds also perform very badly at scale 4 on the PocketC.H.I.P., taking more than a minute to start up and then missing many keystrokes.

![misframed](https://user-images.githubusercontent.com/845061/184465425-1fb26132-fe92-4573-8c49-b090d30eccb4.jpg)

I recorded the image above after twice failing to "exit". Note that the cursor is not visible.

Additionally, sound is currently broken for TIC-80 on the PocketC.H.I.P. (but not for other SDL2 applications.) That is not a big problem by itself, but will complicate the implementation of a screen-framing fix slightly.

# Solution

A sophisticated user can circumvent the screen-framing problem on PocketC.H.I.P. by explicitly reconfiguring uiScale to a lower value. This pull request seeks to address the problem (and indirectly, also the worst of the performance issues) for all PocketC.H.I.P. users by conditionally overriding the uiScale setting, without prompting. Here's how:

   1. Attempt to check the screen bounds with SDL2 on startup. If they are reported, wait until defaults have been applied and file configuration has been loaded. Then, if screen bounds were reported, determine whether the prescribed uiScale would fit. If they would not, reduce uiScreen to the largest agreeable value. Note that the user will still be permitted to specify any scale they want (without a fail-safe) from the command line.
   1. Currently, TIC-80 attempts to initialize all SDL2 subsystems in tandem. Because the sound is broken, this initialization technically fails. That failure seems to compromise SDL2's ability (at least immediately) to report on screen bounds. The workaround is to initialize SDL2 subsystems separately. If the video subsystem fails to initialize, report the problem and quit immediately, because there's no chance TIC-80 will be able to perform productive work. If the sound (or joystick) subsystem fails to initialize, report the problem but keep going.

I have tested this successfully on Ubuntu 20.04.4 and of course on the PocketC.H.I.P., whose new effective default uiScale of 2 is still somewhat slow, but no longer accompanied by lots of missed keystrokes.

I expect most systems should see no change from this pull request, but I can imagine a few others (smartwatches, LED boards, etc.) for which it might be useful.

Feel free to repurpose code from this pull request if that would be more convenient than merging all of it.