### PR TITLE
Added support for fget to return all flags

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -806,11 +806,12 @@ enum
                                                                                                                         \
                                                                                                                         \
     macro(fget,                                                                                                         \
-        "fget(sprite_id flag) -> bool",                                                                                 \
+        "fget(sprite_id flag) -> bool\nfget(sprite_id) -> flags",                                                       \
                                                                                                                         \
-        "Returns true if the specified flag of the sprite is set. See `fset()` for more details.",                      \
+        "Returns true if the specified flag of the sprite is set. If flag is not specified, returns a \n"               \
+        "bitfield of all the flags for that sprite. See `fset()` for more details.",                                    \
         2,                                                                                                              \
-        2,                                                                                                              \
+        1,                                                                                                              \
         0,                                                                                                              \
         bool,                                                                                                           \
         tic_mem*, s32 index, u8 flag)                                                                                   \
@@ -832,6 +833,8 @@ enum
 #define TIC_API_DEF(name, _, __, ___, ____, _____, ret, ...) ret tic_api_##name(__VA_ARGS__);
 TIC_API_LIST(TIC_API_DEF)
 #undef TIC_API_DEF
+
+u8 tic_api_fget_all(tic_mem*, s32 index); // alternate fset API forward declaration
 
 struct tic_mem
 {

--- a/src/api/janet.c
+++ b/src/api/janet.c
@@ -981,13 +981,21 @@ static Janet janet_keyp(int32_t argc, Janet* argv)
 
 static Janet janet_fget(int32_t argc, Janet* argv)
 {
-    janet_fixarity(argc, 2);
+    janet_arity(argc, 1, 2);
 
     s32 index = janet_getinteger(argv, 0);
-    u8 flag = janet_getinteger(argv, 1);
 
-    tic_mem* memory = (tic_mem*)getJanetMachine();
-    return janet_wrap_boolean(tic_api_fget(memory, index, flag));
+    if (argc >= 2)
+    {
+        u8 flag = janet_getinteger(argv, 1);
+        tic_mem* memory = (tic_mem*)getJanetMachine();
+        return janet_wrap_boolean(tic_api_fget(memory, index, flag));
+    }
+    else
+    {
+        tic_mem* memory = (tic_mem*)getJanetMachine();
+        return janet_wrap_integer(tic_api_fget_all(memory, index));
+    }
 }
 
 

--- a/src/api/js.c
+++ b/src/api/js.c
@@ -1011,13 +1011,20 @@ static duk_ret_t duk_fget(duk_context* duk)
     tic_mem* tic = (tic_mem*)getDukCore(duk);
 
     u32 index = duk_opt_int(duk, 0, 0);
-    u32 flag = duk_opt_int(duk, 1, 0);
+    u32 flag = duk_opt_int(duk, 1, 0xBADD);
 
-    bool value = tic_api_fget(tic, index, flag);
-
-    duk_push_boolean(duk, value);
-
-    return 1;
+    if (flag == 0xBADD)
+    {
+        u8 value = tic_api_fget_all(tic, index);
+        duk_push_int(duk, value);
+        return 1;
+    }
+    else
+    {
+        bool value = tic_api_fget(tic, index, flag);
+        duk_push_boolean(duk, value);
+        return 1;
+    }
 }
 
 static duk_ret_t duk_fset(duk_context* duk)

--- a/src/api/lua.c
+++ b/src/api/lua.c
@@ -1449,6 +1449,11 @@ static s32 lua_fget(lua_State* lua)
             lua_pushboolean(lua, tic_api_fget(tic, index, flag));
             return 1;
         }
+        else
+        {
+            lua_pushinteger(lua, tic_api_fget_all(tic, index));
+            return 1;
+        }
     }
 
     luaL_error(lua, "invalid params, fget(sprite,flag)\n");

--- a/src/api/mruby.c
+++ b/src/api/mruby.c
@@ -501,11 +501,18 @@ static mrb_value mrb_vbank(mrb_state* mrb, mrb_value self)
 static mrb_value mrb_fget(mrb_state* mrb, mrb_value self)
 {
     mrb_int index, flag;
-    mrb_get_args(mrb, "ii", &index, &flag);
+    mrb_int argc = mrb_get_args(mrb, "i|i", &index, &flag);
 
     tic_mem* tic = (tic_mem*)getMRubyMachine(mrb);
 
-    return mrb_bool_value(tic_api_fget(tic, index, flag));
+    if (argc >= 2)
+    {
+        return mrb_bool_value(tic_api_fget(tic, index, flag));
+    }
+    else
+    {
+        return mrb_fixnum_value(tic_api_fget_all(tic, index));
+    }
 }
 
 static mrb_value mrb_fset(mrb_state* mrb, mrb_value self)

