### PR TITLE
Update zig examples and template to latest Zig

### DIFF
--- a/demos/bunny/wasmmark/build.zig
+++ b/demos/bunny/wasmmark/build.zig
@@ -1,19 +1,27 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    const mode = b.standardReleaseOptions();
+pub fn build(b: *std.Build) !void {
+    const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addSharedLibrary("cart", "src/main.zig", .unversioned);
-    lib.setBuildMode(mode);
-    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    const lib = b.addSharedLibrary(.{
+        .name = "cart",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = .{ .cpu_arch = .wasm32, .os_tag = .wasi },
+        .optimize = optimize,
+    });
+
     lib.import_memory = true;
+    lib.stack_size = 8192;
     lib.initial_memory = 65536 * 4;
     lib.max_memory = 65536 * 4;
+
     lib.export_table = true;
+
     // all the memory below 96kb is reserved for TIC and memory mapped I/O
     // so our own usage must start above the 96kb mark
     lib.global_base = 96 * 1024;
-    lib.stack_size = 8192;
-    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "SCR", "BOOT" };
-    lib.install();
+
+    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "BOOT" };
+
+    b.installArtifact(lib);
 }

--- a/demos/bunny/wasmmark/src/main.zig
+++ b/demos/bunny/wasmmark/src/main.zig
@@ -138,48 +138,50 @@ export fn TIC() void {
     }
     t = t + 1;
 
