### PR TITLE
Clamp input to animEffect()

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -914,7 +914,10 @@ static inline float animEffect(AnimEffect effect, float x)
 static void animTick(Movie* movie)
 {
     for(Anim* it = movie->items, *end = it + movie->count; it != end; ++it)
-        *it->value = lerp(it->start, it->end, animEffect(it->effect, (float)movie->tick / it->time));
+    {
+	float tick = (float)(movie->tick < it->time ? movie->tick : it->time);
+        *it->value = lerp(it->start, it->end, animEffect(it->effect, tick / it->time));
+    }
 }
 
 void processAnim(Movie* movie, void* data)


### PR DESCRIPTION
Fixes https://github.com/nesbox/TIC-80/issues/1913.

animEffect() seems to expect a value between 0 and 1, and #1913 is caused by the surf coverFade animation lerping past 1, which feeds values greater than 256 into fadePalette(), causing the flashing colors. This PR clamps movie ticks for each item ensuring animEffect won't receive values > 1.

This could create issues if any animation items rely on playing past their end. I didn't notice any while visually checking the editor and surf menu animations, but I could easily have missed something.

It might be better to move this clamp directly to the start of animEffect().

Alternative fixes for #1913 include clamping the fadePalette() value between 0 and 256, or stopping the animation at the right time.