### PR TITLE
Update macOS build instructions to match included plist file

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ to create application icon for development version
 mkdir -p ~/Applications/TIC80dev.app/Contents/{MacOS,Resources}
 cp -f macosx/tic80.plist ~/Applications/TIC80dev.app/Contents/Info.plist
 cp -f macosx/tic80.icns ~/Applications/TIC80dev.app/Contents/Resources
-cat > ~/Applications/TIC80dev.app/Contents/MacOS/TIC80dev <<EOF
+cat > ~/Applications/TIC80dev.app/Contents/MacOS/tic80 <<EOF
 #!/bin/sh
 exec /Users/nesbox/projects/TIC-80/build/bin/tic80 --skip --scale 2 >/dev/null
 EOF


### PR DESCRIPTION
Following the instructions as-is leads to the plist executable pointing to a different executable than what is created from the heredoc script. Renaming the script file fixes it