### PR TITLE
Fix horizontal scrolling when press the shift key

### DIFF
--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -3122,7 +3122,7 @@ static void textEditTick(Code* code)
         tic_point scroll = {input->mouse.scrollx, input->mouse.scrolly};
 
         if(tic_api_key(tic, tic_key_shift))
-            scroll.x = -scroll.y;
+            scroll.x = scroll.y;
 
         s32* val = scroll.x ? &code->scroll.x : scroll.y ? &code->scroll.y : NULL;
 


### PR DESCRIPTION
Fix #2394.
PR #2376 made an incorrect fix to #2358 and #2335, and this PR simply revert changes in `code.c` back to previous version.