### PR TITLE
Support fn+enter alias for insert on mac keyboards

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1046,6 +1046,10 @@ static void handleKeydown(SDL_Keycode keycode, bool down, bool* state)
 #if defined(__TIC_ANDROID__)
     if(keycode == SDLK_AC_BACK)
         state[tic_key_escape] = down;
+#elif defined(__TIC_MACOSX__)
+    // SDLK_KP_ENTER is the equivalent of fn+enter on a Macbook keyboard
+    if(keycode == SDLK_KP_ENTER)
+        state[tic_key_insert] = down;
 #endif
 }
 


### PR DESCRIPTION
The problem as it stands, there's no way to emulate an insert press on a Macbook keyboard, which makes composing music on the TIC-80 a little tricky. 

fn+backspace works fine as 'delete', but support for fn+enter is sporadic at best and for some reason it is equivalent to SDLK_KP_ENTER. So, this change just enables fn+enter as an insert keypress on Mac versions of the application.