### PR TITLE
Add BPP arg to sprites import

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1779,11 +1779,7 @@ static void onImportTilesBase(Console* console, const char* name, const void* bu
                             color1 = tic_nearest_color(pal->colors, (tic_rgb*)(img.pixels + i + j * img.width), 4);
                             color2 = tic_nearest_color(pal->colors, (tic_rgb*)(img.pixels + i + 1 + j * img.width), 4);
                             // unsure if it's better to do add or or it together.
-#ifdef RETRO_IS_BIG_ENDIAN
-                            color = (color1 << 2) + color2;
-#else
                             color = (color2 << 2) + color1;
-#endif
                             setSpritePixel(base, x, y, color);
                             break;
                         case 1:
@@ -1791,11 +1787,7 @@ static void onImportTilesBase(Console* console, const char* name, const void* bu
                             color2 = tic_nearest_color(pal->colors, (tic_rgb*)(img.pixels + i + 1 + j * img.width), 2);
                             color3 = tic_nearest_color(pal->colors, (tic_rgb*)(img.pixels + i + 2 + j * img.width), 2);
                             color4 = tic_nearest_color(pal->colors, (tic_rgb*)(img.pixels + i + 3 + j * img.width), 2);
-#ifdef RETRO_IS_BIG_ENDIAN
-                            color = (color1 << 3) + (color2 << 2) + (color3 << 1) + color4;
-#else
                             color = (color4 << 3) + (color3 << 2) + (color2 << 1) + color1;
-#endif
                             setSpritePixel(base, x, y, color);
                             break;
                     }


### PR DESCRIPTION
only tested with BPP 1. requries that the pngs still use the same colors as the in game pallete. 