### PR TITLE
fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -918,7 +918,7 @@ if(BUILD_DEMO_CARTS)
 
     endforeach(CART_FILE)
 
-    # we need to build these separatly combining both the project
+    # we need to build these separately combining both the project
     # and the external WASM binary chunk since projects do not
     # include BINARY chunks
 

--- a/build/baremetalpi/toolchain.cmake
+++ b/build/baremetalpi/toolchain.cmake
@@ -24,7 +24,7 @@ message("Crosscompiler path is ${BINUTILS_PATH}")
 get_filename_component(ARM_TOOLCHAIN_DIR ${BINUTILS_PATH} DIRECTORY)
 
 # removed squirrel language as it doesn't seem to compile under arm. Needs investigation.
-#    More investigation: Squirrel builds correcly but the linked give these kinds of error:
+#    More investigation: Squirrel builds correctly but the linked give these kinds of error:
 #    arm-none-eabi-ld: error: kernel8-32.elf uses VFP register arguments, ../../build/lib/libsquirrel.a(sqapi.cpp.obj) does not
 #    Even more investigation: turns out i was only setting CMAKE_C_FLAGS and not CMAKE_CXX_FLAGS. So C++ stuff was building without arm/rpi proper flags, VFP-related-stuff in particular.
 #    Now squirrel works.

--- a/demos/car.lua
+++ b/demos/car.lua
@@ -6,8 +6,8 @@
 point={x=0,y=0,z=300}
 fov=100
 mesh={} --    Table that contains all the 3D points
-polygon={} -- Table that contains all conections of 3D points to create triangle polygons, with their texture specified too
-zorder={} --  Tabe used to know the rendering order of the triangles
+polygon={} -- Table that contains all connections of 3D points to create triangle polygons, with their texture specified too
+zorder={} --  Table used to know the rendering order of the triangles
 rspeed=.1 --  Rotation speed, you can change it 
 tspeed=10 --  Translation speed, you can change it
 
@@ -147,7 +147,7 @@ function calculateMeshUV()
 	end
 end
 
--- I made this up but ot works... it gives the avarage of the depth of the three points of each triangle, it works good enough to know witch triangles to draw first (the further ones)
+-- I made this up but not works... it gives the average of the depth of the three points of each triangle, it works good enough to know witch triangles to draw first (the further ones)
 function calculateZOrder()
  m=mesh
  for i,p in pairs(polygon) do
@@ -156,7 +156,7 @@ function calculateZOrder()
 	end
 end
 
--- Once calcuated the zorder you need to update the zorder table with those values
+-- Once calculated the zorder you need to update the zorder table with those values
 -- Why do we need this values in another table? well... lua can sort this table and now we have the order in witch to draw the triangles
 function updateZOrder(polygon,zor)
  for i,z in pairs(zorder) do

--- a/demos/fire.lua
+++ b/demos/fire.lua
@@ -9,7 +9,7 @@ x=120
 y=120
 
 particle = {}
-palete = {14,9,6,3,10,15}
+palette = {14,9,6,3,10,15}
 
 function addParticle(x,y)
  local p = {}
@@ -30,7 +30,7 @@ function ticParticle()
 		p.t = p.t + 1
 		s = math.log(p.t / 2.0)
 		s2 = s/2.0
-		c = palete[math.ceil(p.t/70)]
+		c = palette[math.ceil(p.t/70)]
 	 p.x = p.x + p.dx
 		p.y = p.y + p.dy
 

--- a/demos/janetdemo.janet
+++ b/demos/janetdemo.janet
@@ -7,7 +7,7 @@
 # script: janet
 # strict:  true
 
-# Unlike other langauges, the tic80 API
+# Unlike other languages, the tic80 API
 # is provided as a module.
 (import tic80)
 

--- a/demos/palette.lua
+++ b/demos/palette.lua
@@ -1,6 +1,6 @@
 -- title:  palette demo
 -- author: Nesbox
--- desc:   how to switch palatte in runtime
+-- desc:   how to switch palette in runtime
 -- script: lua
 -- input:  gamepad
 

