### PR TITLE
Autosave option for keeping carts from Surf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,8 @@ build/mruby_vendor-prefix/
 **/zig-out
 .cache
 *~
+
+## LettucePie delete later!
+build/android/.idea/
+build/android/app/.cxx
+build/android/local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,3 @@ build/mruby_vendor-prefix/
 .cache
 *~
 
-## LettucePie delete later!
-build/android/.idea/
-build/android/app/.cxx
-build/android/local.properties

--- a/src/studio/config.c
+++ b/src/studio/config.c
@@ -195,6 +195,7 @@ static void setDefault(Config* config)
             .vsync          = DEFAULT_VSYNC,
             .fullscreen     = false,
             .integerScale   = INTEGER_SCALE_DEFAULT,
+            .autosave       = false,
 #if defined(BUILD_EDITORS)
             .keybindMode    = KEYBIND_STANDARD,
             .devmode        = false,

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2370,8 +2370,6 @@ const char* readMetatag(const char* code, const char* tag, const char* comment);
 static CartSaveResult saveCartName(Console* console, const char* name)
 {
     tic_mem* tic = console->tic;
-    printf("\nconsole.c saveCartName called");
-    printf("\nconsole.c saveCartName: name = %s", name);
 
     bool success = false;
 
@@ -2498,7 +2496,7 @@ static CartSaveResult saveCartName(Console* console, const char* name)
         }
     }
     else if (strlen(console->rom.name))
