### PR TITLE
n3ds: update to dkA release 60

### DIFF
--- a/build/n3ds/README.md
+++ b/build/n3ds/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* devkitARM (tested on release 54, please use latest) + the 3ds-dev meta package
+* devkitARM (tested on release 60, please use latest) + the 3ds-dev meta package
 * the following additional packages:
     * devkitpro-pkgbuild-helpers
     * 3ds-libpng
@@ -13,7 +13,7 @@
 
 ```
 cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/3ds.cmake -DN3DS=TRUE
+cmake .. -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/cmake/3DS.cmake -DN3DS=TRUE
 make
 ```
 

--- a/build/n3ds/elf_to_3dsx.sh
+++ b/build/n3ds/elf_to_3dsx.sh
@@ -2,4 +2,4 @@
 echo "[3DSX] Building metadata"
 ${DEVKITPRO}/tools/bin/smdhtool --create "TIC-80 tiny computer" "Fantasy computer for making, playing and sharing tiny games" "Nesbox" "n3ds/icon.png" tic80.smdh
 echo "[3DSX] Building binary"
-${DEVKITPRO}/tools/bin/3dsxtool bin/tic80_n3ds bin/tic80.3dsx --smdh=tic80.smdh --romfs=n3ds/romfs/
+${DEVKITPRO}/tools/bin/3dsxtool bin/tic80_n3ds.elf bin/tic80.3dsx --smdh=tic80.smdh --romfs=n3ds/romfs/

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -551,7 +551,11 @@ void tic_core_close(tic_mem* memory)
     blip_delete(core->blip.left);
     blip_delete(core->blip.right);
 
+#ifdef _3DS
+    linearFree(memory->product.screen);
+#else
     free(memory->product.screen);
+#endif
     free(memory->product.samples.buffer);
     free(core);
 }

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -34,7 +34,7 @@
 
 #include "tic_assert.h"
 
-#ifdef _3DS
+#ifdef __3DS__
 #include <3ds.h>
 #endif
 
@@ -551,7 +551,7 @@ void tic_core_close(tic_mem* memory)
     blip_delete(core->blip.left);
     blip_delete(core->blip.right);
 
-#ifdef _3DS
+#ifdef __3DS__
     linearFree(memory->product.screen);
 #else
     free(memory->product.screen);
@@ -742,7 +742,7 @@ tic_mem* tic_core_create(s32 samplerate, tic80_pixel_color_format format)
     core->samplerate = samplerate;
 
     memset(core->memory.ram, 0, sizeof(tic_ram));
-#ifdef _3DS
+#ifdef __3DS__
     // To feed texture data directly to the 3DS GPU, linearly allocated memory is required, which is
     // not guaranteed by malloc.
     // Additionally, allocate TIC80_FULLHEIGHT + 1 lines to minimize glitches in linear scaling mode.

--- a/src/studio/fs.c
+++ b/src/studio/fs.c
@@ -24,7 +24,7 @@
 #include "fs.h"
 #include "net.h"
 
-#if defined(BAREMETALPI) || defined(_3DS)
+#if defined(BAREMETALPI) || defined(__3DS__)
   #ifdef EN_DEBUG
     #define dbg(...) printf(__VA_ARGS__)
   #else

--- a/src/studio/net.c
+++ b/src/studio/net.c
@@ -144,7 +144,7 @@ void tic_net_close(tic_net* net)
     free(net);
 }
 
-#elif defined(_3DS)
+#elif defined(__3DS__)
 
 #include <3ds.h>
 

--- a/src/system/n3ds/main.c
+++ b/src/system/n3ds/main.c
@@ -163,7 +163,10 @@ void tic_sys_clipboard_set(const char* text)
         platform.clipboard = NULL;
     }
 
-    platform.clipboard = strdup(text);
+    if(text)
+    {
+        platform.clipboard = strdup(text);
+    }
 }
 
 bool tic_sys_clipboard_has()
@@ -576,7 +579,7 @@ int main(int argc, char **argv) {
     romfsInit();
 
     memset(&platform, 0, sizeof(platform));
-   
+
     n3ds_draw_init();
     n3ds_keyboard_init(&platform.keyboard);
 


### PR DESCRIPTION
~~This [patch](https://github.com/asiekierka/libctru/commit/89cc1484e8b00d7dbf843404c898215d2204d3e9) may be required for updating libctru in particular, due to what appears to be a regression introduced in 2020.~~ ~~The issue was [fixed upstream](https://github.com/devkitPro/libctru/commit/39a53c4fe554394224a72c0000c6243400f4dda5), so now it's a matter of waiting for a new release.~~ Fixed in libctru 2.2.2.