### PR TITLE
Add "rm" as an alias for "del"

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2886,7 +2886,7 @@ static const char HelpUsage[] = "help [<text>"
         tabCompleteFiles)                                                               \
                                                                                         \
     macro("del",                                                                        \
-        NULL,                                                                           \
+        "rm",                                                                           \
         "delete from the filesystem.",                                                  \
         "del <file|folder>",                                                            \
         onDelCommand,                                                                   \


### PR DESCRIPTION
Makes `rm` a console alias for `del` for people who prefer unix-style commands