### PR TITLE
Fix `surf` on win32 builds

### DIFF
--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -37,7 +37,12 @@
 #define TIC_NAME_FULL TIC_NAME " tiny computer"
 #define TIC_TITLE TIC_NAME_FULL " " TIC_VERSION
 #define TIC_HOST "tic80.com"
-#define TIC_WEBSITE "https://" TIC_HOST
+#if defined(_MSC_VER) && defined(_USING_V110_SDK71_)
+    #define TIC_WEBSITE_PROTOCOL "http://"
+#else
+    #define TIC_WEBSITE_PROTOCOL "https://"
+#endif
+#define TIC_WEBSITE TIC_WEBSITE_PROTOCOL TIC_HOST
 #define TIC_COPYRIGHT TIC_WEBSITE " (C) 2017-" TIC_VERSION_YEAR
 
 #define TICNAME_MAX 256


### PR DESCRIPTION
`surf` defaults to HTTPS however the TIC-80 website uses a modern certificate that's not available (by default at least) on old systems, thus we default to plain `http` on the 32-bit build.

Tested on a Thinkpad x220 running Windows XP (32-bit) / Windows 7 (32-bit).

Old build on the left, fix on the right.

![surf-winxp](https://github.com/nesbox/TIC-80/assets/81575558/05f01851-6ce9-4f34-983e-b7e1dd655fe6)

![surf-win7-fix](https://github.com/nesbox/TIC-80/assets/81575558/84c1d8c8-06cb-45c4-a5c9-001053ca187a)
