### PR TITLE
Fix C template build error

### DIFF
--- a/templates/c/Makefile
+++ b/templates/c/Makefile
@@ -26,7 +26,7 @@ LDFLAGS = -Wl,-zstack-size=8192,--no-entry,--import-memory -mexec-model=reactor 
 ifeq ($(DEBUG), 1)
 	LDFLAGS += -Wl,--export-all,--no-gc-sections
 else
-	LDFLAGS += -Wl,--strip-all,--gc-sections,--lto-O3 -Oz
+	LDFLAGS += -Wl,--strip-debug,--gc-sections,--lto-O3 -Oz
 endif
 
 OBJECTS = $(patsubst src/%.c, build/%.o, $(wildcard src/*.c))


### PR DESCRIPTION
Building the C template with recent (>=16) WASI SDKs caused the following error:
```
[wasm-validator error in function 1] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.fill
 (i32.const 100836)
 (i32.const 0)
 (i32.const 66)
)
[wasm-validator error in function 31] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.copy
 (local.get $0)
 (local.get $1)
 (local.get $2)
)
[wasm-validator error in function 32] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
(memory.fill
 (local.get $0)
 (local.get $1)
 (local.get $2)
)
```

This is due to WASI libc now using bulk memory operations. Building with `--strip-all` was removing the WebAssembly target features section, causing the validator to complain about bulk memory operations.