### PR TITLE
Disable structured editing on non-Emacs editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.ipch
 *.opendb
 *.suo
+compile_commands.json
 sexit
 .vscode/
 build/install_manifest.txt

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -1095,9 +1095,16 @@ static bool replaceSelection(Code* code)
     return false;
 }
 
+static inline enum KeybindMode getKeybindMode(Code* code)
+{
+    return getConfig(code->studio)->options.keybindMode;
+}
+
+
 static inline bool shouldUseStructuredEdit(Code* code)
 {
-    return tic_core_script_config(code->tic)->useStructuredEdition;
+    const bool emacsMode = getKeybindMode(code) == KEYBIND_EMACS;
+    return tic_core_script_config(code->tic)->useStructuredEdition && emacsMode;
 }
 
 
@@ -2832,11 +2839,6 @@ static void processViKeyboard(Code* code)
             }
         }
     }
-}
-
-static inline enum KeybindMode getKeybindMode(Code* code)
-{
-    return getConfig(code->studio)->options.keybindMode; 
 }
 
 static void processKeyboard(Code* code)

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -1095,10 +1095,15 @@ static bool replaceSelection(Code* code)
     return false;
 }
 
+static inline bool shouldUseStructuredEdit(Code* code)
+{
+    return tic_core_script_config(code->tic)->useStructuredEdition;
+}
+
+
 static bool structuredDeleteOverride(Code* code, char* pos)
 {
-    const bool useStructuredEdit = tic_core_script_config(code->tic)->useStructuredEdition;
-    if (!useStructuredEdit)
+    if (!shouldUseStructuredEdit(code))
         return false;
 
     const char* end = code->src + strlen(code->src);
@@ -1207,15 +1212,13 @@ static void backspaceWord(Code* code)
 
 char* findLineEnd(Code* code, char* pos)
 {
-    const bool useStructuredEdit = tic_core_script_config(code->tic)->useStructuredEdition;
-    
     char* lineend = pos+1;
     const char* end = code->src + strlen(code->src);
     
     while (lineend < end)
     {
         if (islineend(*lineend)) break;
-        if (useStructuredEdit && iscloseparen_(code, *lineend)) break;
+        if (shouldUseStructuredEdit(code) && iscloseparen_(code, *lineend)) break;
         ++lineend;
     }
     return lineend;
@@ -1227,8 +1230,7 @@ static void deleteLine(Code* code)
     char* lineend = linestart+1;
     const char* end = code->src + strlen(code->src);
     
-    const bool useStructuredEdit = tic_core_script_config(code->tic)->useStructuredEdition;
-    if (useStructuredEdit)
+    if (shouldUseStructuredEdit(code))
     {
         if (islineend(*linestart) || islineend(*lineend))
             noop;
@@ -1287,8 +1289,10 @@ static void inputSymbolBase(Code* code, char sym)
     if (strlen(code->src) >= MAX_CODE)
         return;
 
-    const bool useStructuredEdit = tic_core_script_config(code->tic)->useStructuredEdition;
-    if((useStructuredEdit || getConfig(code->studio)->theme.code.autoDelimiters) && (sym == '(' || sym == '[' || sym == '{'))
+    const bool useStructuredEdit = shouldUseStructuredEdit(code);
+    const bool isOpeningDelimiter = sym == '(' || sym == '[' || sym == '{';
+
+    if((useStructuredEdit || getConfig(code->studio)->theme.code.autoDelimiters) && isOpeningDelimiter)
     {
         insertCode(code, code->cursor.position++, (const char[]){sym, matchingDelim(sym), '\0'});
     } else if (useStructuredEdit && isdoublequote(sym)) {
@@ -1904,8 +1908,7 @@ static void addCommentToLine(Code* code, char* line, size_t size, const char* co
 
 static void sexpify(Code* code)
 {
-    const bool useStructuredEdit = tic_core_script_config(code->tic)->useStructuredEdition;
-    if (!useStructuredEdit)
+    if (!shouldUseStructuredEdit(code))
         return;
 
     char* pos = code->cursor.position;
@@ -1942,8 +1945,7 @@ static void sexpify(Code* code)
 
 static void extirpSExp(Code* code)
 {
-    const bool useStructuredEdit = tic_core_script_config(code->tic)->useStructuredEdition;
-    if (!useStructuredEdit)
+    if (!shouldUseStructuredEdit(code))
         return;
     
     const char* start = code->src;

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -2834,13 +2834,18 @@ static void processViKeyboard(Code* code)
     }
 }
 
+static inline enum KeybindMode getKeybindMode(Code* code)
+{
+    return getConfig(code->studio)->options.keybindMode; 
+}
+
 static void processKeyboard(Code* code)
 {
     tic_mem* tic = code->tic;
 
     if(tic->ram->input.keyboard.data == 0) return;
 
-    enum KeybindMode keymode = getConfig(code->studio)->options.keybindMode;
+    enum KeybindMode keymode = getKeybindMode(code);
 
     if (keymode == KEYBIND_VI) 
     {


### PR DESCRIPTION
Fixes #2293 . Structured editing is disabled in non-Emacs editors by checking the editor mode in `shouldUseStructuredEdit()`.

I also added a root-level  `compile_commands.json` line to the `.gitignore` file, as `clangd` requires the file to be in the root to be detected correctly.