### PR TITLE
Fix autocomplete on command aliases

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -3347,7 +3347,7 @@ static void processConsoleTab(Console* console)
             bool commandMatches = (strlen(Commands[i].name) == commandLen &&
                                        strncmp(Commands[i].name, input, commandLen) == 0) ||
                                   (Commands[i].alt &&
-                                      strlen(Commands[i].name) == commandLen &&
+                                      strlen(Commands[i].alt) == commandLen &&
                                       strncmp(Commands[i].alt, input, commandLen) == 0);
 
             if (commandMatches)


### PR DESCRIPTION
There was an issue in the code that meant autocomplete on aliases such as `rm` were not working (think this only affects `rm` for now.)

Fixes https://github.com/nesbox/TIC-80/issues/2529.