### PR TITLE
`trace` can log object-type argument in ruby to be consistent with lua

### DIFF
--- a/src/api/mruby.c
+++ b/src/api/mruby.c
@@ -900,7 +900,7 @@ static mrb_value mrb_trace(mrb_state *mrb, mrb_value self)
 {
     mrb_value text_obj;
     mrb_int color = TIC_DEFAULT_COLOR;
-    mrb_get_args(mrb, "S|i", &text_obj, &color);
+    mrb_get_args(mrb, "o|i", &text_obj, &color);
 
     tic_core* machine = getMRubyMachine(mrb);
 


### PR DESCRIPTION
`trace` in lua accepts object-type argument. so should ruby be