### PR TITLE
fix high fps bug for >60Hz displays

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1920,6 +1920,8 @@ static s32 start(s32 argc, char **argv, const char* folder)
 
                     if(delay > 0)
                         SDL_Delay((u32)(delay * 1000 / SDL_GetPerformanceFrequency()));
+                    else if(delay < 0)
+                        nextTick = SDL_GetPerformanceCounter();
                 }
             }
 #endif


### PR DESCRIPTION
Fixes bug discussed in #1873 for non-emscripten builds (everything else except html). Tested on Windows 10 machine with a 160Hz display.

Note: This could introduce a lag when catching up with frames not drawn yet.

Thanks to @ronchaine for the code, I just verified the result & created a pull request. :D