### PR TITLE
Run key processing even when ctrl key is pressed

### DIFF
--- a/src/studio/editors/music.c
+++ b/src/studio/editors/music.c
@@ -1442,6 +1442,9 @@ static void processPianoKeyboard(Music* music)
 {
     tic_mem* tic = music->tic;
 
+    if(tic_api_key(tic, tic_key_ctrl) || tic_api_key(tic, tic_key_alt))
+        return;
+
     if(keyWasPressed(music->studio, tic_key_up)) music->piano.edit.y--;
     else if(keyWasPressed(music->studio, tic_key_down)) music->piano.edit.y++;
     else if(keyWasPressed(music->studio, tic_key_left)) music->piano.edit.x--;
@@ -1547,18 +1550,18 @@ static void processKeyboard(Music* music)
                     : playFrame(music))
                 : stopTrack(music);
         }
+    }
 
-        switch (music->tab)
-        {
-        case MUSIC_TRACKER_TAB:
-            music->tracker.edit.y >= 0 
-                ? processTrackerKeyboard(music)
-                : processPatternKeyboard(music);
-            break;
-        case MUSIC_PIANO_TAB:
-            processPianoKeyboard(music);
-            break;
-        }
+    switch (music->tab)
+    {
+    case MUSIC_TRACKER_TAB:
+        music->tracker.edit.y >= 0 
+            ? processTrackerKeyboard(music)
+            : processPatternKeyboard(music);
+        break;
+    case MUSIC_PIANO_TAB:
+        processPianoKeyboard(music);
+        break;
     }
 }
 


### PR DESCRIPTION
I noticed the keyboard shortcuts in the music tracker using the ctrl key did not work. Turns out the code was never called if ctrl was pressed.

Moved the key processing in music tracker out of the `!ctrl` scope.
Added early exit from `processPianoKeyboard()` if ctrl or alt keys are pressed, which mirrors the way it's done in `processPatternKeyboard()`.
