### PR TITLE
PCM sound channel

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -305,6 +305,7 @@ static void soundClear(tic_mem* memory)
     }
 
     memset(&memory->ram->registers, 0, sizeof memory->ram->registers);
+    memset(&memory->ram->pcm, 0, sizeof memory->ram->pcm);
     memset(memory->product.samples.buffer, 0, memory->product.samples.count * TIC80_SAMPLESIZE);
 
     tic_api_music(memory, -1, 0, 0, false, false, -1, -1);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -116,11 +116,14 @@ typedef struct
 
     struct
     {
-        tic_sound_register_data left[TIC_SOUND_CHANNELS];
-        tic_sound_register_data right[TIC_SOUND_CHANNELS];
+        struct sound_register_data
+        {
+            tic_sound_register_data data[TIC_SOUND_CHANNELS];
+            tic_sound_register_data pcm;
+        } left, right;
     } registers;
 
-    struct SoundRingbuf
+    struct sound_ring_buf
     {
         tic_sound_register registers[TIC_SOUND_CHANNELS];
         tic_stereo_volume stereo;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -120,10 +120,11 @@ typedef struct
         tic_sound_register_data right[TIC_SOUND_CHANNELS];
     } registers;
 
-    struct
+    struct SoundRingbuf
     {
         tic_sound_register registers[TIC_SOUND_CHANNELS];
         tic_stereo_volume stereo;
+        tic_pcm pcm;
     } sound_ringbuf[TIC_SOUND_RINGBUF_LEN];
 
     u32 sound_ringbuf_head;

--- a/src/core/sound.c
+++ b/src/core/sound.c
@@ -25,6 +25,7 @@
 #include "core.h"
 
 #include <string.h>
+#include <limits.h>
 #include "tic_assert.h"
 
 #define ENVELOPE_FREQ_SCALE 2

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -3075,6 +3075,7 @@ static s32 createRamTable(char* buf)
         {offsetof(tic_ram, font.alt),               "ALT FONT"},
         {offsetof(tic_ram, font.alt.params),        "ALT FONT PARAMS"},
         {offsetof(tic_ram, mapping),                "BUTTONS MAPPING"},
+        {offsetof(tic_ram, pcm),                    "PCM SAMPLES"},
         {offsetof(tic_ram, free),                   "** RESERVED **"},
         {TIC_RAM_SIZE,                              ""},
     };

--- a/src/tic.h
+++ b/src/tic.h
@@ -91,6 +91,7 @@
 #define WAVE_VALUE_BITS 4
 #define WAVE_MAX_VALUE ((1 << WAVE_VALUE_BITS) - 1)
 #define WAVE_SIZE (WAVE_VALUES * WAVE_VALUE_BITS / BITS_IN_BYTE)
+#define TIC_PCM_SIZE 128
 
 #define TIC_BANKSIZE_BITS 16
 #define TIC_BANK_SIZE (1 << TIC_BANKSIZE_BITS) // 64K
@@ -620,6 +621,11 @@ typedef struct
     u8 data[TIC_GAMEPADS * TIC_BUTTONS];
 } tic_mapping;
 
+typedef struct
+{
+    u8 data[TIC_PCM_SIZE];
+} tic_pcm;
+
 typedef union
 {
     struct
@@ -639,6 +645,7 @@ typedef union
         tic_flags           flags;
         tic_font            font;
         tic_mapping         mapping;
+        tic_pcm             pcm;
 
         u8 free;
     };


### PR DESCRIPTION
Thanks to the discussion https://github.com/nesbox/TIC-80/discussions/2487 I added playback of PCM channel.
You can assign 128 PCM samples at every TIC() function and play sound with a quality of 7680hz (128 * 60).
![image](https://github.com/nesbox/TIC-80/assets/1101448/7bff667c-111a-4163-80c6-1c93f36d6e2b)

A very simple example of JS to generate a sin wave using PCM
```js
// script:js

let t=0
function TIC()
{
	cls(13)
	for(let i=0;i<128;i++)
		poke(0x14E24+i,(Math.sin(t*128+i)+1)*127)

	t++
}
```