### PR TITLE
Fix strict mode in default fennel cart.

### DIFF
--- a/src/api/fennel.c
+++ b/src/api/fennel.c
@@ -38,7 +38,7 @@ static const char* execute_fennel_src = FENNEL_CODE(
   debug.traceback = fennel.traceback
   local opts = {filename="game", allowedGlobals = false}
   local src = ...
-  if(src:find("\n;; strict: true")) then opts.allowedGlobals = nil end
+  if(src:find("\n;; +strict: *true")) then opts.allowedGlobals = nil end
   local ok, msg = pcall(fennel.eval, src, opts)
   if(not ok) then return msg end
 );


### PR DESCRIPTION
In 6171e0d0644ec68908e3478926a1b90b04cec3c1 a bug was introduced which disabled strict mode for newly-created Fennel carts, because strict mode is activated by the presence of ";; strict: true" in the cart's headers, but that commit broke it by adding an extra space after the colon.

See https://github.com/nesbox/TIC-80/blob/main/src/api/fennel.c#L41

If we could ignore backwards-compatibility, it would be better to fix the check so it would be tolerant of spaces.

However, since this bug was introduced before the release of 1.0.2164, carts may have been created using the stable release that have the extra spaces in the header but are not actually compatible with strict mode. So fixing the strict mode check would cause those carts to no longer be playable.

Rather than breaking backwards compatibility it's probably better to just fix the `new fennel` text to include the strict mode header with one space, so that at least new games can benefit from it.

However, if you think the risk of breakage is relatively low, I can change this so that the strict check will trigger even if there are multiple spaces. Strict mode is meant to catch typos by making it so that globals have to be referred to using _G; without strict mode, Fennel mimics the more runtime-error-prone behavior of Lua.