### PR TITLE
Update Python's time() to return a float instead of an int

### DIFF
--- a/src/api/python.c
+++ b/src/api/python.c
@@ -1018,8 +1018,8 @@ static int py_time(pkpy_vm* vm)
     if(pkpy_check_error(vm))
         return 0;
 
-    int time = tic_api_time(tic);
-    pkpy_push_int(vm, time);
+    double time = tic_api_time(tic);
+    pkpy_push_float(vm, time);
     return 1;
 }
 


### PR DESCRIPTION
`tic_api_time` returns a `double`, not an `int`, so it should push a `float`, not an `int`.