### PR TITLE
Fix bank parameter for music export

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2283,7 +2283,7 @@ static void onExport_music(Console* console, const char* type, const char* name,
     bool error = true;
 
     if(params.id >= 0 && params.id < MUSIC_TRACKS)
-        error = studioExportMusic(console->studio, params.id, filename) == NULL;
+        error = studioExportMusic(console->studio, params.id, params.bank, filename) == NULL;
 
     onFileExported(console, filename, !error);
 }

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -322,7 +322,7 @@ const char* studioExportSfx(Studio* studio, s32 index, const char* filename)
     return NULL;
 }
 
-const char* studioExportMusic(Studio* studio, s32 track, const char* filename)
+const char* studioExportMusic(Studio* studio, s32 track, s32 bank, const char* filename)
 {
     tic_mem* tic = studio->tic;
 
@@ -333,7 +333,16 @@ const char* studioExportMusic(Studio* studio, s32 track, const char* filename)
 #if TIC80_SAMPLE_CHANNELS == 2
         wave_enable_stereo();
 #endif
-
+#if defined(TIC80_PRO)
+        // chained = true in CLI. Set to false if want to use unchained
+        bool chained = studio->bank.chained;
+        if(chained)
+            memset(studio->bank.indexes, bank, sizeof studio->bank.indexes);
+        else
+            for(s32 i = 0; i < COUNT_OF(BankModes); i++)
+                if(BankModes[i] == TIC_MUSIC_MODE)
+                    studio->bank.indexes[i] = bank;
+#endif
         const tic_sfx* sfx = getSfxSrc(studio);
         const tic_music* music = getMusicSrc(studio);
 
@@ -341,7 +350,7 @@ const char* studioExportMusic(Studio* studio, s32 track, const char* filename)
         music2ram(tic->ram, music);
 
         const tic_music_state* state = &tic->ram->music_state;
-        const Music* editor = studio->banks.music[studio->bank.index.music];
+        const Music* editor = studio->banks.music[bank];
 
         tic_api_music(tic, track, -1, -1, false, editor->sustain, -1, -1);
 

--- a/src/studio/studio.h
+++ b/src/studio/studio.h
@@ -264,7 +264,7 @@ const StudioConfig* getConfig(Studio* studio);
 struct Start* getStartScreen(Studio* studio);
 struct Sprite* getSpriteEditor(Studio* studio);
 
-const char* studioExportMusic(Studio* studio, s32 track, const char* filename);
+const char* studioExportMusic(Studio* studio, s32 track, s32 bank, const char* filename);
 const char* studioExportSfx(Studio* studio, s32 sfx, const char* filename);
 
 tic_mem* getMemory(Studio* studio);


### PR DESCRIPTION
This commit fixes the bank parameter for exporting music (see issue #2190).

There is still some ambiguity present, because the exported music depends on the sfx bank as well. 

If bank chaining is on, the exported music uses the same sfx bank as the music bank.
If bank chaining is off, the exported music uses the sfx from the currently active sfx bank.

This could be fixed by introducing a `chained=true/false` parameter for the export.