### PR TITLE
Use OpenGL backend for macOS

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1846,6 +1846,9 @@ s32 determineMaximumScale()
 
 static s32 start(s32 argc, char **argv, const char* folder)
 {
+#if defined(__MACOSX__)
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+#endif
     int result = SDL_Init(SDL_INIT_VIDEO);
     if (result != 0)
     {


### PR DESCRIPTION
The SDL2 metal backend has performance issues that is widely reported elsewhere (such as https://stackoverflow.com/questions/59700423/why-is-sdl-so-much-slower-on-mac-than-linux). By opting to the OpenGL backend, TIC-80 uses much less CPU cycles than before and achieved higher benchmark score.