### PR TITLE
add `--target=wasm32-unknown-unknown` to README.md

### DIFF
--- a/templates/rust/README.md
+++ b/templates/rust/README.md
@@ -11,7 +11,7 @@ rustup target add wasm32-unknown-unknown
 Then, to build a cart.wasm file, run:
 
 ```
-cargo build --release
+cargo build --release --target=wasm32-unknown-unknown
 ```
 
 To import the resulting WASM to a cartridge named `game.tic`:


### PR DESCRIPTION
Without `--target=wasm32-unknown-unknown` there is no `wasm32-unknown-unknown` folder and we get a file not found.