### PR TITLE
#2260: Updated Rust template build instructions

### DIFF
--- a/templates/rust/README.md
+++ b/templates/rust/README.md
@@ -14,18 +14,18 @@ Then, to build a cart.wasm file, run:
 cargo build --release
 ```
 
-To import the resulting WASM to a cartridge:
+To import the resulting WASM to a cartridge named `game.tic`:
 
 ```
-tic80 --fs . --cmd 'load game.tic & import binary target/wasm32-unknown-unknown/release/cart.wasm & save'
+tic80 --fs . --cmd 'new wasm & import binary target/wasm32-unknown-unknown/release/cart.wasm & save game'
 ```
 
 Or from the TIC-80 console:
 
 ```
-load game.tic
+new wasm
 import binary target/wasm32-unknown-unknown/release/cart.wasm
-save
+save game
 ```
 
 This is assuming you've run TIC-80 with `--fs .` inside your project directory.


### PR DESCRIPTION
It turned out, that a new WASM cartridge must be created prior to saving a new one, in order to prevent the default Lua code running, instead of the WASM code.