### PR TITLE
Fix segfault in player-sdl

### DIFF
--- a/include/tic80.h
+++ b/include/tic80.h
@@ -176,7 +176,7 @@ typedef struct
 
 TIC80_API tic80* tic80_create(s32 samplerate, tic80_pixel_color_format format);
 TIC80_API void tic80_load(tic80* tic, void* cart, s32 size);
-TIC80_API void tic80_tick(tic80* tic, tic80_input input);
+TIC80_API void tic80_tick(tic80* tic, tic80_input input, u64 (*counter)(), u64 (*freq)());
 TIC80_API void tic80_sound(tic80* tic);
 TIC80_API void tic80_delete(tic80* tic);
 

--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -806,7 +806,7 @@ void tic80_libretro_update(tic80* game)
 	tic80_libretro_update_keyboard(&state->input.keyboard);
 
 	// Update the game state.
-	tic80_tick(game, state->input);
+	tic80_tick(game, state->input, NULL, NULL);
 	tic80_sound(game);
 }
 

--- a/src/system/sdl/player.c
+++ b/src/system/sdl/player.c
@@ -48,6 +48,16 @@ static void onExit()
     state.quit = true;
 }
 
+static u64 tic_sys_counter_get()
+{
+    return SDL_GetPerformanceCounter();
+}
+
+static u64 tic_sys_freq_get()
+{
+    return SDL_GetPerformanceFrequency();
+}
+
 static void audioCallback(void* userdata, u8* stream, s32 len)
 {
     SDL_LockMutex(state.mutex);
@@ -164,7 +174,7 @@ s32 runCart(void* cart, s32 size)
 
             SDL_LockMutex(state.mutex);
             {
-                tic80_tick(tic, input);
+                tic80_tick(tic, input, tic_sys_counter_get, tic_sys_freq_get);
             }
             SDL_UnlockMutex(state.mutex);
 

--- a/src/tic.c
+++ b/src/tic.c
@@ -65,7 +65,7 @@ TIC80_API void tic80_load(tic80* tic, void* cart, s32 size)
     tic_api_reset(mem);
 }
 
-TIC80_API void tic80_tick(tic80* tic, tic80_input input)
+TIC80_API void tic80_tick(tic80* tic, tic80_input input, u64 (*counter)(), u64 (*freq)())
 {
     tic_mem* mem = (tic_mem*)tic;
 
@@ -77,13 +77,14 @@ TIC80_API void tic80_tick(tic80* tic, tic80_input input)
         .trace = onTrace,
         .exit = onExit,
         .data = tic,
-        .start = 0
+        .start = 0,
+        .counter = counter,
+        .freq = freq
     };
 
     tic_core_tick_start(mem);
     tic_core_tick(mem, &tickData);
     tic_core_tick_end(mem);
-
     tic_core_blit(mem);
 }
 


### PR DESCRIPTION
There is a bug in that tic80_tick doesnt set up the counter and freq callbacks properly which leads to a segfault.

This is probably not a good solution and it only works for player-sdl and the same issue is probably also in libretro which needs a proper fix too.