### PR TITLE
Update Rust template to remove optimisation issue

### DIFF
--- a/templates/rust/Cargo.toml
+++ b/templates/rust/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 buddy-alloc = { version = "0.4.1", optional = true }
 
 [profile.release]
-opt-level = 0
 lto = true
 strip = true
 

--- a/templates/rust/README.md
+++ b/templates/rust/README.md
@@ -1,8 +1,7 @@
 # Rust Starter Project Template
 
 ## Important Note
-This template currently produces unoptimised builds. This is required due to TIC-80's memory layout placing data at the address 0, which Rust does not understand.
-If you aren't using direct framebuffer access, you should be able to use another level by changing the  `Cargo.toml`.
+Don't access memory directly. The optimiser will ruin attempts to do this, because Rust has no equivalent to C's `volatile` for direct access. Instead, use [`std::ptr::read_volatile`](https://doc.rust-lang.org/std/ptr/fn.read_volatile.html) and [`std::ptr::write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html).
 
 This is a Rust / TIC-80 starter template. Before using it, make sure you have installed the `wasm32-unknown-unknown` target using rustup:
 ```


### PR DESCRIPTION
Previously I configured the Rust template to disable optimisation due to issues with accessing memory directly. Instead, I think it's best to mention Rust's volatile read and write functions in the README. These allow reliable access to MMIO, so are suitable for memory access in TIC-80.