### PR TITLE
Remove defaults for sx/sy in WASM map() function

### DIFF
--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -685,8 +685,6 @@ m3ApiRawFunction(wasmtic_map)
     if (y == -1) { y = 0; }
     if (w == -1) { w = 30; }
     if (h == -1) { h = 17; }
-    if (sx == -1) { sx = 0; }
-    if (sy == -1) { sy = 0; }
     if (scale == -1) { scale = 1; }
 
     tic_mem* tic = (tic_mem*)getWasmCore(runtime);


### PR DESCRIPTION
Solves https://github.com/nesbox/TIC-80/issues/2131.

This enables calling `map()` from the WASM API with sx or sy=-1, which is consistent with the Lua API. 

This does not break any of the current languages with templates (C, D, Rust, Zig) because arguments to `map()` cannot be omitted. However, for future languages which allow optional arguments, this may require workarounds at the language API level to get sx/sy=0 by default, if `m3ApiGetArg()` defaults to -1 on missing arguments (I do not understand how `m3ApiGetArg()` works, but the other defaults in wasm.c seem to assume a `int32_t` with a value of `-1` from `m3ApiGetArg()` means a missing argument).