### PR TITLE
`#include` `mach-o/dyld.h` on macOS for `_NSGetExecutablePath`

### DIFF
--- a/src/studio/screens/start.c
+++ b/src/studio/screens/start.c
@@ -30,6 +30,10 @@
 #include <unistd.h>
 #endif
 
+#if defined (__TIC_MACOSX__)
+#include <mach-o/dyld.h>
+#endif
+
 static void reset(Start* start)
 {
     u8* tile = (u8*)start->tic->ram->tiles.data;


### PR DESCRIPTION
Another thing that trips up Clang 18 that earlier versions were more forgiving with otherwise.