### PR TITLE
Alt caret

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -14,6 +14,7 @@ THEME=
 		CURSOR =2,
 		SHADOW =true,
 		ALT_FONT=false,
+		ALT_CARET=false,
 		MATCH_DELIMITERS=true,
 		AUTO_DELIMITERS=false,
 	},

--- a/src/studio/config.c
+++ b/src/studio/config.c
@@ -104,6 +104,7 @@ static void readCodeTheme(Config* config, lua_State* lua)
 
         readBool(lua, "SHADOW", &config->data.theme.code.shadow);
         readBool(lua, "ALT_FONT", &config->data.theme.code.altFont);
+        readBool(lua, "ALT_CARET", &config->data.theme.code.altCaret);
         readBool(lua, "MATCH_DELIMITERS", &config->data.theme.code.matchDelimiters);
         readBool(lua, "AUTO_DELIMITERS", &config->data.theme.code.autoDelimiters);
     }

--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -238,12 +238,15 @@ static void drawCursor(Code* code, s32 x, s32 y, char symbol)
 
     if(inverse)
     {
+        bool alt = getConfig(code->studio)->theme.code.altCaret;
+        s32 width = alt ? (code->altFont ? 1 : 2) : getFontWidth(code)+1;
+
         if(code->shadowText)
-            tic_api_rect(code->tic, x, y, getFontWidth(code)+1, TIC_FONT_HEIGHT+1, 0);
+            tic_api_rect(code->tic, x, y, width, TIC_FONT_HEIGHT+1, 0);
 
-        tic_api_rect(code->tic, x-1, y-1, getFontWidth(code)+1, TIC_FONT_HEIGHT+1, getConfig(code->studio)->theme.code.cursor);
+        tic_api_rect(code->tic, x-1, y-1, width, TIC_FONT_HEIGHT+1, getConfig(code->studio)->theme.code.cursor);
 
-        if(symbol)
+        if(symbol && !alt)
             drawChar(code->tic, symbol, x, y, getConfig(code->studio)->theme.code.BG, code->altFont);
     }
 }

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -99,6 +99,7 @@ typedef struct
             u8 cursor;
             bool shadow;
             bool altFont;
+            bool altCaret;
             bool matchDelimiters;
             bool autoDelimiters;
 


### PR DESCRIPTION
The alt caret is one or two pixels wide depending on the font, and does not draw a gray copy of the character underneath.
It will be more familiar to people who are used to modern text editors.
I went with "caret" instead of "cursor" to avoid confusion with the mouse pointer, but can change this if you want.

![tic80_alt_caret](https://github.com/nesbox/TIC-80/assets/43251584/2b791d3c-2b6b-4cbb-91b0-e46b740e3398)

Fixes: #2364