### PR TITLE
bump Janet version to v1.34

### DIFF
--- a/build/janet/janetconf.h
+++ b/build/janet/janetconf.h
@@ -4,10 +4,10 @@
 #define JANETCONF_H
 
 #define JANET_VERSION_MAJOR 1
-#define JANET_VERSION_MINOR 31
+#define JANET_VERSION_MINOR 34
 #define JANET_VERSION_PATCH 0
 #define JANET_VERSION_EXTRA ""
-#define JANET_VERSION "1.31.0"
+#define JANET_VERSION "1.34.0"
 
 /* #define JANET_BUILD "local" */
 

--- a/demos/janetdemo.janet
+++ b/demos/janetdemo.janet
@@ -5,7 +5,6 @@
 # license: MIT License (change this to your license of choice)
 # version: 0.1
 # script: janet
-# strict:  true
 
 # Unlike other languages, the tic80 API
 # is provided as a module.


### PR DESCRIPTION
also removed the `strict: true` from the demo cart, which was incorrectly copy/pasted from the fennel demo cart. 