### PR TITLE
Gamepad shortcut to exit surf

### DIFF
--- a/src/studio/fs.c
+++ b/src/studio/fs.c
@@ -112,10 +112,16 @@ static bool isRoot(tic_fs* fs)
     return fs->work[0] == '\0';
 }
 
+bool tic_fs_isroot(tic_fs* fs)
+{
+    return isRoot(fs);
+}
+
 static bool isPublicRoot(tic_fs* fs)
 {
     return strcmp(fs->work, PublicDir) == 0;
 }
+
 
 static bool isPublic(tic_fs* fs)
 {

--- a/src/studio/fs.h
+++ b/src/studio/fs.h
@@ -50,6 +50,7 @@ bool    tic_fs_makedir      (tic_fs* fs, const char* name);
 bool    tic_fs_exists       (tic_fs* fs, const char* name);
 void    tic_fs_openfolder   (tic_fs* fs);
 bool    tic_fs_isdir        (tic_fs* fs, const char* dir);
+bool    tic_fs_isroot       (tic_fs* fs);
 bool    tic_fs_ispubdir     (tic_fs* fs);
 void    tic_fs_changedir    (tic_fs* fs, const char* dir);
 void    tic_fs_dir          (tic_fs* fs, char* out);

--- a/src/studio/screens/surf.c
+++ b/src/studio/screens/surf.c
@@ -693,7 +693,8 @@ static void processGamepad(Surf* surf)
         if(tic_api_btnp(tic, B, -1, -1)
             || tic_api_keyp(tic, tic_key_backspace, -1, -1))
         {
-            goBackDir(surf);
+            if(tic_fs_isroot(surf->fs)) setStudioMode(surf->studio, TIC_CONSOLE_MODE);
+            else goBackDir(surf);
         }
 
 #ifdef CAN_OPEN_URL


### PR DESCRIPTION
Fulfilling suggestion by @Skeptim from issue 2530 https://github.com/nesbox/TIC-80/issues/2530

**edit** I should probably elaborate...

Opens access to the `isRoot` function already available in `fs.c`. Then checks against it every Backspace or B button press while in `surf.c`. Switches to Console Mode if true, continues normal `goBackDir` if false.