### PR TITLE
Add true, false, nil to FennelKeywords

### DIFF
--- a/src/api/fennel.c
+++ b/src/api/fennel.c
@@ -98,7 +98,8 @@ static const char* const FennelKeywords [] =
     "lambda", "length", "let", "local", "lshift", "lua", "macro",
     "macrodebug", "macros", "match", "match-try", "not", "not=", "or",
     "partial", "pick-args", "pick-values", "quote", "require-macros",
-    "rshift", "set", "tset", "values", "var", "when", "while", "with-open"
+    "rshift", "set", "tset", "values", "var", "when", "while", "with-open",
+    "true", "false", "nil"
 };
 
 static inline bool fennel_isalnum(char c)


### PR DESCRIPTION
Fixed #2302 . This PR adds `true`, `false` and `nil` to FennelKeywords, in order to make those words be in a different color in the editor.

Before PR:
![image](https://github.com/nesbox/TIC-80/assets/58057324/9c39ce71-7f33-41f7-b263-cf9d4f2eb669)

With PR:
![image](https://github.com/nesbox/TIC-80/assets/58057324/dd5f0763-19b2-47fc-a40c-23231e2dfafa)

Feel free to ask any questions! :D