--- a/demos/quest.lua
+++ b/demos/quest.lua
@@ -912,7 +912,7 @@ end
 local p1,boss,golem1,golem2
 
 local function Init()
-	-- detect if run for the fisrt time
+	-- detect if run for the first time
 	if not firstRun then return end
 	firstRun=false
 	

--- a/include/tic80.h
+++ b/include/tic80.h
@@ -132,7 +132,7 @@ typedef struct
             u8 y;
         };
 
-        // releative values
+        // relative values
         struct
         {
             s8 rx;

--- a/src/api.h
+++ b/src/api.h
@@ -363,7 +363,7 @@ enum
         "The map can be up to 240 cells wide by 136 deep.\n"                                                            \
         "This function will draw the desired area of the map to a specified screen position.\n"                         \
         "For example, map(5,5,12,10,0,0) will draw a 12x10 section of the map, "                                        \
-        "starting from map co-ordinates (5,5) to screen position (0,0).\n"                                              \
+        "starting from map coordinates (5,5) to screen position (0,0).\n"                                              \
         "The map function's last parameter is a powerful callback function "                                            \
         "for changing how map cells (sprites) are drawn when map is called.\n"                                          \
         "It can be used to rotate, flip and replace sprites while the game is running.\n"                               \

--- a/src/api/python.c
+++ b/src/api/python.c
@@ -20,7 +20,7 @@ static bool setup_core(pkpy_vm* vm, tic_core* core)
     return true;
 }
 
