### PR TITLE
Upgrade Python language bindings to `v1.3.5`

### DIFF
--- a/src/api/python.c
+++ b/src/api/python.c
@@ -682,14 +682,15 @@ static int py_pix(pkpy_vm* vm) {
     int y;
     int color = -1;
 
-
     pkpy_to_int(vm, 0, &x);
     pkpy_to_int(vm, 1, &y);
-    if (pkpy_is_int(vm, 2))
-        pkpy_to_int(vm, 2, &color);
-    get_core(vm, (tic_core**) &tic);
+
+    if(!pkpy_is_none(vm, 2)) pkpy_to_int(vm, 2, &color);
+
     if(pkpy_check_error(vm)) 
         return 0;
+
+    get_core(vm, (tic_core**) &tic);
 
     if(color >= 0) { //set the pixel
         tic_api_pix(tic, x, y, color, false);

--- a/src/api/python.c
+++ b/src/api/python.c
@@ -684,13 +684,12 @@ static int py_pix(pkpy_vm* vm) {
 
     pkpy_to_int(vm, 0, &x);
     pkpy_to_int(vm, 1, &y);
-
     if(!pkpy_is_none(vm, 2)) pkpy_to_int(vm, 2, &color);
+
+    get_core(vm, (tic_core**) &tic);
 
     if(pkpy_check_error(vm)) 
         return 0;
-
-    get_core(vm, (tic_core**) &tic);
 
     if(color >= 0) { //set the pixel
         tic_api_pix(tic, x, y, color, false);


### PR DESCRIPTION
The previous pr is https://github.com/nesbox/TIC-80/pull/2382 (2 weeks ago)

# What's changed from `v1.3.1` to `v1.3.5`

## TIC-80 library

- [x] `pix(x: int, y: int, color: int=None)` will raise an error if the 3rd arg is not `int`, instead of fail silently

## New features
* improve f-string performance
* add support for `\b`
* add `issubclass()` builtin
* support class decorator
* add a new module `dataclasses`

## Bug fixes
* fix a bug when users are trying to create `module` instance
* fix a bug about `**kwargs` in function call
* fix a parser bug of f-string such as `f"{stack[2:]}"`
* `class` can be used in normal blocks now

## `dataclasses` module

```python
from dataclasses import dataclass, asdict

@dataclass
class A:
    x: int
    y: str = '123'

a = A(x=2)
b = A(3, y='AAA')
print(a)    # A(x=2, y='123')
print(asdict(b))    # {'x': 3, 'y': 'AAA'}
```