### PR TITLE
(fix) fix `time()` API call - revert the `clock()` changes

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -44,7 +44,9 @@ typedef struct
     ErrorOutput error;
     ExitCallback exit;
     
-    clock_t start;
+    u64 (*counter)(void*);
+    u64 (*freq)(void*);
+    u64 start;
 
     void* data;
 } tic_tick_data;

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -204,7 +204,7 @@ void tic_api_sync(tic_mem* tic, u32 mask, s32 bank, bool toCart)
 double tic_api_time(tic_mem* memory)
 {
     tic_core* core = (tic_core*)memory;
-    return (clock() - core->data->start) * 1000.0 / CLOCKS_PER_SEC;
+    return (double)(core->data->counter(core->data->data) - core->data->start) * 1000.0 / core->data->freq(core->data->data);
 }
 
 s32 tic_api_tstamp(tic_mem* memory)
@@ -459,7 +459,7 @@ void tic_core_tick(tic_mem* tic, tic_tick_data* data)
                 tic->input.keyboard = 1;
             else tic->input.data = -1;  // default is all enabled
 
-            data->start = clock();
+            data->start = data->counter(core->data->data);
 
             // TODO: does where to fetch code from need to be a config option so this isn't hard
             // coded for just a single langage? perhaps change it later when we have a second script
@@ -499,7 +499,7 @@ void tic_core_pause(tic_mem* memory)
     if (core->data)
     {
         core->pause.time.start = core->data->start;
-        core->pause.time.paused = clock();
+        core->pause.time.paused = core->data->counter(core->data->data);;
     }
 }
 
@@ -511,7 +511,7 @@ void tic_core_resume(tic_mem* memory)
     {
         memcpy(&core->state, &core->pause.state, sizeof(tic_core_state_data));
         memcpy(memory->ram, &core->pause.ram, sizeof(tic_ram));
-        core->data->start = core->pause.time.start + clock() - core->pause.time.paused;
+        core->data->start = core->pause.time.start + core->data->counter(core->data->data) - core->pause.time.paused;
         memory->input.data = core->pause.input;
     }
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -190,8 +190,8 @@ typedef struct
 
         struct
         {
-            clock_t start;
-            clock_t paused;
+            u64 start;
+            u64 paused;
         } time;
     } pause;
 

--- a/src/studio/screens/run.c
+++ b/src/studio/screens/run.c
@@ -123,6 +123,16 @@ static void tick(Run* run)
 #endif
 }
 
+static u64 getFreq(void* data)
+{
+    return tic_sys_freq_get();
+}
+
+static u64 getCounter(void* data)
+{
+    return tic_sys_counter_get();
+}
+
 void initRun(Run* run, Console* console, tic_fs* fs, Studio* studio)
 {
     *run = (Run)
@@ -139,6 +149,8 @@ void initRun(Run* run, Console* console, tic_fs* fs, Studio* studio)
             .trace = onTrace,
             .exit = onExit,
             .data = run,
+            .counter = getCounter,
+            .freq = getFreq
         },
     };
 

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -50,6 +50,8 @@ void    tic_sys_clipboard_set(const char* text);
 bool    tic_sys_clipboard_has();
 char*   tic_sys_clipboard_get();
 void    tic_sys_clipboard_free(const char* text);
+u64     tic_sys_counter_get();
+u64     tic_sys_freq_get();
 bool    tic_sys_fullscreen_get();
 void    tic_sys_fullscreen_set(bool value);
 void    tic_sys_message(const char* title, const char* message);

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -105,6 +105,16 @@ void tic_sys_clipboard_free(const char* text)
     free((void*)text);
 }
 
+u64 tic_sys_counter_get()
+{
+    return CTimer::Get()->GetTicks();
+}
+
+u64 tic_sys_freq_get()
+{
+    return HZ;
+}
+
 void tic_sys_fullscreen_set(bool value)
 {
 }

--- a/src/system/n3ds/main.c
+++ b/src/system/n3ds/main.c
@@ -181,6 +181,16 @@ void tic_sys_clipboard_free(const char* text)
     free((void*) text);
 }
 
+u64 tic_sys_counter_get()
+{
+    return svcGetSystemTick();
+}
+
+u64 tic_sys_freq_get()
+{
+    return SYSCLOCK_ARM11;
+}
+
 void tic_sys_fullscreen_set(bool value)
 {
 }

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1366,6 +1366,16 @@ void tic_sys_clipboard_free(const char* text)
     SDL_free((void*)text);
 }
 
+u64 tic_sys_counter_get()
+{
+    return SDL_GetPerformanceCounter();
+}
+
+u64 tic_sys_freq_get()
+{
+    return SDL_GetPerformanceFrequency();
+}
+
 bool tic_sys_fullscreen_get()
 {
 #if defined(CRT_SHADER_SUPPORT)

--- a/src/system/sokol/sokol.c
+++ b/src/system/sokol/sokol.c
@@ -80,6 +80,16 @@ void tic_sys_clipboard_free(const char* text)
     free((void*)text);
 }
 
+u64 tic_sys_counter_get()
+{
+    return stm_now();
+}
+
+u64 tic_sys_freq_get()
+{
+    return 1000000000;
+}
+
 void tic_sys_fullscreen_set(bool value)
 {
 }

--- a/src/tic.c
+++ b/src/tic.c
@@ -77,6 +77,7 @@ TIC80_API void tic80_tick(tic80* tic, tic80_input input)
         .trace = onTrace,
         .exit = onExit,
         .data = tic,
+        .start = 0
     };
 
     tic_core_tick_start(mem);


### PR DESCRIPTION
Resolves #1904.

Pretty much a revert of just the time/clock specific portions of 3dc2feacbeb2f1db8e7184eb548d381d7e690efc.  This returns to using per kernel functions for getting the system time and frequency.

<img width="1092" alt="Screen Shot 2022-12-11 at 11 19 57 AM" src="https://user-images.githubusercontent.com/6473/206915371-2506ee64-365e-4a9e-87fc-d3b58b964cc5.png">

Not exact (but I'm betting it's never been exact).