### PR TITLE
api/wasm: `writeToStorage` defaults to `true`, update `wasmtic_pmem` signature from `i(ii)` to `i(iI)`

### DIFF
--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -576,7 +576,7 @@ m3ApiRawFunction(wasmtic_pmem)
 
     m3ApiGetArg      (int32_t, address)
     m3ApiGetArg      (int64_t, value)
-    bool writeToStorage;
+    bool writeToStorage = true;
 
     tic_mem* tic = (tic_mem*)getWasmCore(runtime);
 
@@ -987,7 +987,7 @@ M3Result linkTicAPI(IM3Module module)
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "peek4",   "i(i)",          &wasmtic_peek4)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "peek2",   "i(i)",          &wasmtic_peek2)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "peek1",   "i(i)",          &wasmtic_peek1)));
-    _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "pmem",    "i(ii)",         &wasmtic_pmem)));
+    _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "pmem",    "i(iI)",         &wasmtic_pmem)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "poke",    "v(iii)",        &wasmtic_poke)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "poke4",   "v(ii)",         &wasmtic_poke4)));
     _   (SuppressLookupFailure (m3_LinkRawFunction (module, "env", "poke2",   "v(ii)",         &wasmtic_poke2)));


### PR DESCRIPTION
I noticed two issues in `src/api/wasm.c` when trying to call `pmem` from a small [Zig](https://ziglang.org/) :zap: program (compiling to `.wasm`)

- `writeToStorage` was never set to `true` _(unless I've misunderstood the code that is)_
- The signature of `wasmtic_pmem` indicated that the arguments would be three 32 bit values: `i(ii)`, and not two 32 bit (return value and `address`) + one 64 bit value (for `value`) as I expected: `i(iI)`

Related to issue #2360