### PR TITLE
Bypass checks which disable Fennel friendly compiler errors.

### DIFF
--- a/src/api/fennel.c
+++ b/src/api/fennel.c
@@ -34,9 +34,10 @@
 #define FENNEL_CODE(...) #__VA_ARGS__
 
 static const char* execute_fennel_src = FENNEL_CODE(
+  io = { read = true }
   local fennel = require("fennel")
   debug.traceback = fennel.traceback
-  local opts = {filename="game", allowedGlobals = false}
+  local opts = {allowedGlobals = false, ["error-pinpoint"]={">>", "<<"}}
   local src = ...
   if(src:find("\n;; strict: true")) then opts.allowedGlobals = nil end
   local ok, msg = pcall(fennel.eval, src, opts)


### PR DESCRIPTION
In Fennel 1.3.0, it checks to see whether `_G.io.read` exists before proceeding with friendly compiler error messages, because it used to have to read the source from disk in order to provide these messages. That is no longer needed; it can use the source provided as a string, but the check for `_G.io.read` was accidentally left in place.

This change bypasses that check with a fake io table in order to get improved compiler error message and parse error reporting.

It should be removed once Fennel 1.3.1 or 1.4.0 is brought in.

We also set the error pinpointing characters to `>>` and `<<`. In normal Fennel, these use ANSI escape codes to change the color when writing to the terminal, but TIC-80 does not support these escape codes. I think it would be better if we could change the color of just the portion of the line which in being pinpointed, but I don't think that's possible right now, so the arrows can be used instead.

Here's a sample of how it looks in TIC, and one of how it looks in the terminal. The term version is a little nicer, but even so the TIC one is much better than what it was before.

![compile error in tic](https://p.hagelb.org/tic-compile-error.png)
![compile error in the terminal](https://p.hagelb.org/shell-compile-error.png)

(This looks like it's related to #1970 but that one is for runtime errors and this one is for compile-time errors.)