### PR TITLE
Gamepad shortcut to Surf

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4035,11 +4035,6 @@ static void processKeyboard(Console* console)
     if(!console->active)
         return;
 
-//    if(tic_api_btnp(tic, 6, -1, -1) && !keyWasPressed(console->studio, tic_key_a))
-//    {
-//        gotoSurf(console->studio);
-//    }
-
     if(tic->ram->input.keyboard.data != 0)
     {
         switch(getClipboardEvent(console->studio))
@@ -4124,10 +4119,8 @@ static void processGamepad(Console* console)
     if(!console->active)
         return;
 
-
     if(tic->ram->input.keyboard.data == 0 && tic_api_btnp(tic, 6, -1, -1))
     {
-        printf("\nconsole.c processGamepad calling gotoSurf");
         gotoSurf(console->studio);
     }
 }

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4035,10 +4035,10 @@ static void processKeyboard(Console* console)
     if(!console->active)
         return;
 
-    if(tic_api_btnp(tic, 6, -1, -1) && !keyWasPressed(console->studio, tic_key_a))
-    {
-        gotoSurf(console->studio);
-    }
+//    if(tic_api_btnp(tic, 6, -1, -1) && !keyWasPressed(console->studio, tic_key_a))
+//    {
+//        gotoSurf(console->studio);
+//    }
 
     if(tic->ram->input.keyboard.data != 0)
     {
@@ -4117,12 +4117,28 @@ static void processKeyboard(Console* console)
 
 }
 
+static void processGamepad(Console* console)
+{
+    tic_mem* tic = console->tic;
+
+    if(!console->active)
+        return;
+
+
+    if(tic->ram->input.keyboard.data == 0 && tic_api_btnp(tic, 6, -1, -1))
+    {
+        printf("\nconsole.c processGamepad calling gotoSurf");
+        gotoSurf(console->studio);
+    }
+}
+
 static void tick(Console* console)
 {
     tic_mem* tic = console->tic;
 
     processMouse(console);
     processKeyboard(console);
+    processGamepad(console);
 
     Start* start = getStartScreen(console->studio);
 

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4035,6 +4035,11 @@ static void processKeyboard(Console* console)
     if(!console->active)
         return;
 
+    if(tic_api_btnp(tic, 6, -1, -1) && !keyWasPressed(console->studio, tic_key_a))
+    {
+        gotoSurf(console->studio);
+    }
+
     if(tic->ram->input.keyboard.data != 0)
     {
         switch(getClipboardEvent(console->studio))


### PR DESCRIPTION
Hello, haven't ever made a pull request before. Also exploring around this project is my introduction to C lang... memory management stuff completely soars over my head. I have very little idea of what I'm doing.

I forked the project a while ago in hopes of making a visual update to Surf called Launcher. Going for the tile-based look. I had some fun tinkering with it, and made a bit of progress, however I keep running into Segmentation Faults and other such errors. Whole original reason is that I'm planning on picking up the Retroid Pocket 2S this holiday. I read around the discord to see if others ever tried using it for tic80 and from what I saw; it's rough at first, mainly because of tic80 being oriented to a keyboard-console. Makes sense. Once people manage to get into the Surf menu though, the experience increases dramatically.

I'm putting a stop on my launcher project though, at least until I properly learn C lol. I figure in the meantime, this one if statement I added in seems pretty effective at getting to the Surf menu with just a controller/gamepad... so here it is.

I haven't actually tested it on the Retroid Pocket 2S or any other Retroid device, rather I tested it on Linux and my own phone using a 8BitDo SN30 Pro... So I'm just assuming at the moment. Probably ill-advised.

On linux, using bluetooth and wired in the x-input mode (the gamepad supports 4 input types) the button shortcut works. On my android phone (Pixel 6a) using wired it works with x-input mode, but not bluetooth. If I want to use bluetooth I have to switch the gamepad to d-input mode. 