### PR TITLE
console: Indent all wrapped lines

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -407,7 +407,10 @@ static void consolePrintOffset(Console* console, const char* text, u8 color, s32
             console->cursor.pos.x++;
 
             if (console->cursor.pos.x >= CONSOLE_BUFFER_WIDTH)
+            {
                 nextLine(console);
+                console->cursor.pos.x = wrapLineOffset;
+            }
         }
     }
 


### PR DESCRIPTION
Currently, the console doesn't indent (offset) the continuation of a wrapped line if wrapping coincides with with a '|' or a space character. This is  demonstrated in the output of `help spec`:

```
DISPLAY 240x136 pixels, 16 colors
	palette.
INPUT   4 gamepads with 8 buttons /
	mouse / keyboard.
SPRITES 256 8x8 tiles and 256 8x8
	sprites.
MAP     240x136 cells, 1920x1088
	pixels.
SOUND   4 channels with configurable
	waveforms.
CODE    64KB of lua, ruby, js, moon,
	fennel, scheme, squirrel, wren,
wasm, janet or python.
```

Above, the last (continuation) line is not indented because the line break coincides with the space (' '), right before `wasm,`.

This makes the console indent all wrapped continuation lines (so the final line of `help spec` is also indented).