-//index should be a postive index
+//index should be a positive index
 static int prepare_colorindex(pkpy_vm* vm, int index, u8 * buffer) 
 {
     if (pkpy_is_int(vm, index)) 

--- a/src/api/scheme.c
+++ b/src/api/scheme.c
@@ -916,7 +916,7 @@ static const char* const SchemeKeywords [] =
     "not", "number->string", "odd?", "even?", "zero?",
     "append", "list-ref", "assoc", "assq", "member", "memq", "memv",
     "tree-memq", "string?", "string-length", "character?",
-    "number?", "integer?", "real?", "rationnal?", "rationalize",
+    "number?", "integer?", "real?", "rational?", "rationalize",
     "numerator", "denominator", "random", "random-state",
     "random-state->list", "random-state?", "complex?",
     "real-part", "imag-part", "number->string", "vector?",

--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -32,7 +32,7 @@
 
 #include <ctype.h>
 
-// Avoid redefining u* ans s*
+// Avoid redefining u* and s*
 #define d_m3ShortTypesDefined 1
 typedef int8_t i8;
 typedef int16_t i16;
@@ -366,7 +366,7 @@ m3ApiRawFunction(wasmtic_btnp)
     tic_core* core = getWasmCore(runtime);
 
     // -1 is the "default" placeholder for index, hold, and period but the TIC side API
-    // knows this so we don't need to do any transation, we can just pass the -1 values
+    // knows this so we don't need to do any transaction, we can just pass the -1 values
     // straight thru 
 
     m3ApiReturn(tic_api_btnp((tic_mem *)core, index, hold, period));

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -486,7 +486,7 @@ void tic_core_tick(tic_mem* tic, tic_tick_data* data)
             data->start = data->counter(core->data->data);
 
             // TODO: does where to fetch code from need to be a config option so this isn't hard
-            // coded for just a single langage? perhaps change it later when we have a second script
+            // coded for just a single language? perhaps change it later when we have a second script
             // engine that uses BINARY?
             if (strcmp(config->name,"wasm")==0) {
                 code = tic->cart.binary.data;

--- a/src/core/sound.c
+++ b/src/core/sound.c
@@ -29,7 +29,7 @@
 
 #define ENVELOPE_FREQ_SCALE 2
 #define SECONDS_PER_MINUTE 60
-#define NOTES_PER_MUNUTE (TIC80_FRAMERATE / NOTES_PER_BEAT * SECONDS_PER_MINUTE)
+#define NOTES_PER_MINUTE (TIC80_FRAMERATE / NOTES_PER_BEAT * SECONDS_PER_MINUTE)
 #define PIANO_START 8
 
 static const u16 NoteFreqs[] = { 0x10, 0x11, 0x12, 0x13, 0x15, 0x16, 0x17, 0x18, 0x1a, 0x1c, 0x1d, 0x1f, 0x21, 0x23, 0x25, 0x27, 0x29, 0x2c, 0x2e, 0x31, 0x34, 0x37, 0x3a, 0x3e, 0x41, 0x45, 0x49, 0x4e, 0x52, 0x57, 0x5c, 0x62, 0x68, 0x6e, 0x75, 0x7b, 0x83, 0x8b, 0x93, 0x9c, 0xa5, 0xaf, 0xb9, 0xc4, 0xd0, 0xdc, 0xe9, 0xf7, 0x106, 0x115, 0x126, 0x137, 0x14a, 0x15d, 0x172, 0x188, 0x19f, 0x1b8, 0x1d2, 0x1ee, 0x20b, 0x22a, 0x24b, 0x26e, 0x293, 0x2ba, 0x2e4, 0x310, 0x33f, 0x370, 0x3a4, 0x3dc, 0x417, 0x455, 0x497, 0x4dd, 0x527, 0x575, 0x5c8, 0x620, 0x67d, 0x6e0, 0x749, 0x7b8, 0x82d, 0x8a9, 0x92d, 0x9b9, 0xa4d, 0xaea, 0xb90, 0xc40, 0xcfa, 0xdc0, 0xe91, 0xf6f, 0x105a, 0x1153, 0x125b, 0x1372, 0x149a, 0x15d4, 0x1720, 0x1880 };
@@ -43,15 +43,15 @@ static_assert(sizeof(tic_music_state) == 4,                         "tic_music_s
 
 static s32 getTempo(tic_core* core, const tic_track* track)
 {
-    return core->state.music.tempo < 0 
-        ? track->tempo + DEFAULT_TEMPO 
+    return core->state.music.tempo < 0
+        ? track->tempo + DEFAULT_TEMPO
         : core->state.music.tempo;
 }
 
 static s32 getSpeed(tic_core* core, const tic_track* track)
 {
-    return core->state.music.speed < 0 
-        ? track->speed + DEFAULT_SPEED 
+    return core->state.music.speed < 0
+        ? track->speed + DEFAULT_SPEED
         : core->state.music.speed;
 }
 
@@ -59,8 +59,8 @@ static s32 tick2row(tic_core* core, const tic_track* track, s32 tick)
 {
     // BPM = tempo * 6 / speed
     s32 speed = getSpeed(core, track);
-    return speed 
-        ? tick * getTempo(core, track) * DEFAULT_SPEED / speed / NOTES_PER_MUNUTE
+    return speed
+        ? tick * getTempo(core, track) * DEFAULT_SPEED / speed / NOTES_PER_MINUTE
         : 0;
 }
 
@@ -68,7 +68,7 @@ static s32 row2tick(tic_core* core, const tic_track* track, s32 row)
 {
     s32 tempo = getTempo(core, track);
     return tempo
-        ? row * getSpeed(core, track) * NOTES_PER_MUNUTE / tempo / DEFAULT_SPEED
+        ? row * getSpeed(core, track) * NOTES_PER_MINUTE / tempo / DEFAULT_SPEED
         : 0;
 }
 
@@ -118,7 +118,7 @@ static void runEnvelope(blip_buffer_t* blip, const tic_sound_register* reg, tic_
 
 static void runNoise(blip_buffer_t* blip, const tic_sound_register* reg, tic_sound_register_data* data, s32 end_time, u8 volume)
 {
-    // phase is noise LFSR, which must never be zero 
+    // phase is noise LFSR, which must never be zero
     if (data->phase == 0)
         data->phase = 1;
 
@@ -408,7 +408,7 @@ static void processMusic(tic_mem* memory)
             s32 note = channel->note;
             s32 pitch = 0;
 
-            // process chord commmand
+            // process chord command
             {
                 s32 chord[] =
                 {
@@ -420,7 +420,7 @@ static void processMusic(tic_mem* memory)
                 note += chord[cmdData->chord.tick % (cmdData->chord.note2 == 0 ? 2 : 3)];
             }
 
-            // process vibrato commmand
+            // process vibrato command
             if (cmdData->vibrato.period && cmdData->vibrato.depth)
             {
                 static const s32 VibData[] = { 0x0, 0x31f1, 0x61f8, 0x8e3a, 0xb505, 0xd4db, 0xec83, 0xfb15, 0x10000, 0xfb15, 0xec83, 0xd4db, 0xb505, 0x8e3a, 0x61f8, 0x31f1, 0x0, 0xffffce0f, 0xffff9e08, 0xffff71c6, 0xffff4afb, 0xffff2b25, 0xffff137d, 0xffff04eb, 0xffff0000, 0xffff04eb, 0xffff137d, 0xffff2b25, 0xffff4afb, 0xffff71c6, 0xffff9e08, 0xffffce0f };

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -63,7 +63,7 @@ static void packState(Code* code)
     }
 }
 
-//if pos_undo is true, we set the position to the first charcter
+//if pos_undo is true, we set the position to the first character
 //that is different between the current source and the state (wanted undo behavior)
 //otherwise we set the position to the stored location (wanted redo behavior)
 //in either case if no change was detected we do not change the position

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -130,7 +130,7 @@
     macro(id)                   \
     ALONE_KEY(macro)
 
-static const char* WelcomeText = 
+static const char* WelcomeText =
     "TIC-80 is a fantasy computer for making, playing and sharing tiny games.\n\n"
     "It has built-in tools for development: code, sprites, maps, sound editors and the command line, "
     "which is enough to create a mini retro game.\n"
@@ -139,7 +139,7 @@ static const char* WelcomeText =
     "To make a retro-style game, the whole creation process takes place under some technical limitations: "
     "240x136 pixels display, 16 color palette, 256 8x8 color sprites, 4 channel sound, etc.";
 
-static const struct SpecRow {const char* section; const char* info;} SpecText1[] = 
+static const struct SpecRow {const char* section; const char* info;} SpecText1[] =
 {
     {"DISPLAY", "240x136 pixels, 16 colors palette."},
     {"INPUT",   "4 gamepads with 8 buttons / mouse / keyboard."},
@@ -150,7 +150,7 @@ static const struct SpecRow {const char* section; const char* info;} SpecText1[]
     },
 };
 
-static const char* TermsText = 
+static const char* TermsText =
     "## Terms of Use\n"
     "- All cartridges posted on the " TIC_WEBSITE " website are the property of their authors.\n"
     "- Do not redistribute the cartridge without permission, directly from the author.\n"
@@ -162,7 +162,7 @@ static const char* TermsText =
     "We store only the user's email and password in encrypted form and will not transfer any personal "
     "information to third parties without explicit permission.";
 
-static const char* LicenseText = 
+static const char* LicenseText =
     "## MIT License\n"
     "\n"
     "Copyright (c) 2017-" TIC_VERSION_YEAR " Vadim Grigoruk @nesbox // grigoruk@gmail.com\n"
@@ -184,7 +184,7 @@ static const char* LicenseText =
     "OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE "
     "SOFTWARE.";
 
-static const struct StartupOption {const char* name; const char* help;} StartupOptions[] = 
+static const struct StartupOption {const char* name; const char* help;} StartupOptions[] =
 {
 #define CMD_PARAMS_DEF(name, ctype, type, post, help) {#name post, help},
     CMD_PARAMS_LIST(CMD_PARAMS_DEF)
@@ -347,7 +347,7 @@ static s32 cursorOffset(Console* console)
 static tic_point cursorPos(Console* console)
 {
     s32 offset = cursorOffset(console) + console->input.pos;
-    return (tic_point) 
+    return (tic_point)
     {
         offset % CONSOLE_BUFFER_WIDTH,
         offset / CONSOLE_BUFFER_WIDTH
@@ -408,7 +408,7 @@ static void consolePrintOffset(Console* console, const char* text, u8 color, s32
 
             if (console->cursor.pos.x >= CONSOLE_BUFFER_WIDTH)
                 nextLine(console);
-        }        
+        }
     }
 
     console->input.text = console->text + cursorOffset(console);
@@ -519,7 +519,7 @@ static void drawConsoleText(Console* console)
     {
         const char* start;
         const char* end;
-    } select = 
+    } select =
     {
         console->select.start,
         console->select.end
@@ -960,7 +960,7 @@ static void onLoadCommandConfirmed(Console* console)
                 } else {
                     printError(console, "\ncart loading error");
                 }
-                
+
 #endif
             }
         }
@@ -993,7 +993,7 @@ static void onConfirm(Studio* studio, bool yes, void* data)
 }
 
 static void confirmCommand(Console* console, const char** text, s32 rows, ConsoleConfirmCallback callback)
-{    
+{
     if(console->args.cli)
     {
         for(s32 i = 0; i < rows; i++)
@@ -1339,7 +1339,7 @@ static bool printFilename(const char* name, const char* title, const char* hash,
 
 static s32 casecmp(const char *str1, const char *str2)
 {
-    while (*str1 && *str2) 
+    while (*str1 && *str2)
     {
         if (tolower((u8) *str1) != tolower((u8) *str2))
             break;
@@ -1644,7 +1644,7 @@ static void onSurfCommand(Console* console)
 
 static void loadExternal(Console* console, const char* path)
 {
-    CommandDesc desc = 
+    CommandDesc desc =
     {
         .params = malloc(sizeof *desc.params),
         .count = 1,
@@ -1687,7 +1687,7 @@ static void onConfigCommand(Console* console)
     }
     else
     {
-        CommandDesc desc = 
+        CommandDesc desc =
         {
             .params = malloc(sizeof *desc.params),
             .count = 1,
@@ -1700,7 +1700,7 @@ static void onConfigCommand(Console* console)
 
         return;
     }
-   
+
     commandDone(console);
 }
 
@@ -1736,7 +1736,7 @@ static inline tic_bank* getBank(Console* console, s32 bank)
 
 static inline const tic_palette* getPalette(Console* console, s32 bank, s32 vbank)
 {
-    return vbank 
+    return vbank
         ? &getBank(console, bank)->palette.vbank1
         : &getBank(console, bank)->palette.vbank0;
 }
@@ -1751,11 +1751,11 @@ static void onImportTilesBase(Console* console, const char* name, const void* bu
     if(img.data) SCOPE(free(img.data))
     {
         const tic_palette* pal = getPalette(console, params.bank, params.vbank);
-        
+
         for(s32 j = 0, y = params.y, h = y + (params.h ? params.h : img.height); y < h; ++y, ++j)
             for(s32 i = 0, x = params.x, w = x + (params.w ? params.w : img.width); x < w; ++x, ++i)
                 if(x >= 0 && x < TIC_SPRITESHEET_SIZE && y >= 0 && y < TIC_SPRITESHEET_SIZE)
-                    setSpritePixel(base, x, y, tic_nearest_color(pal->colors, 
+                    setSpritePixel(base, x, y, tic_nearest_color(pal->colors,
                         (tic_rgb*)(img.pixels + i + j * img.width), TIC_PALETTE_SIZE));
 
         error = false;
@@ -1779,7 +1779,7 @@ static void onImport_binary(Console* console, const char* name, const void* buff
         binary->size = size;
         memcpy(binary->data, buffer, size);
     }
-        
+
     onFileImported(console, name, ok);
 }
 
@@ -1800,7 +1800,7 @@ static void onImport_map(Console* console, const char* name, const void* buffer,
         memset(map, 0, Size);
         memcpy(map, buffer, MIN(size, Size));
     }
-        
+
     onFileImported(console, name, ok);
 }
 
@@ -1873,7 +1873,7 @@ static void onImportCommand(Console* console)
             {
                 const char* section;
                 void (*handler)(Console*, const char*, const void*, s32, ImportParams);
-            } Handlers[] = 
+            } Handlers[] =
             {
 #define         IMPORT_CMD_DEF(name) {#name, onImport_##name},
                 IMPORT_CMD_LIST(IMPORT_CMD_DEF)
@@ -1975,7 +1975,7 @@ static void* embedCart(Console* console, u8* app, s32* size)
             {
                 s32 appSize = *size;
 
-                EmbedHeader header = 
+                EmbedHeader header =
                 {
                     .appSize = appSize,
                     .cartSize = zipSize,
@@ -1997,11 +1997,11 @@ static void* embedCart(Console* console, u8* app, s32* size)
             }
         }
     }
-    
+
     return data;
 }
 
-typedef struct 
+typedef struct
 {
     Console* console;
     char filename[TICNAME_MAX];
@@ -2109,9 +2109,9 @@ static void onHtmlExportGet(const net_get_data* data)
             free(exportData);
 
             const char* zipPath = tic_fs_path(console->fs, filename);
-            bool errorOccured = !fs_write(zipPath, data->done.data, data->done.size);
+            bool errorOccurred = !fs_write(zipPath, data->done.data, data->done.size);
 
-            if(!errorOccured)
+            if(!errorOccurred)
             {
                 struct zip_t *zip = zip_open(zipPath, ZIP_DEFAULT_COMPRESSION_LEVEL, 'a');
 
@@ -2129,13 +2129,13 @@ static void onHtmlExportGet(const net_get_data* data)
                             zip_entry_write(zip, cart, cartSize);
                             zip_entry_close(zip);
                         }
-                        else errorOccured = true;
+                        else errorOccurred = true;
                     }
                 }
-                else errorOccured = true;                
+                else errorOccurred = true;
             }
 
-            onFileExported(console, filename, !errorOccured);
+            onFileExported(console, filename, !errorOccurred);
         }
         break;
     default:
@@ -2245,14 +2245,14 @@ static void onExport_mapimg(Console* console, const char* param, const char* pat
             for(s32 r = 0; r < TIC_MAP_ROWS; r++)
                 for(s32 c = 0; c < TIC_MAP_COLS; c++)
                 {
-                    tic_api_map(tic, c * TIC_MAP_SCREEN_WIDTH, r * TIC_MAP_SCREEN_HEIGHT, 
+                    tic_api_map(tic, c * TIC_MAP_SCREEN_WIDTH, r * TIC_MAP_SCREEN_HEIGHT,
                         TIC_MAP_SCREEN_WIDTH, TIC_MAP_SCREEN_HEIGHT, 0, 0, NULL, 0, 1, NULL, NULL);
 
                     tic_core_blit(tic);
 
                     for(s32 j = 0; j < TIC80_HEIGHT; j++)
                         for(s32 i = 0; i < TIC80_WIDTH; i++)
-                            img.values[(i + c * TIC80_WIDTH) + (j + r * TIC80_HEIGHT) * Width] = 
+                            img.values[(i + c * TIC80_WIDTH) + (j + r * TIC80_HEIGHT) * Width] =
                                 tic->product.screen[(i + TIC80_MARGIN_LEFT) + (j + TIC80_MARGIN_TOP) * TIC80_FULLWIDTH];
                 }
         }
@@ -2310,7 +2310,7 @@ static void onExport_screen(Console* console, const char* param, const char* nam
         SCOPE(free(png.data))
         {
             onFileExported(console, filename, tic_fs_save(console->fs, filename, png.data, png.size, true));
-        }        
+        }
     }
 }
 
@@ -2337,7 +2337,7 @@ static void onExportCommand(Console* console)
             void(*handler)(Console*, const char*, const char*, ExportParams);
         } Handlers[] =
         {
-#define     EXPORT_CMD_DEF(name) {#name, onExport_##name}, 
+#define     EXPORT_CMD_DEF(name) {#name, onExport_##name},
             EXPORT_CMD_LIST(EXPORT_CMD_DEF)
 #undef      EXPORT_CMD_DEF
         };
@@ -2397,7 +2397,7 @@ static CartSaveResult saveCartName(Console* console, const char* name)
                     {
                         enum{CoverWidth = 256};
 
-                        static const u8 Cartridge[] = 
+                        static const u8 Cartridge[] =
                         {
                             #include "../build/assets/cart.png.dat"
                         };
@@ -2462,9 +2462,9 @@ static CartSaveResult saveCartName(Console* console, const char* name)
                         png_buffer cart = png_create(sizeof(tic_cartridge));
                         cart.size = tic_cart_save(&tic->cart, cart.data);
                         zip.size = tic_tool_zip(zip.data, zip.size, cart.data, cart.size);
-                        free(cart.data);                        
+                        free(cart.data);
                     }
-                    
+
                     png_buffer result = png_encode(cover, zip);
                     free(zip.data);
                     free(cover.data);
@@ -2531,7 +2531,7 @@ static void onSaveCommand(Console* console)
 {
     const char* param = console->desc->count ? console->desc->params->key : NULL;
 
-    if(param && strlen(param) && 
+    if(param && strlen(param) &&
         (tic_fs_exists(console->fs, param) ||
             tic_fs_exists(console->fs, getCartName(param))))
     {
@@ -2649,7 +2649,7 @@ static void onAddFile(Console* console, const char* name, const u8* buffer, s32 
             printError(console, "\nerror: ");
             printError(console, name);
             printError(console, " already exists :(");
-        }        
+        }
     }
 
     commandDone(console);
@@ -2966,7 +2966,7 @@ typedef struct Command Command;
     TIC_CALLBACK_LIST(macro)    \
     TIC_API_LIST(macro)
 
-static struct ApiItem {const char* name; const char* def; const char* help;} Api[] = 
+static struct ApiItem {const char* name; const char* def; const char* help;} Api[] =
 {
 #define TIC_API_DEF(name, def, help, ...) {#name, def, help},
     API_LIST(TIC_API_DEF)
@@ -3214,7 +3214,7 @@ static void onExport_help(Console* console, const char* param, const char* name,
         ptr += sprintf(ptr, "```\n\n## Console commands\n");
 
         FOR(const Command*, cmd, Commands)
-            ptr += sprintf(ptr, "\n### %s\n%s\nusage: `%s`\n", 
+            ptr += sprintf(ptr, "\n### %s\n%s\nusage: `%s`\n",
                 cmd->name, cmd->help, cmd->usage ? cmd->usage : cmd->name);
 
         ptr += sprintf(ptr, "\n## API functions\n");
@@ -3242,7 +3242,7 @@ static void onExport_help(Console* console, const char* param, const char* name,
 
         SCOPE(free(helpReplaced))
         {
-            onFileExported(console, filename, tic_fs_save(console->fs, filename, helpReplaced, strlen(helpReplaced), true));        
+            onFileExported(console, filename, tic_fs_save(console->fs, filename, helpReplaced, strlen(helpReplaced), true));
         }
     }
 }
@@ -3532,12 +3532,12 @@ static void onHelpCommand(Console* console)
 
         if(printUsage(console, param)) {
             foundTopic = true;
-        } 
+        }
         if(printApi(console, param)) {
             foundTopic = true;
         }
-            
-        static const struct Handler {const char* cmd; void(*handler)(Console*);} Handlers[] = 
+
+        static const struct Handler {const char* cmd; void(*handler)(Console*);} Handlers[] =
         {
 #define         HELP_CMD_DEF(name) {#name, onHelp_##name},
                 HELP_CMD_LIST(HELP_CMD_DEF)
@@ -3609,7 +3609,7 @@ static void processCommand(Console* console, const char* text)
         const char* command = console->desc->command;
 
         FOR(const Command*, cmd, Commands)
-            if(casecmp(console->desc->command, cmd->name) == 0 || 
+            if(casecmp(console->desc->command, cmd->name) == 0 ||
                 (cmd->alt && casecmp(console->desc->command, cmd->alt) == 0))
             {
                 cmd->handler(console);
@@ -3742,7 +3742,7 @@ static void onHttpVersionGet(const net_get_data* data)
         {
             lua_State* lua = netLuaInit(data->done.data, data->done.size);
 
-            union 
+            union
             {
                 struct
                 {
@@ -3752,7 +3752,7 @@ static void onHttpVersionGet(const net_get_data* data)
                 };
 
                 s32 data[3];
-            } version = 
+            } version =
             {
 	      {
                 .major = TIC_VERSION_MAJOR,
@@ -3902,7 +3902,7 @@ static void processMouse(Console* console)
         {
             console->scroll.active = true;
             console->scroll.start = tic_api_mouse(tic).y + console->scroll.pos * STUDIO_TEXT_HEIGHT;
-        }            
+        }
     }
     else console->scroll.active = false;
 
@@ -3912,8 +3912,8 @@ static void processMouse(Console* console)
     {
         tic_point m = tic_api_mouse(tic);
 
-        console->select.end = console->text 
-            + m.x / STUDIO_TEXT_WIDTH 
+        console->select.end = console->text
+            + m.x / STUDIO_TEXT_WIDTH
             + (m.y / STUDIO_TEXT_HEIGHT + console->scroll.pos) * CONSOLE_BUFFER_WIDTH;
 
         if(!console->select.active)
@@ -4027,9 +4027,9 @@ static void processKeyboard(Console* console)
         bool ctrl = tic_api_key(tic, tic_key_ctrl);
         bool alt = tic_api_key(tic, tic_key_alt);
 
-        if (ctrl || alt) 
+        if (ctrl || alt)
         {
-            if (ctrl) 
+            if (ctrl)
             {
 #if defined(__TIC_LINUX__)
                 tic_keycode clearKey = tic_key_l;
@@ -4039,7 +4039,7 @@ static void processKeyboard(Console* console)
 
                 if (keyWasPressed(console->studio, tic_key_a))      processConsoleHome(console);
                 else if (keyWasPressed(console->studio, tic_key_e)) processConsoleEnd(console);
-                else if (keyWasPressed(console->studio, clearKey)) 
+                else if (keyWasPressed(console->studio, clearKey))
                 {
                     onClsCommand(console);
                     return;
@@ -4144,7 +4144,7 @@ static void tick(Console* console)
         }
     }
     else
-    {   
+    {
         if(console->cursor.delay)
             console->cursor.delay--;
 
@@ -4185,7 +4185,7 @@ static bool cmdLoadCart(Console* console, const char* path)
     if(data)
     {
         const char* cartName = NULL;
-        
+
         {
             const char* ptr = path + strlen(path);
             while(ptr > path && !isslash(*ptr))--ptr;
@@ -4218,7 +4218,7 @@ static bool cmdLoadCart(Console* console, const char* path)
                 done = true;
         }
 #endif
-        
+
         free(data);
     }
 
@@ -4286,7 +4286,7 @@ void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Con
                 *command = '\0';
                 command += STRLEN(Sep);
             }
-        }        
+        }
     }
 
     qsort(Commands, COUNT_OF(Commands), sizeof Commands[0], cmdcmp);
@@ -4304,7 +4304,7 @@ void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Con
         memcpy(console->color, start->color, STUDIO_TEXT_BUFFER_SIZE);
 
         printLine(console);
-        for(const char* ptr = console->text, *end = ptr + STUDIO_TEXT_BUFFER_SIZE; 
+        for(const char* ptr = console->text, *end = ptr + STUDIO_TEXT_BUFFER_SIZE;
             ptr < end; ptr += CONSOLE_BUFFER_WIDTH)
             if(*ptr)
                 puts(ptr);
@@ -4316,7 +4316,7 @@ void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Con
             printf("error: cart `%s` not loaded\n", args.cart);
             exit(1);
         }
-        else 
+        else
             getStartScreen(console->studio)->embed = true;
 
     console->active = !start->embed;


### PR DESCRIPTION
found via `codespell -S vendor,./src/system -L siz,crate,gaus,gameboy,windowz,passtime` and `typos --format brief`