-    {   printf("\nconsole.c saveCartName: calling saveCartName again?");
+    {
         return saveCartName(console, console->rom.name);
     }
     else return CART_SAVE_MISSING_NAME;
@@ -2513,7 +2511,6 @@ static CartSaveResult saveCart(Console* console)
 
 static void onSaveCommandConfirmed(Console* console)
 {
-    printf("\nconsole.c onSaveCommandConfirmed called");
     CartSaveResult rom = saveCartName(console, console->desc->count ? console->desc->params->key : NULL);
 
     if(rom == CART_SAVE_OK)
@@ -4269,12 +4266,9 @@ static bool cmdLoadCart(Console* console, const char* path)
 
 void forceAutoSave(Console* console, const char* cart_name)
 {
-    printf("\nconsole.c forceAutoSave called");
-    printf("\nconsole.c forceAutoSave: cart_name = %s", cart_name);
     char namepath[TICNAME_MAX];
     strcpy(namepath, "/downloads/");
     strcat(namepath, cart_name);
-    printf("\nconsole.c forceAutoSave namepath variable = %s", namepath);
     CartSaveResult rom = saveCartName(console, namepath);
 
     if(rom == CART_SAVE_OK)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2370,6 +2370,8 @@ const char* readMetatag(const char* code, const char* tag, const char* comment);
 static CartSaveResult saveCartName(Console* console, const char* name)
 {
     tic_mem* tic = console->tic;
+    printf("\nconsole.c saveCartName called");
+    printf("\nconsole.c saveCartName: name = %s", name);
 
     bool success = false;
 
@@ -2496,7 +2498,7 @@ static CartSaveResult saveCartName(Console* console, const char* name)
         }
     }
     else if (strlen(console->rom.name))
-    {
+    {   printf("\nconsole.c saveCartName: calling saveCartName again?");
         return saveCartName(console, console->rom.name);
     }
     else return CART_SAVE_MISSING_NAME;
@@ -2511,6 +2513,7 @@ static CartSaveResult saveCart(Console* console)
 
 static void onSaveCommandConfirmed(Console* console)
 {
+    printf("\nconsole.c onSaveCommandConfirmed called");
     CartSaveResult rom = saveCartName(console, console->desc->count ? console->desc->params->key : NULL);
 
     if(rom == CART_SAVE_OK)
@@ -4264,10 +4267,28 @@ static bool cmdLoadCart(Console* console, const char* path)
     return done;
 }
 
-void forceAutoSave(Console* console)
+void forceAutoSave(Console* console, const char* cart_name)
 {
     printf("\nconsole.c forceAutoSave called");
-    onSaveCommandConfirmed(console);
+    printf("\nconsole.c forceAutoSave: cart_name = %s", cart_name);
+    char namepath[TICNAME_MAX];
+    strcpy(namepath, "/downloads/");
+    strcat(namepath, cart_name);
+    printf("\nconsole.c forceAutoSave namepath variable = %s", namepath);
+    CartSaveResult rom = saveCartName(console, namepath);
+
+    if(rom == CART_SAVE_OK)
+    {
+        printBack(console, "\ncart ");
+        printFront(console, console->rom.name);
+        printBack(console, " autosaved!\n");
+    }
+    else if(rom == CART_SAVE_MISSING_NAME)
+        printBack(console, "\nautosave name is missing\n");
+    else
+        printBack(console, "\ncart autosave error");
+
+    commandDone(console);
 }
 
 static s32 cmdcmp(const void* a, const void* b)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4264,6 +4264,12 @@ static bool cmdLoadCart(Console* console, const char* path)
     return done;
 }
 
+void forceAutoSave(Console* console)
+{
+    printf("\nconsole.c forceAutoSave called");
+    onSaveCommandConfirmed(console);
+}
+
 static s32 cmdcmp(const void* a, const void* b)
 {
     return strcmp(((const Command*)a)->name, ((const Command*)b)->name);

--- a/src/studio/screens/console.h
+++ b/src/studio/screens/console.h
@@ -116,3 +116,4 @@ struct Console
 
 void initConsole(Console*, Studio* studio, struct tic_fs* fs, struct tic_net* net, struct Config* config, StartArgs args);
 void freeConsole(Console* console);
+void forceAutoSave(Console* console);

--- a/src/studio/screens/console.h
+++ b/src/studio/screens/console.h
@@ -116,4 +116,4 @@ struct Console
 
 void initConsole(Console*, Studio* studio, struct tic_fs* fs, struct tic_net* net, struct Config* config, StartArgs args);
 void freeConsole(Console* console);
-void forceAutoSave(Console* console);
+void forceAutoSave(Console* console, const char* cart_name);

--- a/src/studio/screens/mainmenu.c
+++ b/src/studio/screens/mainmenu.c
@@ -194,6 +194,25 @@ static MenuOption VolumeOption =
     optionVolumeSet,
 };
 
+static s32 optionAutoSaveGet(void* data)
+{
+    StudioMainMenu* main = data;
+    return main->options->autosave ? 1 : 0;
+}
+
+static void optionAutoSaveSet(void* data, s32 pos)
+{
+    StudioMainMenu* main = data;
+    main->options->autosave = pos == 1;
+}
+
+static MenuOption AutoSaveOption =
+{
+    OPTION_VALUES({OffValue, OnValue}),
+    optionAutoSaveGet,
+    optionAutoSaveSet,
+};
+
 #if defined(BUILD_EDITORS)
 static s32 optionTabSizeGet(void* data)
 {
@@ -330,6 +349,7 @@ static const MenuItem OptionMenu[] =
     {"FULLSCREEN",      NULL,   &FullscreenOption},
     {"INTEGER SCALE",   NULL,   &IntegerScaleOption},
     {"VOLUME",          NULL,   &VolumeOption},
+    {"AUTOSAVE",        NULL,   &AutoSaveOption, "Keep carts loaded from the web"},
 #if defined(BUILD_EDITORS)
     {"EDITOR OPTIONS", showEditorMenu},
 #endif

--- a/src/studio/screens/surf.c
+++ b/src/studio/screens/surf.c
@@ -23,6 +23,7 @@
 #include "surf.h"
 #include "studio/fs.h"
 #include "studio/net.h"
+#include "studio/config.h"
 #include "console.h"
 #include "menu.h"
 #include "ext/gif.h"
@@ -563,11 +564,12 @@ static void onCartLoaded(void* data)
 {
     printf("\nsurf.c onCartLoaded called");
     Surf* surf = data;
+    if(surf->config->data.options.autosave)
+    {
+        printf("\nsurf.c onCartLoaded: calling autoSave.");
+        autoSave(surf);
+    }
     printf("\nsurf.c onCartLoaded: newly downloaded cart is loaded, calling runGame.");
-    autoSave(surf);
-    // figure out if autosave enabled
-    // then figure out the version of this cart
-    // then run autosave, append version to name
     runGame(surf->studio);
 }
 
@@ -847,6 +849,7 @@ void initSurf(Surf* surf, Studio* studio, struct Console* console)
         .studio = studio,
         .tic = getMemory(studio),
         .console = console,
+        .config = console->config,
         .fs = console->fs,
         .net = console->net,
         .tick = tick,

--- a/src/studio/screens/surf.c
+++ b/src/studio/screens/surf.c
@@ -547,13 +547,11 @@ static void changeDirectory(Surf* surf, const char* name)
 
 static void autoSave(Surf* surf)
 {
-    printf("\nsurf.c onAutoSave called");
     const char* save_directory = "/downloads";
     const char* cart_name = surf->console->rom.name;
 
     if(!tic_fs_isdir(surf->console->fs, save_directory))
     {
-        printf("\nsurf.c onAutoSave: /downloads directory missing, making it now");
         tic_fs_makedir(surf->console->fs, save_directory);
     }
 
@@ -562,14 +560,13 @@ static void autoSave(Surf* surf)
 
 static void onCartLoaded(void* data)
 {
-    printf("\nsurf.c onCartLoaded called");
     Surf* surf = data;
+
     if(surf->config->data.options.autosave)
     {
-        printf("\nsurf.c onCartLoaded: calling autoSave.");
         autoSave(surf);
     }
-    printf("\nsurf.c onCartLoaded: newly downloaded cart is loaded, calling runGame.");
+
     runGame(surf->studio);
 }
 

--- a/src/studio/screens/surf.c
+++ b/src/studio/screens/surf.c
@@ -546,7 +546,9 @@ static void changeDirectory(Surf* surf, const char* name)
 
 static void onCartLoaded(void* data)
 {
+    printf("\nsurf.c onCartLoaded called");
     Surf* surf = data;
+    printf("\nsurf.c onCartLoaded: newly downloaded cart is loaded, calling runGame.")
     runGame(surf->studio);
 }
 

--- a/src/studio/screens/surf.c
+++ b/src/studio/screens/surf.c
@@ -556,7 +556,7 @@ static void autoSave(Surf* surf)
         tic_fs_makedir(surf->console->fs, save_directory);
     }
 
-    forceAutoSave(surf->console);
+    forceAutoSave(surf->console, cart_name);
 }
 
 static void onCartLoaded(void* data)

--- a/src/studio/screens/surf.c
+++ b/src/studio/screens/surf.c
@@ -544,11 +544,30 @@ static void changeDirectory(Surf* surf, const char* name)
     }
 }
 
