### PR TITLE
Language specific string delimiters

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -98,6 +98,7 @@ typedef struct
     const char* blockCommentEnd2;
     const char* blockStringStart;
     const char* blockStringEnd;
+    const char* stdStringStartEnd;
     const char* singleComment;
     const char* blockEnd;
 

--- a/src/api/lua.c
+++ b/src/api/lua.c
@@ -1818,6 +1818,7 @@ tic_script_config LuaSyntaxConfig =
     .singleComment      = "--",
     .blockStringStart   = "[[",
     .blockStringEnd     = "]]",
+    .stdStringStartEnd  = "\'\"",
     .blockEnd           = "end",
 
     .keywords           = LuaKeywords,

--- a/src/api/scheme.c
+++ b/src/api/scheme.c
@@ -1024,6 +1024,7 @@ tic_script_config SchemeSyntaxConfig =
     .singleComment          = ";;",
     .blockStringStart       = "\"",
     .blockStringEnd         = "\"",
+    .stdStringStartEnd      = "\"",
     .blockEnd               = NULL,
     .lang_isalnum           = scheme_isalnum,
     .api_keywords           = SchemeAPIKeywords,

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -595,7 +595,8 @@ start:
                 ptr += strlen(config->blockStringStart);
                 continue;
             }
-            else if(c == '"' || c == '\'')
+            else if ((config->stdStringStartEnd == NULL && (c == '"' || c == '\''))
+                     || (config->stdStringStartEnd != NULL && c != 0 && strchr(config->stdStringStartEnd, c)))
             {
                 blockStdStringStart = ptr;
                 ptr++;


### PR DESCRIPTION
Added 'stdStringStartEnd' option in tic_script_config to allow language to define their tokens to start/end strings.