--- a/src/api/scheme.c
+++ b/src/api/scheme.c
@@ -724,8 +724,16 @@ s7_pointer scheme_fget(s7_scheme* sc, s7_pointer args)
     // fget(sprite_id flag) -> bool
     tic_mem* tic = (tic_mem*)getSchemeCore(sc);
     const s32 sprite_id = s7_integer(s7_car(args));
-    const u8 flag = s7_integer(s7_cadr(args));
-    return s7_make_boolean(sc, tic_api_fget(tic, sprite_id, flag));
+    const int argn = s7_list_length(sc, args);
+    if (argn > 1)
+    {
+        const u8 flag = s7_integer(s7_cadr(args));
+        return s7_make_boolean(sc, tic_api_fget(tic, sprite_id, flag));
+    }
+    else
+    {
+        return s7_make_integer(sc, tic_api_fget_all(tic, sprite_id));
+    }
 }
 s7_pointer scheme_fset(s7_scheme* sc, s7_pointer args)
 {

--- a/src/api/squirrel.c
+++ b/src/api/squirrel.c
@@ -1471,6 +1471,11 @@ static SQInteger squirrel_fget(HSQUIRRELVM vm)
             sq_pushbool(vm, tic_api_fget(tic, index, flag));
             return 1;
         }
+        else
+        {
+            sq_pushinteger(vm, tic_api_fget_all(tic, index));
+            return 1;
+        }
     }
 
     sq_throwerror(vm, "invalid params, fget(index, flag) -> val\n");

--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -412,7 +412,7 @@ m3ApiRawFunction(wasmtic_keyp)
 
 m3ApiRawFunction(wasmtic_fget)
 {
-    m3ApiReturnType  (bool)
+    m3ApiReturnType  (int8_t)
 
     m3ApiGetArg      (int32_t, sprite_index);
     m3ApiGetArg      (int8_t, flag);

--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -419,7 +419,14 @@ m3ApiRawFunction(wasmtic_fget)
     
     tic_mem* tic = (tic_mem*)getWasmCore(runtime);
 
-    m3ApiReturn(tic_api_fget(tic, sprite_index, flag));
+    if (flag == -1)
+    {
+        m3ApiReturn(tic_api_fget_all(tic, sprite_index));
+    }
+    else
+    {
+        m3ApiReturn(tic_api_fget(tic, sprite_index, flag));
+    }
 
     m3ApiSuccess();
 }

--- a/src/api/wren.c
+++ b/src/api/wren.c
@@ -148,6 +148,7 @@ class TIC {\n\
     foreign static trace__(msg, color)\n\
     foreign static spr__(id, x, y, alpha_color, scale, flip, rotate)\n\
     foreign static fget(index, flag)\n\
+    foreign static fget(index)\n\
     foreign static fset(index, flag, val)\n\
     foreign static mgeti__(index)\n\
     static print(v) { TIC.print__(v.toString, 0, 0, 15, false, 1, false) }\n\
@@ -1412,6 +1413,11 @@ static void wren_fget(WrenVM* vm)
             wrenSetSlotBool(vm, 0, tic_api_fget(tic, index, flag));
             return;
         }
+        else
+        {
+            wrenSetSlotDouble(vm, 0, tic_api_fget_all(tic, index));
+            return;
+        }
     }
 
     wrenError(vm, "invalid params, fget(sprite,flag)\n");
@@ -1546,6 +1552,7 @@ static WrenForeignMethodFn foreignTicMethods(const char* signature)
     if (strcmp(signature, "static TIC.reset()"                  ) == 0) return wren_reset;
     if (strcmp(signature, "static TIC.exit()"                   ) == 0) return wren_exit;
     if (strcmp(signature, "static TIC.fget(_,_)"                ) == 0) return wren_fget;
+    if (strcmp(signature, "static TIC.fget(_)"                  ) == 0) return wren_fget;
     if (strcmp(signature, "static TIC.fset(_,_,_)"              ) == 0) return wren_fset;
 
     // internal functions

--- a/src/core/draw.c
+++ b/src/core/draw.c
@@ -450,6 +450,12 @@ bool tic_api_fget(tic_mem* memory, s32 index, u8 flag)
     return *getFlag(memory, index, flag) & (1 << flag);
 }
 
+u8 tic_api_fget_all(tic_mem* memory, s32 index)
+{
+    static const u8 dummyFlag = 0;
+    return *getFlag(memory, index, dummyFlag);
+}
+
 void tic_api_fset(tic_mem* memory, s32 index, u8 flag, bool value)
 {
     if (value)


### PR DESCRIPTION
A bitfield return when no flag is passed as paramater (similarly to the pico-8 api). I tested all languages except for wasm which I honestly don't know how to test.