### PR TITLE
Add various debug options to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,18 @@ option(BUILD_PRO "Build PRO version" FALSE)
 option(BUILD_PLAYER "Build standalone players" ${BUILD_PLAYER_DEFAULT})
 option(BUILD_TOUCH_INPUT "Build with touch input support" ${BUILD_TOUCH_INPUT_DEFAULT})
 option(BUILD_STUB "Build stub without editors" OFF)
+option(BUILD_NO_OPTIMIZATION "Build without optimizations for debugging" OFF)
+option(BUILD_ASAN_DEBUG "Build with AddressSanitizer" OFF)
+
+if (BUILD_NO_OPTIMIZATION)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+endif()
+
+if (BUILD_ASAN_DEBUG)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+endif()
 
 if(NOT BUILD_SDL)
     set(BUILD_SDLGPU OFF)


### PR DESCRIPTION
While tracking down the bug in https://github.com/nesbox/TIC-80/issues/2448, besides a billion debug `printf`s I got myself acquainted with [`lldb`](https://lldb.llvm.org/) and [`AddressSanitizer`](https://clang.llvm.org/docs/AddressSanitizer.html) which were extremely helpful finding said bug.

To make the debugging process easier I added a few options to `CMakeLists.txt`:
* `BUILD_NO_OPTIMIZATION` — adds `-g -O0`
* `BUILD_ASAN_DEBUG` — adds `-fsanitize=address -fno-omit-frame-pointer`

I have yet to try its sister [`LeakSanitizer`](https://clang.llvm.org/docs/LeakSanitizer.html); gave a go for [`UndefinedBehaviorSanitizer`](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) but too many things fail on it currently, starting with external dependencies.

To get TIC-80 to compile with the latest `clang` (18.1.4) and ASAN I had to update a few submodules; will address these in separate PRs.