### PR TITLE
api/wasm: Make pmem `writeToStorage` an argument

### DIFF
--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -575,15 +575,10 @@ m3ApiRawFunction(wasmtic_pmem)
     m3ApiReturnType  (uint32_t)
 
     m3ApiGetArg      (int32_t, address)
-    m3ApiGetArg      (int64_t, value)
-    bool writeToStorage;
+    m3ApiGetArg      (uint32_t, value)
+    m3ApiGetArg      (bool, writeToStorage)
 
     tic_mem* tic = (tic_mem*)getWasmCore(runtime);
-
-    // read value
-    if (value == -1) { 
-        writeToStorage = false;
-    };
 
     // TODO: this should move into tic_api_pmem, should it not?
     if (address >= TIC_PERSISTENT_SIZE) {
@@ -987,7 +982,7 @@ M3Result linkTicAPI(IM3Module module)
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "peek4",   "i(i)",          &wasmtic_peek4)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "peek2",   "i(i)",          &wasmtic_peek2)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "peek1",   "i(i)",          &wasmtic_peek1)));
-    _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "pmem",    "i(ii)",         &wasmtic_pmem)));
+    _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "pmem",    "i(iii)",        &wasmtic_pmem)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "poke",    "v(iii)",        &wasmtic_poke)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "poke4",   "v(ii)",         &wasmtic_poke4)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "poke2",   "v(ii)",         &wasmtic_poke2)));


### PR DESCRIPTION
Related to #2360 

> [!Important]
> This changes the signature of `wasmtic_pmem` so might not be acceptable?