### PR TITLE
Use memmove in tic_api_memcpy

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -126,7 +126,7 @@ void tic_api_memcpy(tic_mem* memory, s32 dst, s32 src, s32 size)
         && src <= bound)
     {
         u8* base = (u8*)memory->ram;
-        memcpy(base + dst, base + src, size);
+        memmove(base + dst, base + src, size);
     }
 }
 


### PR DESCRIPTION
Calling `memcpy` with overlapping source and destination buffers is undefined behaviour. For example, see #1875. But, users of the _TIC-80 `memcpy` function_ probably expect it to work fine even with overlapping buffers. Thus: `memmove`.