### PR TITLE
[Python] Fix incorrect signature of `print`

### DIFF
--- a/src/api/python.c
+++ b/src/api/python.c
@@ -810,7 +810,6 @@ static int py_print(pkpy_vm* vm) {
     int color;
     bool fixed;
     int scale;
-    bool small_;
     bool alt;
 
     pkpy_dup(vm, 0);
@@ -823,8 +822,7 @@ static int py_print(pkpy_vm* vm) {
     pkpy_to_int(vm, 3, &color);
     pkpy_to_bool(vm, 4, &fixed);
     pkpy_to_int(vm, 5, &scale);
-    pkpy_to_bool(vm, 6, &small_);
-    pkpy_to_bool(vm, 7, &alt);
+    pkpy_to_bool(vm, 6, &alt);
     get_core(vm, (tic_core**) &tic);
     if(pkpy_check_error(vm)) {
         return 0;
@@ -1257,7 +1255,7 @@ static bool setup_c_bindings(pkpy_vm* vm) {
     pkpy_push_function(vm, "poke4(addr: int, value: int)", py_poke4);
     pkpy_setglobal_2(vm, "poke4");
 
-    pkpy_push_function(vm, "print(text, x=0, y=0, color=15, fixed=False, scale=1, smallfont=False, alt=False)", py_print);
+    pkpy_push_function(vm, "print(text, x=0, y=0, color=15, fixed=False, scale=1, alt=False)", py_print);
     pkpy_setglobal_2(vm, "print");
 
     pkpy_push_function(vm, "rect(x: int, y: int, w: int, h: int, color: int)", py_rect);


### PR DESCRIPTION
Change `print` into `print(text, x=0, y=0, color=15, fixed=False, scale=1, alt=False)`.

Fix https://github.com/nesbox/TIC-80/issues/2338.