### PR TITLE
Fix issue 2291

### DIFF
--- a/src/api/js.c
+++ b/src/api/js.c
@@ -237,7 +237,7 @@ static JSValue js_spr(JSContext *ctx, JSValueConst this_val, s32 argc, JSValueCo
     }
     else
     {
-        colors[0] = getInteger2(ctx, argv[3], 0);
+        colors[0] = getInteger2(ctx, argv[3], -1);
         count = 1;
     }
 


### PR DESCRIPTION
As described in issue 2291, the code to handle the colorkey parameter in the spr function did not use the correct default value in one of the two code paths.

We now pass the correct default value to getInteger2, this handles cases where the parameter is not present, and where the parameter is `undefined` in JS.