### PR TITLE
Fix support for the Xcode generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,8 +434,8 @@ set(GIFLIB_SRC
 add_library(giflib STATIC ${GIFLIB_SRC})
 target_include_directories(giflib
     PRIVATE ${GIFLIB_DIR}
-    INTERFACE 
-        ${THIRDPARTY_DIR}/giflib 
+    INTERFACE
+        ${THIRDPARTY_DIR}/giflib
         ${THIRDPARTY_DIR}/msf_gif)
 
 ################################
@@ -454,8 +454,8 @@ set(QUICKJS_DIR ${THIRDPARTY_DIR}/quickjs)
 file(STRINGS ${QUICKJS_DIR}/VERSION CONFIG_VERSION)
 
 add_library(quickjs STATIC
-    ${QUICKJS_DIR}/quickjs.c 
-    ${QUICKJS_DIR}/libregexp.c 
+    ${QUICKJS_DIR}/quickjs.c
+    ${QUICKJS_DIR}/libregexp.c
     ${QUICKJS_DIR}/libunicode.c
     ${QUICKJS_DIR}/cutils.c)
 
@@ -467,7 +467,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 if(BAREMETALPI OR N3DS)
-    target_compile_definitions(quickjs PRIVATE POOR_CLIB) 
+    target_compile_definitions(quickjs PRIVATE POOR_CLIB)
 endif()
 
 if(LINUX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,7 +925,7 @@ if(BUILD_DEMO_CARTS)
         list(APPEND DEMO_CARTS_OUT ${OUTNAME})
 
         add_custom_command(OUTPUT ${OUTNAME}
-            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/prj2cart ${CART_FILE} ${OUTPRJ} && ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin2txt ${OUTPRJ} ${OUTNAME} -z
+            COMMAND $<TARGET_FILE:prj2cart> ${CART_FILE} ${OUTPRJ} && $<TARGET_FILE:bin2txt> ${OUTPRJ} ${OUTNAME} -z
             DEPENDS bin2txt prj2cart ${CART_FILE}
     )
 
@@ -950,14 +950,14 @@ if(BUILD_DEMO_CARTS)
         set(OUTPRJ ${CMAKE_SOURCE_DIR}/build/${CART_NAME}.tic)
         list(APPEND DEMO_CARTS_OUT ${OUTNAME})
         add_custom_command(OUTPUT ${OUTNAME}
-            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/wasmp2cart ${CART_FILE} ${OUTPRJ} --binary ${WASM_BINARY} && ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin2txt ${OUTPRJ} ${OUTNAME} -z
+            COMMAND $<TARGET_FILE:wasmp2cart> ${CART_FILE} ${OUTPRJ} --binary ${WASM_BINARY} && $<TARGET_FILE:bin2txt> ${OUTPRJ} ${OUTNAME} -z
             DEPENDS bin2txt wasmp2cart ${CART_FILE} ${WASM_BINARY}
         )
 
     endforeach(CART_FILE)
 
     add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/build/assets/cart.png.dat
-        COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin2txt ${CMAKE_SOURCE_DIR}/build/cart.png ${CMAKE_SOURCE_DIR}/build/assets/cart.png.dat
+        COMMAND $<TARGET_FILE:bin2txt> ${CMAKE_SOURCE_DIR}/build/cart.png ${CMAKE_SOURCE_DIR}/build/assets/cart.png.dat
         DEPENDS bin2txt ${CMAKE_SOURCE_DIR}/build/cart.png)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -855,6 +855,10 @@ endif ()
 set(CMAKE_DISABLE_TESTING ON CACHE BOOL "" FORCE)
 add_subdirectory(${THIRDPARTY_DIR}/zip)
 
+if(APPLE AND XCODE)
+  target_compile_options(zip PRIVATE -Wno-shorten-64-to-32)
+endif()
+
 ################################
 # bin2txt cart2prj prj2cart xplode wasmp2cart
 ################################

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ cmake ..
 make -j4
 ```
 
+You can replace `cmake ..` with `cmake  -G Xcode ..` to generate an Xcode project in the `build` folder instead of a Makefile.
+
 to create application icon for development version
 ```
 mkdir -p ~/Applications/TIC80dev.app/Contents/{MacOS,Resources}


### PR DESCRIPTION
Here's a few small tweaks to generate an Xcode project files.

The biggest change here is updating the zip library to the latest version.

Since I'm new to contributing to this project, I welcome any feedback or suggestions on how to make sure this change doesn't break other platforms.