### PR TITLE
zig: Replace `addSharedLibrary` with `addExecutable`

### DIFF
--- a/templates/zig/README.md
+++ b/templates/zig/README.md
@@ -1,6 +1,6 @@
 # ZIG Starter Project Template
 
-This is a ZIG / TIC-80 starter template. To build it, ensure you have the latest stable Zig release (0.11) or the development release (0.12), then run:
+This is a ZIG / TIC-80 starter template. To build it, ensure you have the latest development release (`0.12.0-dev.1482+e74ced21b` or newer), then run:
 
 ```
 zig build -Doptimize=ReleaseSmall
@@ -9,14 +9,14 @@ zig build -Doptimize=ReleaseSmall
 To import the resulting WASM to a cartridge:
 
 ```
-tic80 --fs . --cmd 'load game.tic & import binary zig-out/lib/cart.wasm & save'
+tic80 --fs . --cmd 'load game.tic & import binary zig-out/bin/cart.wasm & save'
 ```
 
 Or from the TIC-80 console:
 
 ```
 load game.tic
-import binary zig-out/lib/cart.wasm
+import binary zig-out/bin/cart.wasm
 save
 ```
 

--- a/templates/zig/build.zig
+++ b/templates/zig/build.zig
@@ -3,25 +3,26 @@ const std = @import("std");
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addSharedLibrary(.{
+    const exe = b.addExecutable(.{
         .name = "cart",
         .root_source_file = .{ .path = "src/main.zig" },
         .target = .{ .cpu_arch = .wasm32, .os_tag = .wasi },
         .optimize = optimize,
     });
 
-    lib.import_memory = true;
-    lib.stack_size = 8192;
-    lib.initial_memory = 65536 * 4;
-    lib.max_memory = 65536 * 4;
+    exe.entry = .disabled;
+    exe.import_memory = true;
+    exe.stack_size = 8192;
+    exe.initial_memory = 65536 * 4;
+    exe.max_memory = 65536 * 4;
 
-    lib.export_table = true;
+    exe.export_table = true;
 
     // all the memory below 96kb is reserved for TIC and memory mapped I/O
     // so our own usage must start above the 96kb mark
-    lib.global_base = 96 * 1024;
+    exe.global_base = 96 * 1024;
 
-    lib.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "BOOT" };
+    exe.export_symbol_names = &[_][]const u8{ "TIC", "OVR", "BDR", "BOOT" };
 
-    b.installArtifact(lib);
+    b.installArtifact(exe);
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Related to the breaking changes in https://github.com/ziglang/zig/pull/17815

This requires `0.12.0-dev.1482+e74ced21b` or later (currently the latest `master` release on https://ziglang.org/download/ is `0.12.0-dev.1516+a70d8d29d`)