-
-if (tic.btn(0)) {
-    var i : i32 = 0;
-    while (i<5) {
-        addBunny();
-        i+=1;
+    if (tic.btn(0)) {
+        var i : i32 = 0;
+        while (i<5) {
+            addBunny();
+            i+=1;
+        }
     }
-}
 
-if (tic.btn(1)) {
-    var i : i32 = 0;
-    while (i<5) {
-        removeBunny();
-        i+=1;
+    if (tic.btn(1)) {
+        var i : i32 = 0;
+        while (i<5) {
+            removeBunny();
+            i+=1;
+        }
     }
+
+    // 	-- Update
+    var i : u32 = 0;
+    while (i<bunnyCount) {
+        bunnies[i].update();
+        i += 1;
+    }
+
+    // 	-- Draw
+    tic.cls(15);
+    i = 0;
+    while (i<bunnyCount) {
+        bunnies[i].draw();
+        i += 1;
+    }
+
+
+    tic.rect(0, 0, screenWidth, toolbarHeight, 9);
+
+    _ = tic.printf("Bunnies: {d}", .{bunnyCount}, 1, 0, .{.color = 11});
+    _ = tic.printf("FPS: {d:.4}", .{fps.getValue()}, screenWidth / 2, 0, .{.color = 11});
+    _ = tic.print("hello people", 10, 10, .{.color = 11});
+
+    // var x : u32 = 100000000;
+    // tic.FRAMEBUFFER[x] = 56;
+
+    // testscreen();
 }
 
-// 	-- Update
-var i : u32 = 0;
-while (i<bunnyCount) {
-    bunnies[i].update();
-    i += 1;
-}
+export fn BDR() void {}
 
-// 	-- Draw
-tic.cls(15);
-i = 0;
-while (i<bunnyCount) {
-    bunnies[i].draw();
-    i += 1;
-}
-
-
-tic.rect(0, 0, screenWidth, toolbarHeight, 9);
-
-_ = tic.printf("Bunnies: {d}", .{bunnyCount}, 1, 0, .{.color = 11});
-_ = tic.printf("FPS: {d:.4}", .{fps.getValue()}, screenWidth / 2, 0, .{.color = 11});
-_ = tic.print("hello people", 10, 10, .{.color = 11});
-
-// var x : u32 = 100000000;
-// tic.FRAMEBUFFER[x] = 56;
-
-// testscreen();
-}
-
+export fn OVR() void {}

--- a/demos/bunny/wasmmark/src/main.zig
+++ b/demos/bunny/wasmmark/src/main.zig
@@ -8,15 +8,15 @@
 const tic = @import("tic80.zig");
 const std = @import("std");
 const RndGen = std.rand.DefaultPrng;
-var rnd : std.rand.Random = undefined;
+var rnd: std.rand.Random = undefined;
 
 const screenWidth = 240;
 const screenHeight = 136;
 const toolbarHeight = 6;
-var t : u32 = 0;
+var t: u32 = 0;
 
 fn randomFloat(lower: f32, greater: f32) f32 {
-    return rnd.float(f32) * (greater-lower) + lower;
+    return rnd.float(f32) * (greater - lower) + lower;
 }
 
 const Bunny = struct {
@@ -39,11 +39,7 @@ const Bunny = struct {
     }
 
     fn draw(self: Bunny) void {
-        tic.spr(self.sprite, @floatToInt(i32,self.x), @floatToInt(i32,self.y), .{
-            .transparent = &.{1},
-            .w = 4,
-            .h = 4
-        });
+        tic.spr(self.sprite, @intFromFloat(self.x), @intFromFloat(self.y), .{ .transparent = &.{1}, .w = 4, .h = 4 });
     }
 
     fn update(self: *Bunny) void {
@@ -66,7 +62,6 @@ const Bunny = struct {
             self.speedY = self.speedY * -1;
         }
     }
-
 };
 
 const FPS = struct {
@@ -93,9 +88,9 @@ const FPS = struct {
 };
 
 const MAX_BUNNIES = 1200;
-var fps : FPS = undefined;
-var bunnyCount : usize = 0;
-var bunnies : [MAX_BUNNIES]Bunny = undefined;
+var fps: FPS = undefined;
+var bunnyCount: usize = 0;
+var bunnies: [MAX_BUNNIES]Bunny = undefined;
 
 fn addBunny() void {
     if (bunnyCount >= MAX_BUNNIES) return;
@@ -105,58 +100,59 @@ fn addBunny() void {
 }
 
 fn removeBunny() void {
-    if (bunnyCount==0) return;
+    if (bunnyCount == 0) return;
 
     bunnyCount -= 1;
 }
 
 export fn testscreen() void {
-    var i : usize = 0;
+    var i: usize = 0;
 
-    while (i<2000) {
-    // tic.ZERO.* = 0x99;
-    tic.FRAMEBUFFER[i]=0x56;
-    // tic.FRAMEBUFFER2.*[i]=0x67;
-    // tic.ZERO[i]= 0x56;
-    // bunnies[i].draw();
-    i += 1;
+    while (i < 2000) {
+        // tic.ZERO.* = 0x99;
+        tic.FRAMEBUFFER[i] = 0x56;
+        // tic.FRAMEBUFFER2.*[i]=0x67;
+        // tic.ZERO[i]= 0x56;
+        // bunnies[i].draw();
+        i += 1;
     }
 }
 
 export fn BOOT() void {
-    rnd = RndGen.init(0).random();
+    var xoshiro = RndGen.init(0);
+    rnd = xoshiro.random();
     fps.initFPS();
     addBunny();
 }
 
 export fn TIC() void {
-    if (t==0) {
+    if (t == 0) {
         tic.music(0, .{});
     }
-    if (t == 6*64*2.375) {
+    if (t == 6 * 64 * 2.375) {
         tic.music(1, .{});
     }
     t = t + 1;
 
     if (tic.btn(0)) {
-        var i : i32 = 0;
-        while (i<5) {
+        var i: i32 = 0;
+        while (i < 5) {
             addBunny();
-            i+=1;
+            i += 1;
         }
     }
 
     if (tic.btn(1)) {
-        var i : i32 = 0;
-        while (i<5) {
+        var i: i32 = 0;
+        while (i < 5) {
             removeBunny();
-            i+=1;
+            i += 1;
         }
     }
 
     // 	-- Update
-    var i : u32 = 0;
-    while (i<bunnyCount) {
+    var i: u32 = 0;
+    while (i < bunnyCount) {
         bunnies[i].update();
         i += 1;
     }
@@ -164,17 +160,16 @@ export fn TIC() void {
     // 	-- Draw
     tic.cls(15);
     i = 0;
-    while (i<bunnyCount) {
+    while (i < bunnyCount) {
         bunnies[i].draw();
         i += 1;
     }
 
-
     tic.rect(0, 0, screenWidth, toolbarHeight, 9);
 
-    _ = tic.printf("Bunnies: {d}", .{bunnyCount}, 1, 0, .{.color = 11});
-    _ = tic.printf("FPS: {d:.4}", .{fps.getValue()}, screenWidth / 2, 0, .{.color = 11});
-    _ = tic.print("hello people", 10, 10, .{.color = 11});
+    _ = tic.printf("Bunnies: {d}", .{bunnyCount}, 1, 0, .{ .color = 11 });
+    _ = tic.printf("FPS: {d:.4}", .{fps.getValue()}, screenWidth / 2, 0, .{ .color = 11 });
+    _ = tic.print("hello people", 10, 10, .{ .color = 11 });
 
     // var x : u32 = 100000000;
     // tic.FRAMEBUFFER[x] = 56;

--- a/demos/bunny/wasmmark/src/tic80.zig
+++ b/demos/bunny/wasmmark/src/tic80.zig
@@ -13,14 +13,16 @@
 // (yes even the original has this exact comment, be careful)
 
 const std = @import("std");
-comptime { std.testing.refAllDecls(@This()); } 
+comptime {
+    std.testing.refAllDecls(@This());
+}
 
 // types
 
 const MAX_STRING_SIZE = 200;
 const Offset_i8 = extern struct {
-  x: i8,
-  y: i8,
+    x: i8,
+    y: i8,
 };
 
 const RGBColor = extern struct {
@@ -29,12 +31,7 @@ const RGBColor = extern struct {
     b: u8,
 };
 
-const TextureSource = enum(i32) {
-    TILES = 0,
-    MAP,
-    VBANK1
-};
-
+const TextureSource = enum(i32) { TILES = 0, MAP, VBANK1 };
 
 // ------------------------
 // HARDWARE REGISTERS / RAM
@@ -42,100 +39,99 @@ const TextureSource = enum(i32) {
 pub const WIDTH: u32 = 240;
 pub const HEIGHT: u32 = 136;
 
-pub const FRAMEBUFFER: *allowzero volatile [16320]u8 = @intToPtr(*allowzero volatile [16320]u8, 0);
-pub const TILES : *[8192]u8 = @intToPtr(*[8192]u8, 0x4000);
-pub const SPRITES : *[8192]u8 = @intToPtr(*[8192]u8, 0x6000);
-pub const MAP : *[32640]u8 = @intToPtr(*[32640]u8, 0x8000);
-pub const GAMEPADS : *[4]u8 = @intToPtr(*[4]u8, 0xFF80);
-pub const MOUSE : *[4]u8 = @intToPtr(*[4]u8, 0xFF84);
-pub const KEYBOARD : *[4]u8 = @intToPtr(*[4]u8, 0xFF88);
-pub const SFX_STATE: *[16]u8 = @intToPtr(*[16]u8, 0xFF8C);
-pub const SOUND_REGISTERS: *[72]u8 = @intToPtr(*[72]u8, 0xFF9C);
-pub const WAVEFORMS: *[256]u8 =@intToPtr(*[256]u8, 0xFFE4);
-pub const SFX: *[4224]u8 =@intToPtr(*[4224]u8, 0x100E4);
-pub const MUSIC_PATTERNS: *[11520]u8 =@intToPtr(*[11520]u8, 0x11164);
-pub const MUSIC_TRACKS: *[408]u8 =@intToPtr(*[408]u8, 0x13E64);
-pub const SOUND_STATE: *[4]u8 =@intToPtr(*[4]u8, 0x13FFC);
-pub const STEREO_VOLUME: *[4]u8 =@intToPtr(*[4]u8, 0x14000);
-pub const PERSISTENT_RAM: *[1024]u8 =@intToPtr(*[1024]u8, 0x14004);
-pub const PERSISTENT_RAM_u32: *[256]u32 =@intToPtr(*[256]u32, 0x14004);
-pub const SPRITE_FLAGS: *[512]u8 =@intToPtr(*[512]u8, 0x14404);
-pub const SYSTEM_FONT: *[2048]u8 =@intToPtr(*[2048]u8, 0x14604);
+pub const FRAMEBUFFER: *allowzero volatile [16320]u8 = @as(*allowzero volatile [16320]u8, @ptrFromInt(0));
+pub const TILES: *[8192]u8 = @as(*[8192]u8, @ptrFromInt(0x4000));
+pub const SPRITES: *[8192]u8 = @as(*[8192]u8, @ptrFromInt(0x6000));
+pub const MAP: *[32640]u8 = @as(*[32640]u8, @ptrFromInt(0x8000));
+pub const GAMEPADS: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF80));
+pub const MOUSE: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF84));
+pub const KEYBOARD: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF88));
+pub const SFX_STATE: *[16]u8 = @as(*[16]u8, @ptrFromInt(0xFF8C));
+pub const SOUND_REGISTERS: *[72]u8 = @as(*[72]u8, @ptrFromInt(0xFF9C));
+pub const WAVEFORMS: *[256]u8 = @as(*[256]u8, @ptrFromInt(0xFFE4));
+pub const SFX: *[4224]u8 = @as(*[4224]u8, @ptrFromInt(0x100E4));
+pub const MUSIC_PATTERNS: *[11520]u8 = @as(*[11520]u8, @ptrFromInt(0x11164));
+pub const MUSIC_TRACKS: *[408]u8 = @as(*[408]u8, @ptrFromInt(0x13E64));
+pub const SOUND_STATE: *[4]u8 = @as(*[4]u8, @ptrFromInt(0x13FFC));
+pub const STEREO_VOLUME: *[4]u8 = @as(*[4]u8, @ptrFromInt(0x14000));
+pub const PERSISTENT_RAM: *[1024]u8 = @as(*[1024]u8, @ptrFromInt(0x14004));
+pub const PERSISTENT_RAM_u32: *[256]u32 = @as(*[256]u32, @ptrFromInt(0x14004));
+pub const SPRITE_FLAGS: *[512]u8 = @as(*[512]u8, @ptrFromInt(0x14404));
+pub const SYSTEM_FONT: *[2048]u8 = @as(*[2048]u8, @ptrFromInt(0x14604));
 
 // vbank 0
 
 const PaletteMap = packed struct {
-  color0: u4,
-  color1: u4,
-  color2: u4,
-  color3: u4,
-  color4: u4,
-  color5: u4,
-  color6: u4,
-  color7: u4,
-  color8: u4,
-  color9: u4,
-  color10: u4,
-  color11: u4,
-  color12: u4,
-  color13: u4,
-  color14: u4,
-  color15: u4,
+    color0: u4,
+    color1: u4,
+    color2: u4,
+    color3: u4,
+    color4: u4,
+    color5: u4,
+    color6: u4,
+    color7: u4,
+    color8: u4,
+    color9: u4,
+    color10: u4,
+    color11: u4,
+    color12: u4,
+    color13: u4,
+    color14: u4,
+    color15: u4,
 };
 
-pub const PALETTE: *[16]RGBColor = @intToPtr(*[16]RGBColor, 0x3FC0);
-pub const PALETTE_u8: *[48]u8 = @intToPtr(*[48]u8, 0x3FC0);
-pub const PALETTE_MAP: *PaletteMap = @intToPtr(*PaletteMap, 0x3FF0);
-pub const PALETTE_MAP_u8: *[8]u8 = @intToPtr(*[8]u8, 0x3FF0);
+pub const PALETTE: *[16]RGBColor = @as(*[16]RGBColor, @ptrFromInt(0x3FC0));
+pub const PALETTE_u8: *[48]u8 = @as(*[48]u8, @ptrFromInt(0x3FC0));
+pub const PALETTE_MAP: *PaletteMap = @as(*PaletteMap, @ptrFromInt(0x3FF0));
+pub const PALETTE_MAP_u8: *[8]u8 = @as(*[8]u8, @ptrFromInt(0x3FF0));
 // TODO: this doesn't work unless it's packed, which I dno't think we can do?
-// pub const PALETTE_MAP: *[16]u4 = @intToPtr(*[16]u4, 0x3FF0);
-pub const BORDER_COLOR: *u8 = @intToPtr(*u8, 0x3FF8);
-pub const SCREEN_OFFSET: *Offset_i8 = @intToPtr(*Offset_i8, 0x3FF9);
-pub const MOUSE_CURSOR: *u8 = @intToPtr(*u8, 0x3FFB);
-pub const BLIT_SEGMENT: *u8 = @intToPtr(*u8, 0x3FFC);
+// pub const PALETTE_MAP: *[16]u4 = @ptrFromInt(*[16]u4, 0x3FF0);
+pub const BORDER_COLOR: *u8 = @as(*u8, @ptrFromInt(0x3FF8));
+pub const SCREEN_OFFSET: *Offset_i8 = @as(*Offset_i8, @ptrFromInt(0x3FF9));
+pub const MOUSE_CURSOR: *u8 = @as(*u8, @ptrFromInt(0x3FFB));
+pub const BLIT_SEGMENT: *u8 = @as(*u8, @ptrFromInt(0x3FFC));
 
 // vbank 1
-pub const OVR_TRANSPARENCY: *u8 = @intToPtr(*u8, 0x3FF8);
-
+pub const OVR_TRANSPARENCY: *u8 = @as(*u8, @ptrFromInt(0x3FF8));
 
 // import the RAW api
 
 pub const raw = struct {
     pub extern fn btn(id: i32) i32;
-    pub extern fn btnp(id: i32, hold: i32, period: i32 ) bool;
+    pub extern fn btnp(id: i32, hold: i32, period: i32) bool;
     pub extern fn clip(x: i32, y: i32, w: i32, h: i32) void;
-    pub extern fn cls(color: i32) void; 
+    pub extern fn cls(color: i32) void;
     pub extern fn circ(x: i32, y: i32, radius: i32, color: i32) void;
     pub extern fn circb(x: i32, y: i32, radius: i32, color: i32) void;
     pub extern fn exit() void;
     pub extern fn elli(x: i32, y: i32, a: i32, b: i32, color: i32) void;
     pub extern fn ellib(x: i32, y: i32, a: i32, b: i32, color: i32) void;
     pub extern fn fget(id: i32, flag: u8) bool;
-    pub extern fn font(text: [*:0]u8, x: u32, y: i32, trans_colors: ?[*]const u8, color_count: i32, char_width: i32, char_height: i32, fixed: bool, scale: i32) i32;
+    pub extern fn font(text: [*:0]u8, x: u32, y: i32, trans_colors: ?[*]const u8, color_count: i32, char_width: i32, char_height: i32, fixed: bool, scale: i32, alt: bool) i32;
     pub extern fn fset(id: i32, flag: u8, value: bool) bool;
     pub extern fn key(keycode: i32) bool;
-    pub extern fn keyp(keycode: i32, hold: i32, period: i32 ) bool;
+    pub extern fn keyp(keycode: i32, hold: i32, period: i32) bool;
     pub extern fn line(x0: i32, y0: i32, x1: i32, y1: i32, color: i32) void;
     pub extern fn map(x: i32, y: i32, w: i32, h: i32, sx: i32, sy: i32, trans_colors: ?[*]const u8, color_count: i32, scale: i32, remap: i32) void;
     pub extern fn memcpy(to: u32, from: u32, length: u32) void;
     pub extern fn memset(addr: u32, value: u8, length: u32) void;
-    pub extern fn mget(x: i32, y:i32) i32;
+    pub extern fn mget(x: i32, y: i32) i32;
     pub extern fn mouse(data: *MouseData) void;
-    pub extern fn mset(x: i32, y:i32, value: bool) void;
+    pub extern fn mset(x: i32, y: i32, tile_id: u32) void;
     pub extern fn music(track: i32, frame: i32, row: i32, loop: bool, sustain: bool, tempo: i32, speed: i32) void;
     pub extern fn peek(addr: u32, bits: i32) u8;
     pub extern fn peek4(addr4: u32) u8;
     pub extern fn peek2(addr2: u32) u8;
     pub extern fn peek1(bitaddr: u32) u8;
-    pub extern fn pix(x: i32, y:i32, color: i32) void;
+    pub extern fn pix(x: i32, y: i32, color: i32) void;
     pub extern fn pmem(index: u32, value: i64) u32;
     pub extern fn poke(addr: u32, value: u8, bits: i32) void;
     pub extern fn poke4(addr4: u32, value: u8) void;
     pub extern fn poke2(addr2: u32, value: u8) void;
     pub extern fn poke1(bitaddr: u32, value: u8) void;
     pub extern fn print(text: [*:0]const u8, x: i32, y: i32, color: i32, fixed: bool, scale: i32, smallfont: bool) i32;
-    pub extern fn rect(x: i32, y: i32, w: i32, h:i32, color: i32) void;
-    pub extern fn rectb(x: i32, y: i32, w: i32, h:i32, color: i32) void;    
+    pub extern fn rect(x: i32, y: i32, w: i32, h: i32, color: i32) void;
+    pub extern fn rectb(x: i32, y: i32, w: i32, h: i32, color: i32) void;
     pub extern fn reset() void;
     pub extern fn sfx(id: i32, note: i32, octave: i32, duration: i32, channel: i32, volumeLeft: i32, volumeRight: i32, speed: i32) void;
     pub extern fn spr(id: i32, x: i32, y: i32, trans_colors: ?[*]const u8, color_count: i32, scale: i32, flip: i32, rotate: i32, w: i32, h: i32) void;
@@ -153,13 +149,13 @@ pub const raw = struct {
 // INPUT
 
 const MouseData = extern struct {
-  x: i16,
-  y: i16,
-  scrollx: i8,
-  scrolly: i8,
-  left: bool,
-  middle: bool,
-  right: bool,
+    x: i16,
+    y: i16,
+    scrollx: i8,
+    scrolly: i8,
+    left: bool,
+    middle: bool,
+    right: bool,
 };
 
 pub const key = raw.key;
@@ -178,7 +174,6 @@ pub fn btn(id: i32) bool {
 pub fn anybtn() bool {
     return raw.btn(-1) != 0;
 }
-
 
 // -----------------
 // DRAW / DRAW UTILS
@@ -204,30 +199,30 @@ pub const mouse = raw.mouse;
 // pub extern fn map(x: i32, y: i32, w: i32, h: i32, sx: i32, sy: i32, trans_colors: ?[*]u8, color_count: i32, scale: i32, remap: i32) void;
 
 const MapArgs = struct {
-    x: i32 = 0, 
+    x: i32 = 0,
     y: i32 = 0,
     w: i32 = 30,
     h: i32 = 17,
     sx: i32 = 0,
     sy: i32 = 0,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     scale: u8 = 1,
     remap: i32 = -1, // TODO
 };
 
 pub fn map(args: MapArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
     std.debug.assert(color_count < 16);
     raw.map(args.x, args.y, args.w, args.h, args.sx, args.sy, colors, color_count, args.scale, args.remap);
 }
 
 pub fn pix(x: i32, y: i32, color: u8) void {
-    raw.pix(x,y,color);
+    raw.pix(x, y, color);
 }
 
 pub fn getpix(x: i32, y: i32) u8 {
-    raw.pix(x,y, -1);
+    raw.pix(x, y, -1);
 }
 
 // pub extern fn spr(id: i32, x: i32, y: i32, trans_colors: [*]u8, color_count: i32, scale: i32, flip: i32, rotate: i32, w: i32, h: i32) void;
@@ -249,17 +244,17 @@ pub const Rotate = enum(u2) {
 const SpriteArgs = struct {
     w: i32 = 1,
     h: i32 = 1,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     scale: u8 = 1,
     flip: Flip = Flip.no,
     rotate: Rotate = Rotate.no,
 };
 
 pub fn spr(id: i32, x: i32, y: i32, args: SpriteArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
     std.debug.assert(color_count < 16);
-    raw.spr(id, x, y, colors, color_count, args.scale, @enumToInt(args.flip), @enumToInt(args.rotate), args.w, args.h);
+    raw.spr(id, x, y, colors, color_count, args.scale, @intFromEnum(args.flip), @intFromEnum(args.rotate), args.w, args.h);
 }
 
 pub const rect = raw.rect;
@@ -268,18 +263,18 @@ pub const tri = raw.tri;
 pub const trib = raw.trib;
 
 const TextriArgs = struct {
-    texture_source : TextureSource = TextureSource.TILES,
-    transparent: []const u8 = .{},
-    z1 : f32 = 0,
-    z2 : f32 = 0,
-    z3 : f32 = 0,
-    depth : bool = false,
+    texture_source: TextureSource = TextureSource.TILES,
+    transparent: []const u8 = &.{},
+    z1: f32 = 0,
+    z2: f32 = 0,
+    z3: f32 = 0,
+    depth: bool = false,
 };
 
 pub fn ttri(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32, @"u1": f32, v1: f32, @"u2": f32, v2: f32, @"u3": f32, v3: f32, args: TextriArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const trans_colors = args.transparent.ptr;
-    raw.ttri(x1, y1, x2, y2, x3, y3, @"u1", v1, @"u2", v2, @"u3", v3, @enumToInt(args.texture_source), trans_colors, color_count, args.z1, args.z2, args.z3, args.depth);
+    raw.ttri(x1, y1, x2, y2, x3, y3, @"u1", v1, @"u2", v2, @"u3", v3, @intFromEnum(args.texture_source), trans_colors, color_count, args.z1, args.z2, args.z3, args.depth);
 }
 
 // ----
@@ -287,45 +282,33 @@ pub fn ttri(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32, @"u1": f32, v1
 
 const PrintArgs = struct {
     color: u8 = 15,
-    fixed : bool = false,
-    small_font : bool = false,
-    scale : u8 = 1,
-};
-
-const FontArgs = struct {
-    transparent: []const u8 = .{},
-    char_width: u8, 
-    char_height: u8,
     fixed: bool = false,
-    scale: u8 = 1
+    small_font: bool = false,
+    scale: u8 = 1,
 };
 
-fn sliceToZString(text: []const u8, buff: [*:0]u8, maxLen: u16) void {
-    var len = std.math.min(maxLen, text.len);
-    std.mem.copy(u8, buff[0..len], text[0..len]);
-    buff[len] = 0; 
-}
+const FontArgs = struct { transparent: []const u8 = &.{}, char_width: u8, char_height: u8, fixed: bool = false, scale: u8 = 1, alt: bool = false };
 
+/// Prints the text and returns the width of the text in pixels
 pub fn print(text: []const u8, x: i32, y: i32, args: PrintArgs) i32 {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    return raw.print(&buff, x, y, args.color, args.fixed, args.scale, args.small_font);
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    return raw.print(as_ptr, x, y, args.color, args.fixed, args.scale, args.small_font);
 }
 
+/// Prints the text using format and returns the width of the text in pixels
 pub fn printf(comptime fmt: []const u8, fmtargs: anytype, x: i32, y: i32, args: PrintArgs) i32 {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
+    var buff: [MAX_STRING_SIZE:0]u8 = undefined;
     _ = std.fmt.bufPrintZ(&buff, fmt, fmtargs) catch unreachable;
     return raw.print(&buff, x, y, args.color, args.fixed, args.scale, args.small_font);
 }
 
 pub fn font(text: []const u8, x: u32, y: i32, args: FontArgs) i32 {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    return raw.font(&buff, x, y, colors, color_count, args.char_width, args.char_height, args.fixed, args.scale);
-}
 
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    return raw.font(as_ptr, x, y, colors, color_count, args.char_width, args.char_height, args.fixed, args.scale, args.alt);
+}
 
 // -----
 // AUDIO
@@ -334,13 +317,13 @@ pub fn font(text: []const u8, x: u32, y: i32, args: FontArgs) i32 {
 const MusicArgs = struct {
     frame: i8 = -1,
     row: i8 = -1,
-    loop: bool = true, 
+    loop: bool = true,
     sustain: bool = false,
     tempo: i8 = -1,
     speed: i8 = -1,
 };
 
-pub fn music(track:i32, args: MusicArgs) void {
+pub fn music(track: i32, args: MusicArgs) void {
     raw.music(track, args.frame, args.row, args.loop, args.sustain, args.tempo, args.speed);
 }
 
@@ -350,26 +333,26 @@ pub fn nomusic() void {
 
 // sfx id [note] [duration=-1] [channel=0] [volume=15] [speed=0]
 // void tic_api_sfx(tic_mem* memory, s32 index, s32 note, s32 octave, s32 duration, s32 channel, s32 left, s32 right, s32 speed)
-const MAX_VOLUME : i8 = 15;
+const MAX_VOLUME: i8 = 15;
 const SfxArgs = struct {
     sfx: i8 = -1,
-    note: i8 = -1, 
+    note: i8 = -1,
     octave: i8 = -1,
     duration: i8 = -1,
     channel: i8 = 0,
     volume: i8 = 15,
     volumeLeft: i8 = 15,
     volumeRight: i8 = 15,
-    speed: i8 = 0,  
+    speed: i8 = 0,
 };
 
 // pub extern fn sfx(id: i32, note: i32, duration: i32, channel: i32, volume: i32, speed: i32) void;
 
-const SFX_NOTES = [_][] const u8 {"C-", "C#", "D-", "D#", "E-", "F-", "F#", "G-", "G#", "A-", "A#", "B-"};
+const SFX_NOTES = [_][]const u8{ "C-", "C#", "D-", "D#", "E-", "F-", "F#", "G-", "G#", "A-", "A#", "B-" };
 
 fn parse_note(name: []const u8, noteArgs: *SfxArgs) bool {
-    var note_signature : []const u8 = undefined;
-    var octave : u8 = undefined;
+    var note_signature: []const u8 = undefined;
+    var octave: u8 = undefined;
     if (name.len == 2) {
         note_signature = &.{ name[0], '-' };
         octave = name[1];
@@ -382,17 +365,16 @@ fn parse_note(name: []const u8, noteArgs: *SfxArgs) bool {
     for (SFX_NOTES) |music_note| {
         if (std.mem.eql(u8, music_note, note_signature)) {
             noteArgs.note = i;
-            noteArgs.octave = @intCast(i8, octave - '1');
+            noteArgs.octave = @as(i8, @intCast(octave - '1'));
             return true;
         }
-        i+=1;
+        i += 1;
     }
     return false;
 }
 
-
 pub fn note(name: []const u8, args: SfxArgs) void {
-    var largs : SfxArgs = args;
+    var largs: SfxArgs = args;
     if (parse_note(name, &largs)) {
         sfx(args.sfx, largs);
     }
@@ -403,7 +385,7 @@ pub fn sfx(id: i32, args: SfxArgs) void {
     if (args.volume != MAX_VOLUME) {
         largs.volumeLeft = args.volume;
         largs.volumeRight = args.volume;
-    } 
+    }
     raw.sfx(id, args.note, args.octave, args.duration, args.channel, largs.volumeLeft, largs.volumeRight, args.speed);
 }
 
@@ -433,7 +415,6 @@ pub const poke4 = raw.poke4;
 pub const poke2 = raw.poke2;
 pub const poke1 = raw.poke1;
 
-
 pub fn peek(addr: u32) u8 {
     return raw.peek(addr, 8);
 }
@@ -447,9 +428,14 @@ pub const vbank = raw.vbank;
 pub const exit = raw.exit;
 pub const reset = raw.reset;
 pub fn trace(text: []const u8) void {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    raw.trace(&buff);
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    raw.trace(as_ptr, 15);
+}
+
+pub fn tracef(comptime fmt: []const u8, fmtargs: anytype) void {
+    var buf: [MAX_STRING_SIZE:0]u8 = undefined;
+    _ = std.fmt.bufPrintZ(&buf, fmt, fmtargs) catch unreachable;
+    trace(&buf);
 }
 
 const SectionFlags = packed struct {
@@ -483,11 +469,10 @@ const SyncArgs = struct {
 
 pub fn sync(args: SyncArgs) void {
     // var mask = SectionFlagsMask { .sections = args.sections };
-    raw.sync(@bitCast(u8, args.sections), args.bank, args.toCartridge);
+    raw.sync(@as(u8, @bitCast(args.sections)), args.bank, args.toCartridge);
 }
 
 // TIME KEEPING
 
 pub const time = raw.time;
 pub const tstamp = raw.tstamp;
-

--- a/demos/wasm/build.zig
+++ b/demos/wasm/build.zig
@@ -1,19 +1,27 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    const mode = b.standardReleaseOptions();
+pub fn build(b: *std.Build) !void {
+    const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addSharedLibrary("cart", "src/main.zig", .unversioned);
-    lib.setBuildMode(mode);
-    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    const lib = b.addSharedLibrary(.{
+        .name = "cart",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = .{ .cpu_arch = .wasm32, .os_tag = .wasi },
+        .optimize = optimize,
+    });
+
     lib.import_memory = true;
+    lib.stack_size = 8192;
     lib.initial_memory = 65536 * 4;
     lib.max_memory = 65536 * 4;
+
     lib.export_table = true;
+
     // all the memory below 96kb is reserved for TIC and memory mapped I/O
     // so our own usage must start above the 96kb mark
     lib.global_base = 96 * 1024;
-    lib.stack_size = 8192;
-    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "SCR", "BOOT" };
-    lib.install();
+
+    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "BOOT" };
+
+    b.installArtifact(lib);
 }

--- a/demos/wasm/src/main.zig
+++ b/demos/wasm/src/main.zig
@@ -1,10 +1,5 @@
 const tic = @import("tic80.zig");
 
-var initDone = false;
-
-fn INIT() void {
-}
-
 const TICGuy = struct {
     x : i32 = 96,
     y : i32 = 24,
@@ -13,9 +8,9 @@ const TICGuy = struct {
 var t : u16 = 0;
 var mascot : TICGuy = .{};
 
-export fn TIC() void {
-    if (!initDone) { INIT(); }
+export fn BOOT() void {}
 
+export fn TIC() void {
     tic.sync(.{
         .sections = .{.tiles = true},
         .bank = 1,
@@ -47,3 +42,6 @@ export fn TIC() void {
     t += 1;
 }
 
+export fn BDR() void {}
+
+export fn OVR() void {}

--- a/demos/wasm/src/tic80.zig
+++ b/demos/wasm/src/tic80.zig
@@ -13,14 +13,16 @@
 // (yes even the original has this exact comment, be careful)
 
 const std = @import("std");
-comptime { std.testing.refAllDecls(@This()); } 
+comptime {
+    std.testing.refAllDecls(@This());
+}
 
 // types
 
 const MAX_STRING_SIZE = 200;
 const Offset_i8 = extern struct {
-  x: i8,
-  y: i8,
+    x: i8,
+    y: i8,
 };
 
 const RGBColor = extern struct {
@@ -29,12 +31,7 @@ const RGBColor = extern struct {
     b: u8,
 };
 
-const TextureSource = enum(i32) {
-    TILES = 0,
-    MAP,
-    VBANK1
-};
-
+const TextureSource = enum(i32) { TILES = 0, MAP, VBANK1 };
 
 // ------------------------
 // HARDWARE REGISTERS / RAM
@@ -42,100 +39,99 @@ const TextureSource = enum(i32) {
 pub const WIDTH: u32 = 240;
 pub const HEIGHT: u32 = 136;
 
-pub const FRAMEBUFFER: *allowzero volatile [16320]u8 = @intToPtr(*allowzero volatile [16320]u8, 0);
-pub const TILES : *[8192]u8 = @intToPtr(*[8192]u8, 0x4000);
-pub const SPRITES : *[8192]u8 = @intToPtr(*[8192]u8, 0x6000);
-pub const MAP : *[32640]u8 = @intToPtr(*[32640]u8, 0x8000);
-pub const GAMEPADS : *[4]u8 = @intToPtr(*[4]u8, 0xFF80);
-pub const MOUSE : *[4]u8 = @intToPtr(*[4]u8, 0xFF84);
-pub const KEYBOARD : *[4]u8 = @intToPtr(*[4]u8, 0xFF88);
-pub const SFX_STATE: *[16]u8 = @intToPtr(*[16]u8, 0xFF8C);
-pub const SOUND_REGISTERS: *[72]u8 = @intToPtr(*[72]u8, 0xFF9C);
-pub const WAVEFORMS: *[256]u8 =@intToPtr(*[256]u8, 0xFFE4);
-pub const SFX: *[4224]u8 =@intToPtr(*[4224]u8, 0x100E4);
-pub const MUSIC_PATTERNS: *[11520]u8 =@intToPtr(*[11520]u8, 0x11164);
-pub const MUSIC_TRACKS: *[408]u8 =@intToPtr(*[408]u8, 0x13E64);
-pub const SOUND_STATE: *[4]u8 =@intToPtr(*[4]u8, 0x13FFC);
-pub const STEREO_VOLUME: *[4]u8 =@intToPtr(*[4]u8, 0x14000);
-pub const PERSISTENT_RAM: *[1024]u8 =@intToPtr(*[1024]u8, 0x14004);
-pub const PERSISTENT_RAM_u32: *[256]u32 =@intToPtr(*[256]u32, 0x14004);
-pub const SPRITE_FLAGS: *[512]u8 =@intToPtr(*[512]u8, 0x14404);
-pub const SYSTEM_FONT: *[2048]u8 =@intToPtr(*[2048]u8, 0x14604);
+pub const FRAMEBUFFER: *allowzero volatile [16320]u8 = @as(*allowzero volatile [16320]u8, @ptrFromInt(0));
+pub const TILES: *[8192]u8 = @as(*[8192]u8, @ptrFromInt(0x4000));
+pub const SPRITES: *[8192]u8 = @as(*[8192]u8, @ptrFromInt(0x6000));
+pub const MAP: *[32640]u8 = @as(*[32640]u8, @ptrFromInt(0x8000));
+pub const GAMEPADS: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF80));
+pub const MOUSE: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF84));
+pub const KEYBOARD: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF88));
+pub const SFX_STATE: *[16]u8 = @as(*[16]u8, @ptrFromInt(0xFF8C));
+pub const SOUND_REGISTERS: *[72]u8 = @as(*[72]u8, @ptrFromInt(0xFF9C));
+pub const WAVEFORMS: *[256]u8 = @as(*[256]u8, @ptrFromInt(0xFFE4));
+pub const SFX: *[4224]u8 = @as(*[4224]u8, @ptrFromInt(0x100E4));
+pub const MUSIC_PATTERNS: *[11520]u8 = @as(*[11520]u8, @ptrFromInt(0x11164));
+pub const MUSIC_TRACKS: *[408]u8 = @as(*[408]u8, @ptrFromInt(0x13E64));
+pub const SOUND_STATE: *[4]u8 = @as(*[4]u8, @ptrFromInt(0x13FFC));
+pub const STEREO_VOLUME: *[4]u8 = @as(*[4]u8, @ptrFromInt(0x14000));
+pub const PERSISTENT_RAM: *[1024]u8 = @as(*[1024]u8, @ptrFromInt(0x14004));
+pub const PERSISTENT_RAM_u32: *[256]u32 = @as(*[256]u32, @ptrFromInt(0x14004));
+pub const SPRITE_FLAGS: *[512]u8 = @as(*[512]u8, @ptrFromInt(0x14404));
+pub const SYSTEM_FONT: *[2048]u8 = @as(*[2048]u8, @ptrFromInt(0x14604));
 
 // vbank 0
 
 const PaletteMap = packed struct {
-  color0: u4,
-  color1: u4,
-  color2: u4,
-  color3: u4,
-  color4: u4,
-  color5: u4,
-  color6: u4,
-  color7: u4,
-  color8: u4,
-  color9: u4,
-  color10: u4,
-  color11: u4,
-  color12: u4,
-  color13: u4,
-  color14: u4,
-  color15: u4,
+    color0: u4,
+    color1: u4,
+    color2: u4,
+    color3: u4,
+    color4: u4,
+    color5: u4,
+    color6: u4,
+    color7: u4,
+    color8: u4,
+    color9: u4,
+    color10: u4,
+    color11: u4,
+    color12: u4,
+    color13: u4,
+    color14: u4,
+    color15: u4,
 };
 
-pub const PALETTE: *[16]RGBColor = @intToPtr(*[16]RGBColor, 0x3FC0);
-pub const PALETTE_u8: *[48]u8 = @intToPtr(*[48]u8, 0x3FC0);
-pub const PALETTE_MAP: *PaletteMap = @intToPtr(*PaletteMap, 0x3FF0);
-pub const PALETTE_MAP_u8: *[8]u8 = @intToPtr(*[8]u8, 0x3FF0);
+pub const PALETTE: *[16]RGBColor = @as(*[16]RGBColor, @ptrFromInt(0x3FC0));
+pub const PALETTE_u8: *[48]u8 = @as(*[48]u8, @ptrFromInt(0x3FC0));
+pub const PALETTE_MAP: *PaletteMap = @as(*PaletteMap, @ptrFromInt(0x3FF0));
+pub const PALETTE_MAP_u8: *[8]u8 = @as(*[8]u8, @ptrFromInt(0x3FF0));
 // TODO: this doesn't work unless it's packed, which I dno't think we can do?
-// pub const PALETTE_MAP: *[16]u4 = @intToPtr(*[16]u4, 0x3FF0);
-pub const BORDER_COLOR: *u8 = @intToPtr(*u8, 0x3FF8);
-pub const SCREEN_OFFSET: *Offset_i8 = @intToPtr(*Offset_i8, 0x3FF9);
-pub const MOUSE_CURSOR: *u8 = @intToPtr(*u8, 0x3FFB);
-pub const BLIT_SEGMENT: *u8 = @intToPtr(*u8, 0x3FFC);
+// pub const PALETTE_MAP: *[16]u4 = @ptrFromInt(*[16]u4, 0x3FF0);
+pub const BORDER_COLOR: *u8 = @as(*u8, @ptrFromInt(0x3FF8));
+pub const SCREEN_OFFSET: *Offset_i8 = @as(*Offset_i8, @ptrFromInt(0x3FF9));
+pub const MOUSE_CURSOR: *u8 = @as(*u8, @ptrFromInt(0x3FFB));
+pub const BLIT_SEGMENT: *u8 = @as(*u8, @ptrFromInt(0x3FFC));
 
 // vbank 1
-pub const OVR_TRANSPARENCY: *u8 = @intToPtr(*u8, 0x3FF8);
-
+pub const OVR_TRANSPARENCY: *u8 = @as(*u8, @ptrFromInt(0x3FF8));
 
 // import the RAW api
 
 pub const raw = struct {
     pub extern fn btn(id: i32) i32;
-    pub extern fn btnp(id: i32, hold: i32, period: i32 ) bool;
+    pub extern fn btnp(id: i32, hold: i32, period: i32) bool;
     pub extern fn clip(x: i32, y: i32, w: i32, h: i32) void;
-    pub extern fn cls(color: i32) void; 
+    pub extern fn cls(color: i32) void;
     pub extern fn circ(x: i32, y: i32, radius: i32, color: i32) void;
     pub extern fn circb(x: i32, y: i32, radius: i32, color: i32) void;
     pub extern fn exit() void;
     pub extern fn elli(x: i32, y: i32, a: i32, b: i32, color: i32) void;
     pub extern fn ellib(x: i32, y: i32, a: i32, b: i32, color: i32) void;
     pub extern fn fget(id: i32, flag: u8) bool;
-    pub extern fn font(text: [*:0]u8, x: u32, y: i32, trans_colors: ?[*]const u8, color_count: i32, char_width: i32, char_height: i32, fixed: bool, scale: i32) i32;
+    pub extern fn font(text: [*:0]u8, x: u32, y: i32, trans_colors: ?[*]const u8, color_count: i32, char_width: i32, char_height: i32, fixed: bool, scale: i32, alt: bool) i32;
     pub extern fn fset(id: i32, flag: u8, value: bool) bool;
     pub extern fn key(keycode: i32) bool;
-    pub extern fn keyp(keycode: i32, hold: i32, period: i32 ) bool;
+    pub extern fn keyp(keycode: i32, hold: i32, period: i32) bool;
     pub extern fn line(x0: i32, y0: i32, x1: i32, y1: i32, color: i32) void;
     pub extern fn map(x: i32, y: i32, w: i32, h: i32, sx: i32, sy: i32, trans_colors: ?[*]const u8, color_count: i32, scale: i32, remap: i32) void;
     pub extern fn memcpy(to: u32, from: u32, length: u32) void;
     pub extern fn memset(addr: u32, value: u8, length: u32) void;
-    pub extern fn mget(x: i32, y:i32) i32;
+    pub extern fn mget(x: i32, y: i32) i32;
     pub extern fn mouse(data: *MouseData) void;
-    pub extern fn mset(x: i32, y:i32, value: bool) void;
+    pub extern fn mset(x: i32, y: i32, tile_id: u32) void;
     pub extern fn music(track: i32, frame: i32, row: i32, loop: bool, sustain: bool, tempo: i32, speed: i32) void;
     pub extern fn peek(addr: u32, bits: i32) u8;
     pub extern fn peek4(addr4: u32) u8;
     pub extern fn peek2(addr2: u32) u8;
     pub extern fn peek1(bitaddr: u32) u8;
-    pub extern fn pix(x: i32, y:i32, color: i32) void;
+    pub extern fn pix(x: i32, y: i32, color: i32) void;
     pub extern fn pmem(index: u32, value: i64) u32;
     pub extern fn poke(addr: u32, value: u8, bits: i32) void;
     pub extern fn poke4(addr4: u32, value: u8) void;
     pub extern fn poke2(addr2: u32, value: u8) void;
     pub extern fn poke1(bitaddr: u32, value: u8) void;
     pub extern fn print(text: [*:0]const u8, x: i32, y: i32, color: i32, fixed: bool, scale: i32, smallfont: bool) i32;
-    pub extern fn rect(x: i32, y: i32, w: i32, h:i32, color: i32) void;
-    pub extern fn rectb(x: i32, y: i32, w: i32, h:i32, color: i32) void;    
+    pub extern fn rect(x: i32, y: i32, w: i32, h: i32, color: i32) void;
+    pub extern fn rectb(x: i32, y: i32, w: i32, h: i32, color: i32) void;
     pub extern fn reset() void;
     pub extern fn sfx(id: i32, note: i32, octave: i32, duration: i32, channel: i32, volumeLeft: i32, volumeRight: i32, speed: i32) void;
     pub extern fn spr(id: i32, x: i32, y: i32, trans_colors: ?[*]const u8, color_count: i32, scale: i32, flip: i32, rotate: i32, w: i32, h: i32) void;
@@ -153,13 +149,13 @@ pub const raw = struct {
 // INPUT
 
 const MouseData = extern struct {
-  x: i16,
-  y: i16,
-  scrollx: i8,
-  scrolly: i8,
-  left: bool,
-  middle: bool,
-  right: bool,
+    x: i16,
+    y: i16,
+    scrollx: i8,
+    scrolly: i8,
+    left: bool,
+    middle: bool,
+    right: bool,
 };
 
 pub const key = raw.key;
@@ -178,7 +174,6 @@ pub fn btn(id: i32) bool {
 pub fn anybtn() bool {
     return raw.btn(-1) != 0;
 }
-
 
 // -----------------
 // DRAW / DRAW UTILS
@@ -204,30 +199,30 @@ pub const mouse = raw.mouse;
 // pub extern fn map(x: i32, y: i32, w: i32, h: i32, sx: i32, sy: i32, trans_colors: ?[*]u8, color_count: i32, scale: i32, remap: i32) void;
 
 const MapArgs = struct {
-    x: i32 = 0, 
+    x: i32 = 0,
     y: i32 = 0,
     w: i32 = 30,
     h: i32 = 17,
     sx: i32 = 0,
     sy: i32 = 0,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     scale: u8 = 1,
     remap: i32 = -1, // TODO
 };
 
 pub fn map(args: MapArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
     std.debug.assert(color_count < 16);
     raw.map(args.x, args.y, args.w, args.h, args.sx, args.sy, colors, color_count, args.scale, args.remap);
 }
 
 pub fn pix(x: i32, y: i32, color: u8) void {
-    raw.pix(x,y,color);
+    raw.pix(x, y, color);
 }
 
 pub fn getpix(x: i32, y: i32) u8 {
-    raw.pix(x,y, -1);
+    raw.pix(x, y, -1);
 }
 
 // pub extern fn spr(id: i32, x: i32, y: i32, trans_colors: [*]u8, color_count: i32, scale: i32, flip: i32, rotate: i32, w: i32, h: i32) void;
@@ -249,17 +244,17 @@ pub const Rotate = enum(u2) {
 const SpriteArgs = struct {
     w: i32 = 1,
     h: i32 = 1,
-    transparent: []const u8 = .{},
+    transparent: []const u8 = &.{},
     scale: u8 = 1,
     flip: Flip = Flip.no,
     rotate: Rotate = Rotate.no,
 };
 
 pub fn spr(id: i32, x: i32, y: i32, args: SpriteArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
     std.debug.assert(color_count < 16);
-    raw.spr(id, x, y, colors, color_count, args.scale, @enumToInt(args.flip), @enumToInt(args.rotate), args.w, args.h);
+    raw.spr(id, x, y, colors, color_count, args.scale, @intFromEnum(args.flip), @intFromEnum(args.rotate), args.w, args.h);
 }
 
 pub const rect = raw.rect;
@@ -268,18 +263,18 @@ pub const tri = raw.tri;
 pub const trib = raw.trib;
 
 const TextriArgs = struct {
-    texture_source : TextureSource = TextureSource.TILES,
-    transparent: []const u8 = .{},
-    z1 : f32 = 0,
-    z2 : f32 = 0,
-    z3 : f32 = 0,
-    depth : bool = false,
+    texture_source: TextureSource = TextureSource.TILES,
+    transparent: []const u8 = &.{},
+    z1: f32 = 0,
+    z2: f32 = 0,
+    z3: f32 = 0,
+    depth: bool = false,
 };
 
 pub fn ttri(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32, @"u1": f32, v1: f32, @"u2": f32, v2: f32, @"u3": f32, v3: f32, args: TextriArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const trans_colors = args.transparent.ptr;
-    raw.ttri(x1, y1, x2, y2, x3, y3, @"u1", v1, @"u2", v2, @"u3", v3, @enumToInt(args.texture_source), trans_colors, color_count, args.z1, args.z2, args.z3, args.depth);
+    raw.ttri(x1, y1, x2, y2, x3, y3, @"u1", v1, @"u2", v2, @"u3", v3, @intFromEnum(args.texture_source), trans_colors, color_count, args.z1, args.z2, args.z3, args.depth);
 }
 
 // ----
@@ -287,45 +282,33 @@ pub fn ttri(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32, @"u1": f32, v1
 
 const PrintArgs = struct {
     color: u8 = 15,
-    fixed : bool = false,
-    small_font : bool = false,
-    scale : u8 = 1,
-};
-
-const FontArgs = struct {
-    transparent: []const u8 = .{},
-    char_width: u8, 
-    char_height: u8,
     fixed: bool = false,
-    scale: u8 = 1
+    small_font: bool = false,
+    scale: u8 = 1,
 };
 
-fn sliceToZString(text: []const u8, buff: [*:0]u8, maxLen: u16) void {
-    var len = std.math.min(maxLen, text.len);
-    std.mem.copy(u8, buff[0..len], text[0..len]);
-    buff[len] = 0; 
-}
+const FontArgs = struct { transparent: []const u8 = &.{}, char_width: u8, char_height: u8, fixed: bool = false, scale: u8 = 1, alt: bool = false };
 
+/// Prints the text and returns the width of the text in pixels
 pub fn print(text: []const u8, x: i32, y: i32, args: PrintArgs) i32 {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    return raw.print(&buff, x, y, args.color, args.fixed, args.scale, args.small_font);
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    return raw.print(as_ptr, x, y, args.color, args.fixed, args.scale, args.small_font);
 }
 
+/// Prints the text using format and returns the width of the text in pixels
 pub fn printf(comptime fmt: []const u8, fmtargs: anytype, x: i32, y: i32, args: PrintArgs) i32 {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
+    var buff: [MAX_STRING_SIZE:0]u8 = undefined;
     _ = std.fmt.bufPrintZ(&buff, fmt, fmtargs) catch unreachable;
     return raw.print(&buff, x, y, args.color, args.fixed, args.scale, args.small_font);
 }
 
 pub fn font(text: []const u8, x: u32, y: i32, args: FontArgs) i32 {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    return raw.font(&buff, x, y, colors, color_count, args.char_width, args.char_height, args.fixed, args.scale);
-}
 
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    return raw.font(as_ptr, x, y, colors, color_count, args.char_width, args.char_height, args.fixed, args.scale, args.alt);
+}
 
 // -----
 // AUDIO
@@ -334,13 +317,13 @@ pub fn font(text: []const u8, x: u32, y: i32, args: FontArgs) i32 {
 const MusicArgs = struct {
     frame: i8 = -1,
     row: i8 = -1,
-    loop: bool = true, 
+    loop: bool = true,
     sustain: bool = false,
     tempo: i8 = -1,
     speed: i8 = -1,
 };
 
-pub fn music(track:i32, args: MusicArgs) void {
+pub fn music(track: i32, args: MusicArgs) void {
     raw.music(track, args.frame, args.row, args.loop, args.sustain, args.tempo, args.speed);
 }
 
@@ -350,26 +333,26 @@ pub fn nomusic() void {
 
 // sfx id [note] [duration=-1] [channel=0] [volume=15] [speed=0]
 // void tic_api_sfx(tic_mem* memory, s32 index, s32 note, s32 octave, s32 duration, s32 channel, s32 left, s32 right, s32 speed)
-const MAX_VOLUME : i8 = 15;
+const MAX_VOLUME: i8 = 15;
 const SfxArgs = struct {
     sfx: i8 = -1,
-    note: i8 = -1, 
+    note: i8 = -1,
     octave: i8 = -1,
     duration: i8 = -1,
     channel: i8 = 0,
     volume: i8 = 15,
     volumeLeft: i8 = 15,
     volumeRight: i8 = 15,
-    speed: i8 = 0,  
+    speed: i8 = 0,
 };
 
 // pub extern fn sfx(id: i32, note: i32, duration: i32, channel: i32, volume: i32, speed: i32) void;
 
-const SFX_NOTES = [_][] const u8 {"C-", "C#", "D-", "D#", "E-", "F-", "F#", "G-", "G#", "A-", "A#", "B-"};
+const SFX_NOTES = [_][]const u8{ "C-", "C#", "D-", "D#", "E-", "F-", "F#", "G-", "G#", "A-", "A#", "B-" };
 
 fn parse_note(name: []const u8, noteArgs: *SfxArgs) bool {
-    var note_signature : []const u8 = undefined;
-    var octave : u8 = undefined;
+    var note_signature: []const u8 = undefined;
+    var octave: u8 = undefined;
     if (name.len == 2) {
         note_signature = &.{ name[0], '-' };
         octave = name[1];
@@ -382,17 +365,16 @@ fn parse_note(name: []const u8, noteArgs: *SfxArgs) bool {
     for (SFX_NOTES) |music_note| {
         if (std.mem.eql(u8, music_note, note_signature)) {
             noteArgs.note = i;
-            noteArgs.octave = @intCast(i8, octave - '1');
+            noteArgs.octave = @as(i8, @intCast(octave - '1'));
             return true;
         }
-        i+=1;
+        i += 1;
     }
     return false;
 }
 
-
 pub fn note(name: []const u8, args: SfxArgs) void {
-    var largs : SfxArgs = args;
+    var largs: SfxArgs = args;
     if (parse_note(name, &largs)) {
         sfx(args.sfx, largs);
     }
@@ -403,7 +385,7 @@ pub fn sfx(id: i32, args: SfxArgs) void {
     if (args.volume != MAX_VOLUME) {
         largs.volumeLeft = args.volume;
         largs.volumeRight = args.volume;
-    } 
+    }
     raw.sfx(id, args.note, args.octave, args.duration, args.channel, largs.volumeLeft, largs.volumeRight, args.speed);
 }
 
@@ -433,7 +415,6 @@ pub const poke4 = raw.poke4;
 pub const poke2 = raw.poke2;
 pub const poke1 = raw.poke1;
 
-
 pub fn peek(addr: u32) u8 {
     return raw.peek(addr, 8);
 }
@@ -447,9 +428,14 @@ pub const vbank = raw.vbank;
 pub const exit = raw.exit;
 pub const reset = raw.reset;
 pub fn trace(text: []const u8) void {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    raw.trace(&buff);
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    raw.trace(as_ptr, 15);
+}
+
+pub fn tracef(comptime fmt: []const u8, fmtargs: anytype) void {
+    var buf: [MAX_STRING_SIZE:0]u8 = undefined;
+    _ = std.fmt.bufPrintZ(&buf, fmt, fmtargs) catch unreachable;
+    trace(&buf);
 }
 
 const SectionFlags = packed struct {
@@ -483,11 +469,10 @@ const SyncArgs = struct {
 
 pub fn sync(args: SyncArgs) void {
     // var mask = SectionFlagsMask { .sections = args.sections };
-    raw.sync(@bitCast(u8, args.sections), args.bank, args.toCartridge);
+    raw.sync(@as(u8, @bitCast(args.sections)), args.bank, args.toCartridge);
 }
 
 // TIME KEEPING
 
 pub const time = raw.time;
 pub const tstamp = raw.tstamp;
-

--- a/templates/zig/README.md
+++ b/templates/zig/README.md
@@ -1,9 +1,9 @@
 # ZIG Starter Project Template
 
-This is a ZIG / TIC-80 starter template.  To build it, ensure you have a recent development release of Zig 0.10, then run:
+This is a ZIG / TIC-80 starter template. To build it, ensure you have the latest stable Zig release (0.11) or the development release (0.12), then run:
 
 ```
-zig build
+zig build -Doptimize=ReleaseSmall
 ```
 
 To import the resulting WASM to a cartridge:
@@ -21,3 +21,4 @@ save
 ```
 
 This is assuming you've run TIC-80 with `--fs .` inside your project directory.
+

--- a/templates/zig/build.zig
+++ b/templates/zig/build.zig
@@ -1,19 +1,27 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    const mode = b.standardReleaseOptions();
+pub fn build(b: *std.Build) !void {
+    const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addSharedLibrary("cart", "src/main.zig", .unversioned);
-    lib.setBuildMode(mode);
-    lib.setTarget(.{ .cpu_arch = .wasm32, .os_tag = .freestanding });
+    const lib = b.addSharedLibrary(.{
+        .name = "cart",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = .{ .cpu_arch = .wasm32, .os_tag = .wasi },
+        .optimize = optimize,
+    });
+
     lib.import_memory = true;
+    lib.stack_size = 8192;
     lib.initial_memory = 65536 * 4;
     lib.max_memory = 65536 * 4;
+
     lib.export_table = true;
+
     // all the memory below 96kb is reserved for TIC and memory mapped I/O
     // so our own usage must start above the 96kb mark
     lib.global_base = 96 * 1024;
-    lib.stack_size = 8192;
-    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "SCR", "BOOT" };
-    lib.install();
+
+    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "BOOT" };
+
+    b.installArtifact(lib);
 }

--- a/templates/zig/src/main.zig
+++ b/templates/zig/src/main.zig
@@ -30,3 +30,7 @@ export fn TIC() void {
 
     t += 1;
 }
+
+export fn BDR() void {}
+
+export fn OVR() void {}

--- a/templates/zig/src/tic80.zig
+++ b/templates/zig/src/tic80.zig
@@ -13,14 +13,16 @@
 // (yes even the original has this exact comment, be careful)
 
 const std = @import("std");
-comptime { std.testing.refAllDecls(@This()); } 
+comptime {
+    std.testing.refAllDecls(@This());
+}
 
 // types
 
 const MAX_STRING_SIZE = 200;
 const Offset_i8 = extern struct {
-  x: i8,
-  y: i8,
+    x: i8,
+    y: i8,
 };
 
 const RGBColor = extern struct {
@@ -29,12 +31,7 @@ const RGBColor = extern struct {
     b: u8,
 };
 
-const TextureSource = enum(i32) {
-    TILES = 0,
-    MAP,
-    VBANK1
-};
-
+const TextureSource = enum(i32) { TILES = 0, MAP, VBANK1 };
 
 // ------------------------
 // HARDWARE REGISTERS / RAM
@@ -42,69 +39,68 @@ const TextureSource = enum(i32) {
 pub const WIDTH: u32 = 240;
 pub const HEIGHT: u32 = 136;
 
-pub const FRAMEBUFFER: *allowzero volatile [16320]u8 = @intToPtr(*allowzero volatile [16320]u8, 0);
-pub const TILES : *[8192]u8 = @intToPtr(*[8192]u8, 0x4000);
-pub const SPRITES : *[8192]u8 = @intToPtr(*[8192]u8, 0x6000);
-pub const MAP : *[32640]u8 = @intToPtr(*[32640]u8, 0x8000);
-pub const GAMEPADS : *[4]u8 = @intToPtr(*[4]u8, 0xFF80);
-pub const MOUSE : *[4]u8 = @intToPtr(*[4]u8, 0xFF84);
-pub const KEYBOARD : *[4]u8 = @intToPtr(*[4]u8, 0xFF88);
-pub const SFX_STATE: *[16]u8 = @intToPtr(*[16]u8, 0xFF8C);
-pub const SOUND_REGISTERS: *[72]u8 = @intToPtr(*[72]u8, 0xFF9C);
-pub const WAVEFORMS: *[256]u8 =@intToPtr(*[256]u8, 0xFFE4);
-pub const SFX: *[4224]u8 =@intToPtr(*[4224]u8, 0x100E4);
-pub const MUSIC_PATTERNS: *[11520]u8 =@intToPtr(*[11520]u8, 0x11164);
-pub const MUSIC_TRACKS: *[408]u8 =@intToPtr(*[408]u8, 0x13E64);
-pub const SOUND_STATE: *[4]u8 =@intToPtr(*[4]u8, 0x13FFC);
-pub const STEREO_VOLUME: *[4]u8 =@intToPtr(*[4]u8, 0x14000);
-pub const PERSISTENT_RAM: *[1024]u8 =@intToPtr(*[1024]u8, 0x14004);
-pub const PERSISTENT_RAM_u32: *[256]u32 =@intToPtr(*[256]u32, 0x14004);
-pub const SPRITE_FLAGS: *[512]u8 =@intToPtr(*[512]u8, 0x14404);
-pub const SYSTEM_FONT: *[2048]u8 =@intToPtr(*[2048]u8, 0x14604);
+pub const FRAMEBUFFER: *allowzero volatile [16320]u8 = @as(*allowzero volatile [16320]u8, @ptrFromInt(0));
+pub const TILES: *[8192]u8 = @as(*[8192]u8, @ptrFromInt(0x4000));
+pub const SPRITES: *[8192]u8 = @as(*[8192]u8, @ptrFromInt(0x6000));
+pub const MAP: *[32640]u8 = @as(*[32640]u8, @ptrFromInt(0x8000));
+pub const GAMEPADS: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF80));
+pub const MOUSE: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF84));
+pub const KEYBOARD: *[4]u8 = @as(*[4]u8, @ptrFromInt(0xFF88));
+pub const SFX_STATE: *[16]u8 = @as(*[16]u8, @ptrFromInt(0xFF8C));
+pub const SOUND_REGISTERS: *[72]u8 = @as(*[72]u8, @ptrFromInt(0xFF9C));
+pub const WAVEFORMS: *[256]u8 = @as(*[256]u8, @ptrFromInt(0xFFE4));
+pub const SFX: *[4224]u8 = @as(*[4224]u8, @ptrFromInt(0x100E4));
+pub const MUSIC_PATTERNS: *[11520]u8 = @as(*[11520]u8, @ptrFromInt(0x11164));
+pub const MUSIC_TRACKS: *[408]u8 = @as(*[408]u8, @ptrFromInt(0x13E64));
+pub const SOUND_STATE: *[4]u8 = @as(*[4]u8, @ptrFromInt(0x13FFC));
+pub const STEREO_VOLUME: *[4]u8 = @as(*[4]u8, @ptrFromInt(0x14000));
+pub const PERSISTENT_RAM: *[1024]u8 = @as(*[1024]u8, @ptrFromInt(0x14004));
+pub const PERSISTENT_RAM_u32: *[256]u32 = @as(*[256]u32, @ptrFromInt(0x14004));
+pub const SPRITE_FLAGS: *[512]u8 = @as(*[512]u8, @ptrFromInt(0x14404));
+pub const SYSTEM_FONT: *[2048]u8 = @as(*[2048]u8, @ptrFromInt(0x14604));
 
 // vbank 0
 
 const PaletteMap = packed struct {
-  color0: u4,
-  color1: u4,
-  color2: u4,
-  color3: u4,
-  color4: u4,
-  color5: u4,
-  color6: u4,
-  color7: u4,
-  color8: u4,
-  color9: u4,
-  color10: u4,
-  color11: u4,
-  color12: u4,
-  color13: u4,
-  color14: u4,
-  color15: u4,
+    color0: u4,
+    color1: u4,
+    color2: u4,
+    color3: u4,
+    color4: u4,
+    color5: u4,
+    color6: u4,
+    color7: u4,
+    color8: u4,
+    color9: u4,
+    color10: u4,
+    color11: u4,
+    color12: u4,
+    color13: u4,
+    color14: u4,
+    color15: u4,
 };
 
-pub const PALETTE: *[16]RGBColor = @intToPtr(*[16]RGBColor, 0x3FC0);
-pub const PALETTE_u8: *[48]u8 = @intToPtr(*[48]u8, 0x3FC0);
-pub const PALETTE_MAP: *PaletteMap = @intToPtr(*PaletteMap, 0x3FF0);
-pub const PALETTE_MAP_u8: *[8]u8 = @intToPtr(*[8]u8, 0x3FF0);
+pub const PALETTE: *[16]RGBColor = @as(*[16]RGBColor, @ptrFromInt(0x3FC0));
+pub const PALETTE_u8: *[48]u8 = @as(*[48]u8, @ptrFromInt(0x3FC0));
+pub const PALETTE_MAP: *PaletteMap = @as(*PaletteMap, @ptrFromInt(0x3FF0));
+pub const PALETTE_MAP_u8: *[8]u8 = @as(*[8]u8, @ptrFromInt(0x3FF0));
 // TODO: this doesn't work unless it's packed, which I dno't think we can do?
-// pub const PALETTE_MAP: *[16]u4 = @intToPtr(*[16]u4, 0x3FF0);
-pub const BORDER_COLOR: *u8 = @intToPtr(*u8, 0x3FF8);
-pub const SCREEN_OFFSET: *Offset_i8 = @intToPtr(*Offset_i8, 0x3FF9);
-pub const MOUSE_CURSOR: *u8 = @intToPtr(*u8, 0x3FFB);
-pub const BLIT_SEGMENT: *u8 = @intToPtr(*u8, 0x3FFC);
+// pub const PALETTE_MAP: *[16]u4 = @ptrFromInt(*[16]u4, 0x3FF0);
+pub const BORDER_COLOR: *u8 = @as(*u8, @ptrFromInt(0x3FF8));
+pub const SCREEN_OFFSET: *Offset_i8 = @as(*Offset_i8, @ptrFromInt(0x3FF9));
+pub const MOUSE_CURSOR: *u8 = @as(*u8, @ptrFromInt(0x3FFB));
+pub const BLIT_SEGMENT: *u8 = @as(*u8, @ptrFromInt(0x3FFC));
 
 // vbank 1
-pub const OVR_TRANSPARENCY: *u8 = @intToPtr(*u8, 0x3FF8);
-
+pub const OVR_TRANSPARENCY: *u8 = @as(*u8, @ptrFromInt(0x3FF8));
 
 // import the RAW api
 
 pub const raw = struct {
     pub extern fn btn(id: i32) i32;
-    pub extern fn btnp(id: i32, hold: i32, period: i32 ) bool;
+    pub extern fn btnp(id: i32, hold: i32, period: i32) bool;
     pub extern fn clip(x: i32, y: i32, w: i32, h: i32) void;
-    pub extern fn cls(color: i32) void; 
+    pub extern fn cls(color: i32) void;
     pub extern fn circ(x: i32, y: i32, radius: i32, color: i32) void;
     pub extern fn circb(x: i32, y: i32, radius: i32, color: i32) void;
     pub extern fn exit() void;
@@ -114,28 +110,28 @@ pub const raw = struct {
     pub extern fn font(text: [*:0]u8, x: u32, y: i32, trans_colors: ?[*]const u8, color_count: i32, char_width: i32, char_height: i32, fixed: bool, scale: i32, alt: bool) i32;
     pub extern fn fset(id: i32, flag: u8, value: bool) bool;
     pub extern fn key(keycode: i32) bool;
-    pub extern fn keyp(keycode: i32, hold: i32, period: i32 ) bool;
+    pub extern fn keyp(keycode: i32, hold: i32, period: i32) bool;
     pub extern fn line(x0: i32, y0: i32, x1: i32, y1: i32, color: i32) void;
     pub extern fn map(x: i32, y: i32, w: i32, h: i32, sx: i32, sy: i32, trans_colors: ?[*]const u8, color_count: i32, scale: i32, remap: i32) void;
     pub extern fn memcpy(to: u32, from: u32, length: u32) void;
     pub extern fn memset(addr: u32, value: u8, length: u32) void;
-    pub extern fn mget(x: i32, y:i32) i32;
+    pub extern fn mget(x: i32, y: i32) i32;
     pub extern fn mouse(data: *MouseData) void;
-    pub extern fn mset(x: i32, y:i32, value: bool) void;
+    pub extern fn mset(x: i32, y: i32, tile_id: u32) void;
     pub extern fn music(track: i32, frame: i32, row: i32, loop: bool, sustain: bool, tempo: i32, speed: i32) void;
     pub extern fn peek(addr: u32, bits: i32) u8;
     pub extern fn peek4(addr4: u32) u8;
     pub extern fn peek2(addr2: u32) u8;
     pub extern fn peek1(bitaddr: u32) u8;
-    pub extern fn pix(x: i32, y:i32, color: i32) void;
+    pub extern fn pix(x: i32, y: i32, color: i32) void;
     pub extern fn pmem(index: u32, value: i64) u32;
     pub extern fn poke(addr: u32, value: u8, bits: i32) void;
     pub extern fn poke4(addr4: u32, value: u8) void;
     pub extern fn poke2(addr2: u32, value: u8) void;
     pub extern fn poke1(bitaddr: u32, value: u8) void;
     pub extern fn print(text: [*:0]const u8, x: i32, y: i32, color: i32, fixed: bool, scale: i32, smallfont: bool) i32;
-    pub extern fn rect(x: i32, y: i32, w: i32, h:i32, color: i32) void;
-    pub extern fn rectb(x: i32, y: i32, w: i32, h:i32, color: i32) void;    
+    pub extern fn rect(x: i32, y: i32, w: i32, h: i32, color: i32) void;
+    pub extern fn rectb(x: i32, y: i32, w: i32, h: i32, color: i32) void;
     pub extern fn reset() void;
     pub extern fn sfx(id: i32, note: i32, octave: i32, duration: i32, channel: i32, volumeLeft: i32, volumeRight: i32, speed: i32) void;
     pub extern fn spr(id: i32, x: i32, y: i32, trans_colors: ?[*]const u8, color_count: i32, scale: i32, flip: i32, rotate: i32, w: i32, h: i32) void;
@@ -153,13 +149,13 @@ pub const raw = struct {
 // INPUT
 
 const MouseData = extern struct {
-  x: i16,
-  y: i16,
-  scrollx: i8,
-  scrolly: i8,
-  left: bool,
-  middle: bool,
-  right: bool,
+    x: i16,
+    y: i16,
+    scrollx: i8,
+    scrolly: i8,
+    left: bool,
+    middle: bool,
+    right: bool,
 };
 
 pub const key = raw.key;
@@ -178,7 +174,6 @@ pub fn btn(id: i32) bool {
 pub fn anybtn() bool {
     return raw.btn(-1) != 0;
 }
-
 
 // -----------------
 // DRAW / DRAW UTILS
@@ -204,7 +199,7 @@ pub const mouse = raw.mouse;
 // pub extern fn map(x: i32, y: i32, w: i32, h: i32, sx: i32, sy: i32, trans_colors: ?[*]u8, color_count: i32, scale: i32, remap: i32) void;
 
 const MapArgs = struct {
-    x: i32 = 0, 
+    x: i32 = 0,
     y: i32 = 0,
     w: i32 = 30,
     h: i32 = 17,
@@ -216,18 +211,18 @@ const MapArgs = struct {
 };
 
 pub fn map(args: MapArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
     std.debug.assert(color_count < 16);
     raw.map(args.x, args.y, args.w, args.h, args.sx, args.sy, colors, color_count, args.scale, args.remap);
 }
 
 pub fn pix(x: i32, y: i32, color: u8) void {
-    raw.pix(x,y,color);
+    raw.pix(x, y, color);
 }
 
 pub fn getpix(x: i32, y: i32) u8 {
-    raw.pix(x,y, -1);
+    raw.pix(x, y, -1);
 }
 
 // pub extern fn spr(id: i32, x: i32, y: i32, trans_colors: [*]u8, color_count: i32, scale: i32, flip: i32, rotate: i32, w: i32, h: i32) void;
@@ -256,10 +251,10 @@ const SpriteArgs = struct {
 };
 
 pub fn spr(id: i32, x: i32, y: i32, args: SpriteArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
     std.debug.assert(color_count < 16);
-    raw.spr(id, x, y, colors, color_count, args.scale, @enumToInt(args.flip), @enumToInt(args.rotate), args.w, args.h);
+    raw.spr(id, x, y, colors, color_count, args.scale, @intFromEnum(args.flip), @intFromEnum(args.rotate), args.w, args.h);
 }
 
 pub const rect = raw.rect;
@@ -268,18 +263,18 @@ pub const tri = raw.tri;
 pub const trib = raw.trib;
 
 const TextriArgs = struct {
-    texture_source : TextureSource = TextureSource.TILES,
+    texture_source: TextureSource = TextureSource.TILES,
     transparent: []const u8 = &.{},
-    z1 : f32 = 0,
-    z2 : f32 = 0,
-    z3 : f32 = 0,
-    depth : bool = false,
+    z1: f32 = 0,
+    z2: f32 = 0,
+    z3: f32 = 0,
+    depth: bool = false,
 };
 
 pub fn ttri(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32, @"u1": f32, v1: f32, @"u2": f32, v2: f32, @"u3": f32, v3: f32, args: TextriArgs) void {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const trans_colors = args.transparent.ptr;
-    raw.ttri(x1, y1, x2, y2, x3, y3, @"u1", v1, @"u2", v2, @"u3", v3, @enumToInt(args.texture_source), trans_colors, color_count, args.z1, args.z2, args.z3, args.depth);
+    raw.ttri(x1, y1, x2, y2, x3, y3, @"u1", v1, @"u2", v2, @"u3", v3, @intFromEnum(args.texture_source), trans_colors, color_count, args.z1, args.z2, args.z3, args.depth);
 }
 
 // ----
@@ -287,46 +282,33 @@ pub fn ttri(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32, @"u1": f32, v1
 
 const PrintArgs = struct {
     color: u8 = 15,
-    fixed : bool = false,
-    small_font : bool = false,
-    scale : u8 = 1,
-};
-
-const FontArgs = struct {
-    transparent: []const u8 = &.{},
-    char_width: u8, 
-    char_height: u8,
     fixed: bool = false,
+    small_font: bool = false,
     scale: u8 = 1,
-    alt: bool = false
 };
 
-fn sliceToZString(text: []const u8, buff: [*:0]u8, maxLen: u16) void {
-    var len = std.math.min(maxLen, text.len);
-    std.mem.copy(u8, buff[0..len], text[0..len]);
-    buff[len] = 0; 
-}
+const FontArgs = struct { transparent: []const u8 = &.{}, char_width: u8, char_height: u8, fixed: bool = false, scale: u8 = 1, alt: bool = false };
 
+/// Prints the text and returns the width of the text in pixels
 pub fn print(text: []const u8, x: i32, y: i32, args: PrintArgs) i32 {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    return raw.print(&buff, x, y, args.color, args.fixed, args.scale, args.small_font);
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    return raw.print(as_ptr, x, y, args.color, args.fixed, args.scale, args.small_font);
 }
 
+/// Prints the text using format and returns the width of the text in pixels
 pub fn printf(comptime fmt: []const u8, fmtargs: anytype, x: i32, y: i32, args: PrintArgs) i32 {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
+    var buff: [MAX_STRING_SIZE:0]u8 = undefined;
     _ = std.fmt.bufPrintZ(&buff, fmt, fmtargs) catch unreachable;
     return raw.print(&buff, x, y, args.color, args.fixed, args.scale, args.small_font);
 }
 
 pub fn font(text: []const u8, x: u32, y: i32, args: FontArgs) i32 {
-    const color_count = @intCast(u8,args.transparent.len);
+    const color_count = @as(u8, @intCast(args.transparent.len));
     const colors = args.transparent.ptr;
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    return raw.font(&buff, x, y, colors, color_count, args.char_width, args.char_height, args.fixed, args.scale, args.alt);
-}
 
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    return raw.font(as_ptr, x, y, colors, color_count, args.char_width, args.char_height, args.fixed, args.scale, args.alt);
+}
 
 // -----
 // AUDIO
@@ -335,13 +317,13 @@ pub fn font(text: []const u8, x: u32, y: i32, args: FontArgs) i32 {
 const MusicArgs = struct {
     frame: i8 = -1,
     row: i8 = -1,
-    loop: bool = true, 
+    loop: bool = true,
     sustain: bool = false,
     tempo: i8 = -1,
     speed: i8 = -1,
 };
 
-pub fn music(track:i32, args: MusicArgs) void {
+pub fn music(track: i32, args: MusicArgs) void {
     raw.music(track, args.frame, args.row, args.loop, args.sustain, args.tempo, args.speed);
 }
 
@@ -351,26 +333,26 @@ pub fn nomusic() void {
 
 // sfx id [note] [duration=-1] [channel=0] [volume=15] [speed=0]
 // void tic_api_sfx(tic_mem* memory, s32 index, s32 note, s32 octave, s32 duration, s32 channel, s32 left, s32 right, s32 speed)
-const MAX_VOLUME : i8 = 15;
+const MAX_VOLUME: i8 = 15;
 const SfxArgs = struct {
     sfx: i8 = -1,
-    note: i8 = -1, 
+    note: i8 = -1,
     octave: i8 = -1,
     duration: i8 = -1,
     channel: i8 = 0,
     volume: i8 = 15,
     volumeLeft: i8 = 15,
     volumeRight: i8 = 15,
-    speed: i8 = 0,  
+    speed: i8 = 0,
 };
 
 // pub extern fn sfx(id: i32, note: i32, duration: i32, channel: i32, volume: i32, speed: i32) void;
 
-const SFX_NOTES = [_][] const u8 {"C-", "C#", "D-", "D#", "E-", "F-", "F#", "G-", "G#", "A-", "A#", "B-"};
+const SFX_NOTES = [_][]const u8{ "C-", "C#", "D-", "D#", "E-", "F-", "F#", "G-", "G#", "A-", "A#", "B-" };
 
 fn parse_note(name: []const u8, noteArgs: *SfxArgs) bool {
-    var note_signature : []const u8 = undefined;
-    var octave : u8 = undefined;
+    var note_signature: []const u8 = undefined;
+    var octave: u8 = undefined;
     if (name.len == 2) {
         note_signature = &.{ name[0], '-' };
         octave = name[1];
@@ -383,17 +365,16 @@ fn parse_note(name: []const u8, noteArgs: *SfxArgs) bool {
     for (SFX_NOTES) |music_note| {
         if (std.mem.eql(u8, music_note, note_signature)) {
             noteArgs.note = i;
-            noteArgs.octave = @intCast(i8, octave - '1');
+            noteArgs.octave = @as(i8, @intCast(octave - '1'));
             return true;
         }
-        i+=1;
+        i += 1;
     }
     return false;
 }
 
-
 pub fn note(name: []const u8, args: SfxArgs) void {
-    var largs : SfxArgs = args;
+    var largs: SfxArgs = args;
     if (parse_note(name, &largs)) {
         sfx(args.sfx, largs);
     }
@@ -404,7 +385,7 @@ pub fn sfx(id: i32, args: SfxArgs) void {
     if (args.volume != MAX_VOLUME) {
         largs.volumeLeft = args.volume;
         largs.volumeRight = args.volume;
-    } 
+    }
     raw.sfx(id, args.note, args.octave, args.duration, args.channel, largs.volumeLeft, largs.volumeRight, args.speed);
 }
 
@@ -434,7 +415,6 @@ pub const poke4 = raw.poke4;
 pub const poke2 = raw.poke2;
 pub const poke1 = raw.poke1;
 
-
 pub fn peek(addr: u32) u8 {
     return raw.peek(addr, 8);
 }
@@ -448,9 +428,14 @@ pub const vbank = raw.vbank;
 pub const exit = raw.exit;
 pub const reset = raw.reset;
 pub fn trace(text: []const u8) void {
-    var buff : [MAX_STRING_SIZE:0]u8 = undefined;
-    sliceToZString(text, &buff, MAX_STRING_SIZE);
-    raw.trace(&buff);
+    const as_ptr: [*:0]const u8 = @as([*:0]const u8, @ptrCast(text));
+    raw.trace(as_ptr, 15);
+}
+
+pub fn tracef(comptime fmt: []const u8, fmtargs: anytype) void {
+    var buf: [MAX_STRING_SIZE:0]u8 = undefined;
+    _ = std.fmt.bufPrintZ(&buf, fmt, fmtargs) catch unreachable;
+    trace(&buf);
 }
 
 const SectionFlags = packed struct {
@@ -484,11 +469,10 @@ const SyncArgs = struct {
 
 pub fn sync(args: SyncArgs) void {
     // var mask = SectionFlagsMask { .sections = args.sections };
-    raw.sync(@bitCast(u8, args.sections), args.bank, args.toCartridge);
+    raw.sync(@as(u8, @bitCast(args.sections)), args.bank, args.toCartridge);
 }
 
 // TIME KEEPING
 
 pub const time = raw.time;
 pub const tstamp = raw.tstamp;
-


### PR DESCRIPTION
The previous Zig `build` and `tic80.zig` files built fine with Zig 0.10, but no longer build with the latest _stable_ (0.11) nor the current development version (0.12). 

This PR updates the Zig examples so that they build with both 0.11 and 0.12 😄 

I've also formatted the files in question with Zig's language server formatter.