### PR TITLE
Upgrade Python language bindings to `v1.3.1`

### DIFF
--- a/src/api/python.c
+++ b/src/api/python.c
@@ -89,7 +89,6 @@ static int prepare_colorindex(pkpy_vm* vm, int index, u8 * buffer)
     }
 }
 
-
 static int py_trace(pkpy_vm* vm) 
 {
     tic_mem* tic;


### PR DESCRIPTION
The previous pr is https://github.com/nesbox/TIC-80/pull/2353 (3 weeks ago)

## What's changed from `v1.3.0` to `v1.3.1`

1. fix a bug of type names
2. improve f-string. It supports `{{` and `}}` escape now
3. rename easing functions. Now names are like `easing.Linear` and `easing.OutQuad`
4. allow complex assignment in class definition
5. add `str.splitlines()`
6. fix https://github.com/blueloveTH/pocketpy/issues/179
7. add `csv` module

## New module `csv`

`v1.3.1` introduces `csv` module with `csv.reader` and `csv.DictReader` for parsing csv files.
The module is a compatible subset of cpython's `csv` which supports common csv format with linebreaks.

```python
import csv
def test(data: str, expected):
    ret: list = csv.reader(data.splitlines())
    assert ret==expected, f"Expected {expected}, got {ret}"

test("""a,b,c
1,2,3
""",  [['a', 'b', 'c'], ['1', '2', '3']])

test("""a,b,c
1,2,"3"
""",  [['a', 'b', 'c'], ['1', '2', '3']])

test("""a,b,c
1,2,"3,,"
""",  [['a', 'b', 'c'], ['1', '2', '3,,']])

test("""a,b,c
1,2,'3'
""",  [['a', 'b', 'c'], ['1', '2', '\'3\'']])

test('''a,b,c
1,2,"123"""
''',  [['a', 'b', 'c'], ['1', '2', '123"']])

test("""a,b,c,
1,2,3,
""",  [['a', 'b', 'c', ''], ['1', '2', '3', '']])

test("""a,b ,c,
1,"22""33",3
""",  [['a', 'b ', 'c', ''], ['1', '22"33', '3']])

# newline
test('''a,b,c
1,2,"3,
  4"
5,"a,""
b",7
''',  [['a', 'b', 'c'], ['1', '2', '3,\n  4'], ['5', 'a,"\nb', '7']])

ret: list[dict] = csv.DictReader("""a,b,c
1,2,3
"4",5,6
""".splitlines())

assert ret==[
    {'a': '1', 'b': '2', 'c': '3'},
    {'a': '4', 'b': '5', 'c': '6'},
]
```

This upgrade has no break change and it should not break anything.
