### PR TITLE
Fix tab-completion crash with load/save/etc.

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -1186,6 +1186,9 @@ static void addTabCompleteOption(TabCompleteData* data, const char* option)
         {
             // This is the first option to be added. Initialize the prefix.
             strncpy(data->commonPrefix, option, CONSOLE_BUFFER_SCREEN);
+            // strncpy does not null-terminate if the source string is too long so
+            // null terminate in the end just to be sure
+            data->commonPrefix[CONSOLE_BUFFER_SCREEN - 1] = 0;
         }
         else
         {
@@ -1202,8 +1205,12 @@ static void addTabCompleteOption(TabCompleteData* data, const char* option)
         }
 
         // The option matches the incomplete word, add it to the list.
-        strncat(data->options, option, CONSOLE_BUFFER_SCREEN);
-        strncat(data->options, " ", CONSOLE_BUFFER_SCREEN);
+        // the last parameter of strcat is the maximum number of characters to be
+        // copied, and it adds a null terminator in the end. data->options having
+        // capacity CONSOLE_BUFFER_SCREEN, we can append CONSOLE_BUFFER_SCREEN -
+        // strlen(data->options) - 1 characters to its end at most
+        strncat(data->options, option, CONSOLE_BUFFER_SCREEN - strlen(data->options) - 1);
+        strncat(data->options, " ", CONSOLE_BUFFER_SCREEN - strlen(data->options) - 1);
     }
 }
 
@@ -1212,6 +1219,9 @@ static void provideHint(Console* console, const char* hint)
 {
     char* input = malloc(CONSOLE_BUFFER_SCREEN);
     strncpy(input, console->input.text, CONSOLE_BUFFER_SCREEN);
+    // strncpy does not null-terminate if the source string is too long so
+    // null terminate in the end just to be sure
+    input[CONSOLE_BUFFER_SCREEN - 1] = 0;
 
     printLine(console);
     printBack(console, hint);


### PR DESCRIPTION
# Issue

When using tab completion with `load`/`save` in a folder with a lot of files, or really anything that'd result in an output longer than `CONSOLE_BUFFER_SCREEN`, TIC-80 would crash. This is due to `data->options` of TabCompleteData overflowing and not being null-terminated.

## Minimal repro:

Create 100 blank `.tic` files:
```
#!/bin/bash
mkdir repro && cd repro || exit 1
for i in {001..100}; do
  touch "test-$i.tic"
done
```

Start TIC-80 with the `repro` folder as its base: `./build/bin/tic80 --fs ~/repro`

Type "load<tab>" and it'll likely crash. maybe not at first, but after a few tries at most, definitely.

## Notes

This was a hell of a bug to track down, but also a fun one that made me learn `lldb` and `ASAN`. I have some other PRs coming soon about that.

## Future improvements

I have a few suggestions for future improvements and PRs:
* Upping `CONSOLE_BUFFER_SCREEN` (=760) to something higher, so more can be displayed, and suggestions will be cut off less at `load`/`save`
* Having the suggestions sorted alphabetically, which they are currently not

## String handling

This is a larger discussion, but it's worth considering either:
* Migrating string operations in the codebase to [`strlcat`](https://linux.die.net/man/3/strlcat) which is safer and guarantees null-termination, or
* Adopting a real string library, such as [`cstr`](https://github.com/stclib/STC/blob/master/docs/cstr_api.md) from [`STC`](https://github.com/stclib/STC) or [`SDS`](https://github.com/antirez/sds)

Curious of your thoughts about the potential improvements I've listed in the two sections above.

----

Fixes https://github.com/nesbox/TIC-80/issues/2448.