### PR TITLE
Increase in possible notes for playing on piano roll, new keyboard layout (like in popular DAWs)

### DIFF
--- a/src/studio/editors/music.c
+++ b/src/studio/editors/music.c
@@ -1102,6 +1102,9 @@ static void processTrackerKeyboard(Music* music)
                 resetSelection(music);
         }
 
+    static const u8 newOctaveIndex = 16;
+    static const u8 keboardShift = 5;
+
     static const u8 Piano[] =
     {
         tic_key_z,
@@ -1116,6 +1119,11 @@ static void processTrackerKeyboard(Music* music)
         tic_key_n,
         tic_key_j,
         tic_key_m,
+        tic_key_comma,
+        tic_key_l,
+        tic_key_period,
+        tic_key_semicolon,
+        tic_key_slash,
 
         // octave +1
         tic_key_q,
@@ -1147,7 +1155,12 @@ static void processTrackerKeyboard(Music* music)
         {
         case ColumnNote:
         case ColumnSemitone:
-            if (keyWasPressed(music->studio, tic_key_1) || keyWasPressed(music->studio, tic_key_a))
+            if(keyWasPressed(music->studio, tic_key_z) && shift) 
+                music->last.octave -= 1;
+            else if(keyWasPressed(music->studio, tic_key_x) && shift) 
+                music->last.octave += 1;
+
+            if (keyWasPressed(music->studio, tic_key_a))
             {
                 setStopNote(music);
                 downRow(music);
@@ -1158,10 +1171,10 @@ static void processTrackerKeyboard(Music* music)
 
                 for (s32 i = 0; i < COUNT_OF(Piano); i++)
                 {
-                    if (keyWasPressed(music->studio, Piano[i]))
+                    if (keyWasPressed(music->studio, Piano[i]) && !shift)
                     {
-                        s32 note = i % NOTES;
-                        s32 octave = i / NOTES + music->last.octave;
+                        s32 note = (i > newOctaveIndex ? i - keboardShift : i)  % NOTES;
+                        s32 octave = (i - note) / NOTES + music->last.octave;
                         s32 sfx = music->last.sfx;
                         setNote(music, note, octave, sfx);
 

--- a/src/studio/editors/music.c
+++ b/src/studio/editors/music.c
@@ -1053,6 +1053,11 @@ static void setChannelPattern(Music* music, s32 delta, s32 channel)
     setChannelPatternValue(music, pattern + delta, music->frame, channel);
 }
 
+static inline bool keyWasPressedOnce(tic_mem* tic, s32 key)
+{
+    return tic_api_keyp(tic, key, -1, -1);
+}
+
 static void processTrackerKeyboard(Music* music)
 {
     tic_mem* tic = music->tic;
@@ -1155,9 +1160,9 @@ static void processTrackerKeyboard(Music* music)
         {
         case ColumnNote:
         case ColumnSemitone:
-            if(keyWasPressed(music->studio, tic_key_z) && shift) 
+            if(keyWasPressedOnce(tic, tic_key_z) && shift) 
                 music->last.octave -= 1;
-            else if(keyWasPressed(music->studio, tic_key_x) && shift) 
+            else if(keyWasPressedOnce(tic, tic_key_x) && shift) 
                 music->last.octave += 1;
 
             if (keyWasPressed(music->studio, tic_key_a))
@@ -1181,7 +1186,7 @@ static void processTrackerKeyboard(Music* music)
                         downRow(music);
 
                         break;
-                    }               
+                    } 
                 }
             }
             break;


### PR DESCRIPTION
Slightly changed the keyboard in the SFX editor so that it became more similar to the popular DAWs (Ableton, Garage Band, etc...)

1. Added the ability to switch between octaves on Z and X
2. Raised all the shortcuts one row higher (A, W, S, E, D, ...)
3. Increase the number of possible notes that can be played on the keyboard