+static void autoSave(Surf* surf)
+{
+    printf("\nsurf.c onAutoSave called");
+    const char* save_directory = "/downloads";
+    const char* cart_name = surf->console->rom.name;
+
+    if(!tic_fs_isdir(surf->console->fs, save_directory))
+    {
+        printf("\nsurf.c onAutoSave: /downloads directory missing, making it now");
+        tic_fs_makedir(surf->console->fs, save_directory);
+    }
+
+    forceAutoSave(surf->console);
+}
+
 static void onCartLoaded(void* data)
 {
     printf("\nsurf.c onCartLoaded called");
     Surf* surf = data;
-    printf("\nsurf.c onCartLoaded: newly downloaded cart is loaded, calling runGame.")
+    printf("\nsurf.c onCartLoaded: newly downloaded cart is loaded, calling runGame.");
+    autoSave(surf);
+    // figure out if autosave enabled
+    // then figure out the version of this cart
+    // then run autosave, append version to name
     runGame(surf->studio);
 }
 

--- a/src/studio/screens/surf.h
+++ b/src/studio/screens/surf.h
@@ -33,6 +33,7 @@ struct Surf
     struct tic_fs* fs;
     struct tic_net* net;
     struct Console* console;
+    struct Config* config;
 
     bool init;
     bool loading;

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -131,6 +131,7 @@ typedef struct
         bool vsync;
         bool integerScale;
         s32 volume;
+        bool autosave;
         tic_mapping mapping;
 #if defined(BUILD_EDITORS)
         enum KeybindMode keybindMode;


### PR DESCRIPTION
Hello again for my second pull request ever. This time I actually searched through pull requests and issues first to see if my idea has previously been denied lol.

While waiting until Christmas to possibly get the Retroid Pocket 2S, I've been using tic80 more with just a controller and my phone. I encountered another difficulty, and that is keeping games for offline play. Currently if you like a game you found on Surf and you want to play it later without internet; you have to close it then use the keyboard to name/save it locally. Using the app Unexpected Keboard (available on fdroid) this isn't too bad, and once again fits in logically with the keyboard/console design. However if your device is small and can barely accommodate a keyboard this quickly becomes too much.

Here I added an Autosave option into the config menu. It is set to OFF by default. When turned ON it waits for Surf to finish loading a new cart and runs a new function that checks to see if the file system has a "downloads" folder, if not it makes one. Then it tells the console to save with a new function called forceAutoSave. It's a clone of onSaveCommandConfirmed with the /downloads/ path added in.

I had to include the config.h header file thing into surf, and also toss in the config class struct thing into its init function... I still don't entirely know what I'm doing by the way... So I'm mostly just hoping I haven't done something obviously horrible.

That's kind of it. It works pretty well so far. I've tested on Linux and Android. Thing that surprised me the most is that it retains save file progress from the instance played on Surf/cache, as well as the newly autosaved one in /downloads.

I would have really liked to be able to compare the version of one already downloaded with the one on surf, but looking through the net.c file I couldn't find anything that obviously jumped out. Maybe I have to look into how the net.c file parses the server? Another qol could be deciding the folder the autosaved carts land in, or even retaining their sorting setup on surf...