### PR TITLE
Remove whitespaces before colons in pythondemo.py

### DIFF
--- a/demos/pythondemo.py
+++ b/demos/pythondemo.py
@@ -10,27 +10,26 @@ t=0
 x=96
 y=24
 
-def TIC() :
-  global t
-  global x
-  global y
-  
-  if btn(0) : y-=1
-  if btn(1) : y+=1
-  if btn(2) : x-=1
-  if btn(3) : x+=1
-  
-  cls(13)
-  spr(
-    1+t%60//30*2,
-    x, y,
-    colorkey=14,
-    scale=3,
-    w=2, h=2
-  )
-  print("HELLO WORLD!", 84, 84)
-  t+=1
+def TIC():
+ global t
+ global x
+ global y
 
+ if btn(0): y-=1
+ if btn(1): y+=1
+ if btn(2): x-=1
+ if btn(3): x+=1
+
+ cls(13)
+ spr(
+  1+t%60//30*2,
+  x,y,
+  colorkey=14,
+  scale=3,
+  w=2,h=2
+ )
+ print("HELLO WORLD!",84,84)
+ t+=1
 
 # <TILES>
 # 001:eccccccccc888888caaaaaaaca888888cacccccccacc0ccccacc0ccccacc0ccc


### PR DESCRIPTION
This is the more common syntax and it is PEP 8 compliant.

Although PEP default indentation width is 4, the default indentation width of TIC-80 is 1, so this commit changes it to 1. As is typical for TIC-80's brevity, this commit removes spaces after commas as well.

https://peps.python.org/pep-0008/