### PR TITLE
Added functions for distinguishing gamepad button presses, also fix gamepad data persisting

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -280,6 +280,33 @@ enum
         tic_mem*, s32 id, s32 hold, s32 period)                                                                         \
                                                                                                                         \
                                                                                                                         \
+    macro(btnd,                                                                                                         \
+        "btnd(id) -> just pressed",                                                                                     \
+                                                                                                                        \
+        "This function allows you to read the status of one of the buttons attached to TIC.\n"                          \
+        "The function returns true if the key with the supplied id was just pressed.\n"                                 \
+        "It only returns true for the single tick the event occurred in.\n"                                             \
+        1,                                                                                                              \
+        1,                                                                                                              \
+        0,                                                                                                              \
+        u32,                                                                                                            \
+        tic_mem*, s32 id)                                                                                               \
+                                                                                                                        \
+                                                                                                                        \
+                                                                                                                        \
+    macro(btnu,                                                                                                         \
+        "btnu(id) -> just released",                                                                                    \
+                                                                                                                        \
+        "This function allows you to read the status of one of the buttons attached to TIC.\n"                          \
+        "The function returns true if the key with the supplied id was just released.\n"                                \
+        "It only returns true for the single tick the event occurred in.\n"                                             \
+        1,                                                                                                              \
+        1,                                                                                                              \
+        0,                                                                                                              \
+        u32,                                                                                                            \
+        tic_mem*, s32 id)                                                                                               \
+                                                                                                                        \
+                                                                                                                        \
     macro(sfx,                                                                                                          \
         "sfx(id note=-1 duration=-1 channel=0 volume=15 speed=0)",                                                      \
                                                                                                                         \

--- a/src/api.h
+++ b/src/api.h
@@ -285,7 +285,7 @@ enum
                                                                                                                         \
         "This function allows you to read the status of one of the buttons attached to TIC.\n"                          \
         "The function returns true if the key with the supplied id was just pressed.\n"                                 \
-        "It only returns true for the single tick the event occurred in.\n"                                             \
+        "It only returns true for the single tick the event occurred in.\n",                                             \
         1,                                                                                                              \
         1,                                                                                                              \
         0,                                                                                                              \
@@ -293,13 +293,12 @@ enum
         tic_mem*, s32 id)                                                                                               \
                                                                                                                         \
                                                                                                                         \
-                                                                                                                        \
     macro(btnu,                                                                                                         \
         "btnu(id) -> just released",                                                                                    \
                                                                                                                         \
         "This function allows you to read the status of one of the buttons attached to TIC.\n"                          \
         "The function returns true if the key with the supplied id was just released.\n"                                \
-        "It only returns true for the single tick the event occurred in.\n"                                             \
+        "It only returns true for the single tick the event occurred in.\n",                                             \
         1,                                                                                                              \
         1,                                                                                                              \
         0,                                                                                                              \

--- a/src/api/janet.c
+++ b/src/api/janet.c
@@ -41,6 +41,8 @@ static Janet janet_rectb(int32_t argc, Janet* argv);
 static Janet janet_spr(int32_t argc, Janet* argv);
 static Janet janet_btn(int32_t argc, Janet* argv);
 static Janet janet_btnp(int32_t argc, Janet* argv);
+static Janet janet_btnd(int32_t argc, Janet* argv);
+static Janet janet_btnu(int32_t argc, Janet* argv);
 static Janet janet_sfx(int32_t argc, Janet* argv);
 static Janet janet_map(int32_t argc, Janet* argv);
 static Janet janet_mget(int32_t argc, Janet* argv);
@@ -103,6 +105,8 @@ static const JanetReg janet_c_functions[] =
     {"spr", janet_spr, NULL},
     {"btn", janet_btn, NULL},
     {"btnp", janet_btnp, NULL},
+    {"btnd", janet_btnd, NULL},
+    {"btnu", janet_btnu, NULL},
     {"sfx", janet_sfx, NULL},
     {"map", janet_map, NULL},
     {"mget", janet_mget, NULL},
@@ -417,6 +421,26 @@ static Janet janet_btnp(int32_t argc, Janet* argv)
     tic_core* core = getJanetMachine(); tic_mem* tic = (tic_mem*)core;
 
     return janet_wrap_boolean(core->api.btnp(tic, id, hold, period));
+}
+
+static Janet janet_btnd(int32_t argc, Janet* argv)
+{
+    janet_fixarity(argc, 1);
+
+    s32 id = (s32)janet_getinteger(argv, 0);
+
+    tic_core* core = getJanetMachine(); tic_mem* tic = (tic_mem*)core;
+    return janet_wrap_boolean(core->api.btnd(tic, id));
+}
+
+static Janet janet_btnu(int32_t argc, Janet* argv)
+{
+    janet_fixarity(argc, 1);
+
+    s32 id = (s32)janet_getinteger(argv, 0);
+
+    tic_core* core = getJanetMachine(); tic_mem* tic = (tic_mem*)core;
+    return janet_wrap_boolean(core->api.btnu(tic, id));
 }
 
 static Janet janet_sfx(int32_t argc, Janet* argv)

--- a/src/api/js.c
+++ b/src/api/js.c
@@ -266,6 +266,24 @@ static JSValue js_btn(JSContext *ctx, JSValueConst this_val, s32 argc, JSValueCo
         : JS_NewBool(ctx, core->api.btn(tic, getInteger(ctx, argv[0]) & 0x1f));
 }
 
+static JSValue js_btnd(JSContext *ctx, JSValueConst this_val, s32 argc, JSValueConst *argv)
+{
+    tic_core* core = getCore(ctx); tic_mem* tic = (tic_mem*)core;
+
+    return JS_IsUndefined(argv[0])
+        ? JS_NewUint32(ctx, core->api.btnd(tic, -1))
+        : JS_NewBool(ctx, core->api.btnd(tic, getInteger(ctx, argv[0]) & 0x1f));
+}
+
+static JSValue js_btnu(JSContext *ctx, JSValueConst this_val, s32 argc, JSValueConst *argv)
+{
+    tic_core* core = getCore(ctx); tic_mem* tic = (tic_mem*)core;
+
+    return JS_IsUndefined(argv[0])
+        ? JS_NewUint32(ctx, core->api.btnu(tic, -1))
+        : JS_NewBool(ctx, core->api.btnu(tic, getInteger(ctx, argv[0]) & 0x1f));
+}
+
 static JSValue js_btnp(JSContext *ctx, JSValueConst this_val, s32 argc, JSValueConst *argv)
 {
     tic_core* core = getCore(ctx); tic_mem* tic = (tic_mem*)core;

--- a/src/api/lua.c
+++ b/src/api/lua.c
@@ -668,6 +668,56 @@ static s32 lua_btn(lua_State* lua)
     return 1;
 }
 
+static s32 lua_btnd(lua_State* lua)
+{
+    tic_core* core = getLuaCore(lua);
+    tic_mem* tic = (tic_mem*)core;
+
+    s32 top = lua_gettop(lua);
+
+    if (top == 0)
+    {
+        lua_pushinteger(lua, core->api.btnd(tic, -1));
+    }
+    else if (top == 1)
+    {
+        bool pressed = core->api.btnd(tic, getLuaNumber(lua, 1) & 0x1f);
+        lua_pushboolean(lua, pressed);
+    }
+    else
+    {
+        luaL_error(lua, "invalid params, btnd [ id ]\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+static s32 lua_btnu(lua_State* lua)
+{
+    tic_core* core = getLuaCore(lua);
+    tic_mem* tic = (tic_mem*)core;
+
+    s32 top = lua_gettop(lua);
+
+    if (top == 0)
+    {
+        lua_pushinteger(lua, core->api.btnu(tic, -1));
+    }
+    else if (top == 1)
+    {
+        bool pressed = core->api.btnu(tic, getLuaNumber(lua, 1) & 0x1f);
+        lua_pushboolean(lua, pressed);
+    }
+    else
+    {
+        luaL_error(lua, "invalid params, btnu [ id ]\n");
+        return 0;
+    }
+
+    return 1;
+}
+
 static s32 lua_spr(lua_State* lua)
 {
     s32 top = lua_gettop(lua);

--- a/src/api/mruby.c
+++ b/src/api/mruby.c
@@ -388,6 +388,52 @@ static mrb_value mrb_btnp(mrb_state* mrb, mrb_value self)
     }
 }
 
+static mrb_value mrb_btnd(mrb_state* mrb, mrb_value self)
+{
+    tic_core* core = getMRubyMachine(mrb); tic_mem* tic = (tic_mem*)core;
+
+
+    mrb_int index, hold, period;
+    mrb_int argc = mrb_get_args(mrb, "|i", &index, &hold, &period);
+
+    if (argc == 0)
+    {
+        return mrb_bool_value(core->api.btnd(tic, -1) != 0);
+    }
+    else if (argc == 1)
+    {
+        return mrb_bool_value(core->api.btnd(tic, index & 0x1f) != 0);
+    }
+    else
+    {
+        mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid params, btnd [ id ]\n");
+        return mrb_nil_value();
+    }
+}
+
+static mrb_value mrb_btnu(mrb_state* mrb, mrb_value self)
+{
+    tic_core* core = getMRubyMachine(mrb); tic_mem* tic = (tic_mem*)core;
+
+
+    mrb_int index, hold, period;
+    mrb_int argc = mrb_get_args(mrb, "|i", &index, &hold, &period);
+
+    if (argc == 0)
+    {
+        return mrb_bool_value(core->api.btnu(tic, -1) != 0);
+    }
+    else if (argc == 1)
+    {
+        return mrb_bool_value(core->api.btnu(tic, index & 0x1f) != 0);
+    }
+    else
+    {
+        mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid params, btnu [ id ]\n");
+        return mrb_nil_value();
+    }
+}
+
 static mrb_value mrb_btn(mrb_state* mrb, mrb_value self)
 {
     tic_core* core = getMRubyMachine(mrb); tic_mem* tic = (tic_mem*)core;

--- a/src/api/python.c
+++ b/src/api/python.c
@@ -151,6 +151,36 @@ static int py_btnp(pkpy_vm* vm)
     return 1;
 }
 
+static int py_btnd(pkpy_vm* vm)
+{
+
+    int button_id;
+
+    tic_core* core; get_core(vm, &core); tic_mem* tic = (tic_mem*)core;
+    pkpy_to_int(vm, 0, &button_id);
+    if(pkpy_check_error(vm))
+        return 0;
+
+    bool pressed = core->api.btnd(tic, button_id & 0x1f);
+    pkpy_push_bool(vm, pressed);
+    return 1;
+}
+
+static int py_btnu(pkpy_vm* vm)
+{
+
+    int button_id;
+
+    tic_core* core; get_core(vm, &core); tic_mem* tic = (tic_mem*)core;
+    pkpy_to_int(vm, 0, &button_id);
+    if(pkpy_check_error(vm))
+        return 0;
+
+    bool pressed = core->api.btnu(tic, button_id & 0x1f);
+    pkpy_push_bool(vm, pressed);
+    return 1;
+}
+
 static int py_circ(pkpy_vm* vm) 
 {
     
@@ -1157,6 +1187,11 @@ static bool setup_c_bindings(pkpy_vm* vm) {
     pkpy_setglobal_2(vm, "btn");
     pkpy_push_function(vm, "btnp(id: int, hold=-1, period=-1) -> bool", py_btnp);
     pkpy_setglobal_2(vm, "btnp");
+    pkpy_push_function(vm, "btnd(id: int) -> bool", py_btnd);
+    pkpy_setglobal_2(vm, "btnd");
+    pkpy_push_function(vm, "btnu(id: int) -> bool", py_btnu);
+    pkpy_setglobal_2(vm, "btnu");
+
 
     pkpy_push_function(vm, "circ(x: int, y: int, radius: int, color: int)", py_circ);
     pkpy_setglobal_2(vm, "circ");

--- a/src/api/scheme.c
+++ b/src/api/scheme.c
@@ -181,6 +181,22 @@ s7_pointer scheme_btnp(s7_scheme* sc, s7_pointer args)
     
     return s7_make_boolean(sc, core->api.btnp(tic, id, hold, period));
 }
+s7_pointer scheme_btnd(s7_scheme* sc, s7_pointer args)
+{
+    // btnd(id) -> just pressed
+    tic_core* core = getSchemeCore(sc); tic_mem* tic = (tic_mem*)core;
+    const s32 id = s7_integer(s7_car(args));
+
+    return s7_make_boolean(sc, core->api.btnd(tic, id));
+}
+s7_pointer scheme_btnu(s7_scheme* sc, s7_pointer args)
+{
+    // btnu(id) -> just pressed
+    tic_core* core = getSchemeCore(sc); tic_mem* tic = (tic_mem*)core;
+    const s32 id = s7_integer(s7_car(args));
+
+    return s7_make_boolean(sc, core->api.btnu(tic, id));
+}
 
 u8 get_note_base(char c) {
     switch (c) {

--- a/src/api/scheme.c
+++ b/src/api/scheme.c
@@ -191,7 +191,7 @@ s7_pointer scheme_btnd(s7_scheme* sc, s7_pointer args)
 }
 s7_pointer scheme_btnu(s7_scheme* sc, s7_pointer args)
 {
-    // btnu(id) -> just pressed
+    // btnu(id) -> just released
     tic_core* core = getSchemeCore(sc); tic_mem* tic = (tic_mem*)core;
     const s32 id = s7_integer(s7_car(args));
 

--- a/src/api/squirrel.c
+++ b/src/api/squirrel.c
@@ -623,6 +623,54 @@ static SQInteger squirrel_btn(HSQUIRRELVM vm)
     return 1;
 }
 
+static SQInteger squirrel_btnd(HSQUIRRELVM vm)
+{
+    tic_core* core = getSquirrelCore(vm);
+    tic_mem* tic = (tic_mem*)core;
+
+    SQInteger top = sq_gettop(vm);
+
+    if (top == 1)
+    {
+        sq_pushinteger(vm, core->api.btnd(tic, -1));
+    }
+    else if (top == 2)
+    {
+        bool pressed = core->api.btnd(tic, getSquirrelNumber(vm, 2) & 0x1f);
+        sq_pushbool(vm, pressed ? SQTrue : SQFalse);
+    }
+    else
+    {
+        return sq_throwerror(vm, "invalid params, btnd [ id ]\n");
+    }
+
+    return 1;
+}
+
+static SQInteger squirrel_btnu(HSQUIRRELVM vm)
+{
+    tic_core* core = getSquirrelCore(vm);
+    tic_mem* tic = (tic_mem*)core;
+
+    SQInteger top = sq_gettop(vm);
+
+    if (top == 1)
+    {
+        sq_pushinteger(vm, core->api.btnu(tic, -1));
+    }
+    else if (top == 2)
+    {
+        bool pressed = core->api.btnu(tic, getSquirrelNumber(vm, 2) & 0x1f);
+        sq_pushbool(vm, pressed ? SQTrue : SQFalse);
+    }
+    else
+    {
+        return sq_throwerror(vm, "invalid params, btnu [ id ]\n");
+    }
+
+    return 1;
+}
+
 static SQInteger squirrel_spr(HSQUIRRELVM vm)
 {
     SQInteger top = sq_gettop(vm);

--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -372,6 +372,42 @@ m3ApiRawFunction(wasmtic_btnp)
     m3ApiSuccess();
 }
 
+m3ApiRawFunction(wasmtic_btnd)
+{
+    // TODO: should this be boolean, how to deal with
+    // this being multi-typed
+    m3ApiReturnType  (int32_t)
+
+    m3ApiGetArg      (int32_t, index)
+
+    tic_core* core = getWasmCore(runtime);
+
+    // -1 is a default placeholder here for `id`, but one that `core->api.btnd` already understands, so
+    // it just gets passed straight thru
+
+    m3ApiReturn(core->api.btnd((tic_mem *)core, index));
+
+    m3ApiSuccess();
+}
+
+m3ApiRawFunction(wasmtic_btnu)
+{
+    // TODO: should this be boolean, how to deal with
+    // this being multi-typed
+    m3ApiReturnType  (int32_t)
+
+    m3ApiGetArg      (int32_t, index)
+
+    tic_core* core = getWasmCore(runtime);
+
+    // -1 is a default placeholder here for `id`, but one that `core->api.btnu` already understands, so
+    // it just gets passed straight thru
+
+    m3ApiReturn(core->api.btnu((tic_mem *)core, index));
+
+    m3ApiSuccess();
+}
+
 m3ApiRawFunction(wasmtic_key)
 {
     m3ApiReturnType  (int32_t)

--- a/src/api/wren.c
+++ b/src/api/wren.c
@@ -49,6 +49,10 @@ class TIC {\n\
     foreign static btn(id)\n\
     foreign static btnp(id)\n\
     foreign static btnp(id, hold, period)\n\
+    foreign static btnd()\n\
+    foreign static btnd(id)\n\
+    foreign static btnu()\n\
+    foreign static btnu(id)\n\
     foreign static key(id)\n\
     foreign static keyp(id)\n\
     foreign static keyp(id, hold, period)\n\
@@ -334,6 +338,44 @@ static void wren_btnp(WrenVM* vm)
 
         wrenSetSlotBool(vm, 0, core->api.btnp(tic, index, hold, period));
     }
+}
+
+static void wren_btnd(WrenVM* vm)
+{
+    tic_core* core = getWrenCore(vm);
+    tic_mem* tic = (tic_mem*)core;
+
+    s32 top = wrenGetSlotCount(vm);
+
+    if (top == 1)
+    {
+        wrenSetSlotDouble(vm, 0, core->api.btnd(tic, -1));
+    }
+    else if (top == 2)
+    {
+        bool pressed = core->api.btnd(tic, getWrenNumber(vm, 1) & 0x1f);
+        wrenSetSlotBool(vm, 0, pressed);
+    }
+
+}
+
+static void wren_btnu(WrenVM* vm)
+{
+    tic_core* core = getWrenCore(vm);
+    tic_mem* tic = (tic_mem*)core;
+
+    s32 top = wrenGetSlotCount(vm);
+
+    if (top == 1)
+    {
+        wrenSetSlotDouble(vm, 0, core->api.btnu(tic, -1));
+    }
+    else if (top == 2)
+    {
+        bool pressed = core->api.btnu(tic, getWrenNumber(vm, 1) & 0x1f);
+        wrenSetSlotBool(vm, 0, pressed);
+    }
+
 }
 
 static void wren_key(WrenVM* vm)
@@ -1451,6 +1493,10 @@ static WrenForeignMethodFn foreignTicMethods(const char* signature)
     if (strcmp(signature, "static TIC.btn(_)"                   ) == 0) return wren_btn;
     if (strcmp(signature, "static TIC.btnp(_)"                  ) == 0) return wren_btnp;
     if (strcmp(signature, "static TIC.btnp(_,_,_)"              ) == 0) return wren_btnp;
+    if (strcmp(signature, "static TIC.btnd()"                   ) == 0) return wren_btnd;
+    if (strcmp(signature, "static TIC.btnd(_)"                  ) == 0) return wren_btnd;
+    if (strcmp(signature, "static TIC.btnu()"                   ) == 0) return wren_btnu;
+    if (strcmp(signature, "static TIC.btnu(_)"                  ) == 0) return wren_btnu;
     if (strcmp(signature, "static TIC.key(_)"                   ) == 0) return wren_key;
     if (strcmp(signature, "static TIC.keyp(_)"                  ) == 0) return wren_keyp;
     if (strcmp(signature, "static TIC.keyp(_,_,_)"              ) == 0) return wren_keyp;

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -342,10 +342,10 @@ void tic_api_reset(tic_mem* memory)
     // is copied to previous. This duplicates the prior behavior of
     // `ram.input.keyboard` (which existing outside `state`).
     u32 kb_now = core->state.keyboard.now.data;
-    // u32 gp_now = core->state.gamepads.now.data;
+    u32 gp_now = core->state.gamepads.now.data;
     ZEROMEM(core->state);
     core->state.keyboard.now.data = kb_now;
-    // core->state.gamepads.now.data = gp_now;
+    core->state.gamepads.now.data = gp_now;
     tic_api_clip(memory, 0, 0, TIC80_WIDTH, TIC80_HEIGHT);
 
     resetVbank(memory);

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -342,8 +342,10 @@ void tic_api_reset(tic_mem* memory)
     // is copied to previous. This duplicates the prior behavior of
     // `ram.input.keyboard` (which existing outside `state`).
     u32 kb_now = core->state.keyboard.now.data;
+    // u32 gp_now = core->state.gamepads.now.data;
     ZEROMEM(core->state);
     core->state.keyboard.now.data = kb_now;
+    // core->state.gamepads.now.data = gp_now;
     tic_api_clip(memory, 0, 0, TIC80_WIDTH, TIC80_HEIGHT);
 
     resetVbank(memory);

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -64,7 +64,6 @@ u32 tic_api_btnp(tic_mem* tic, s32 index, s32 hold, s32 period)
 
 u32 tic_api_btnd(tic_mem* tic, s32 index)
 {
-    printf("\nio.c - tic_api_btnd : Called");
     tic_core* core = (tic_core*)tic;
 
     if (index < 0)
@@ -75,13 +74,33 @@ u32 tic_api_btnd(tic_mem* tic, s32 index)
     {
         if ((core->state.gamepads.previous.data & (1 << index)) == (core->memory.ram->input.gamepads.data & (1 << index)))
         {
-            printf("\nio.c - tic_api_btnd : previous data + index mask is equal to current data + index mask");
             return 0;
         }
         else
         {
-            printf("\nio.c - tic_api_btnd : previous data + index mask is NOT equal to current data + index mask");
             return core->memory.ram->input.gamepads.data & (1 << index);
+        }
+    }
+}
+
+u32 tic_api_btnu(tic_mem* tic, s32 index)
+{
+    tic_core* core = (tic_core*)tic;
+
+    if (index < 0)
+    {
+        return core->memory.ram->input.gamepads.data;
+    }
+    else
+    {
+        if ((core->state.gamepads.previous.data & (1 << index)) != (core->memory.ram->input.gamepads.data & (1 << index))
+            && (core->memory.ram->input.gamepads.data & (1 << index)) == 0)
+        {
+            return core->state.gamepads.previous.data & (1 << index);
+        }
+        else
+        {
+            return 0;
         }
     }
 }

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -62,6 +62,30 @@ u32 tic_api_btnp(tic_mem* tic, s32 index, s32 hold, s32 period)
     return ((~previous.data) & core->memory.ram->input.gamepads.data) & (1 << index);
 }
 
+u32 tic_api_btnd(tic_mem* tic, s32 index)
+{
+    printf("\nio.c - tic_api_btnd : Called");
+    tic_core* core = (tic_core*)tic;
+
+    if (index < 0)
+    {
+        return core->memory.ram->input.gamepads.data;
+    }
+    else
+    {
+        if ((core->state.gamepads.previous.data & (1 << index)) == (core->memory.ram->input.gamepads.data & (1 << index)))
+        {
+            printf("\nio.c - tic_api_btnd : previous data + index mask is equal to current data + index mask");
+            return 0;
+        }
+        else
+        {
+            printf("\nio.c - tic_api_btnd : previous data + index mask is NOT equal to current data + index mask");
+            return core->memory.ram->input.gamepads.data & (1 << index);
+        }
+    }
+}
+
 u32 tic_api_btn(tic_mem* tic, s32 index)
 {
     tic_core* core = (tic_core*)tic;

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4044,8 +4044,14 @@ static void processGamepad(Console* console)
 
     if(!console->active)
         return;
+    printf("\nconsole.c - processGamepad : asking tic_api_btnd(tic, 6)");
+    printf("\nconsole.c - processGamepad : tic_api_btnd(tic, 6) result : %d", tic_api_btnd(tic, 6));
 
-    if(tic->ram->input.keyboard.data == 0 && tic_api_btnp(tic, 6, -1, -1))
+
+    printf("\nconsole.c - processGamepad : asking tic_api_btn(tic, 6)");
+    printf("\nconsole.c - processGamepad : tic_api_btn(tic, 6) result : %d", tic_api_btn(tic, 6));
+
+    if(tic->ram->input.keyboard.data == 0 && tic_api_btnd(tic, 6))
     {
         gotoSurf(console->studio);
     }

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4044,12 +4044,14 @@ static void processGamepad(Console* console)
 
     if(!console->active)
         return;
-    printf("\nconsole.c - processGamepad : asking tic_api_btnd(tic, 6)");
-    printf("\nconsole.c - processGamepad : tic_api_btnd(tic, 6) result : %d", tic_api_btnd(tic, 6));
 
-
-    printf("\nconsole.c - processGamepad : asking tic_api_btn(tic, 6)");
-    printf("\nconsole.c - processGamepad : tic_api_btn(tic, 6) result : %d", tic_api_btn(tic, 6));
+    printf("\nconsole.c - processGamepad : testing btnd and btnu");
+    printf("\nconsole.c - processGamepad : btnd on index 4 = %d", tic_api_btnd(tic, 4));
+    printf("\nconsole.c - processGamepad : btnu on index 4 = %d", tic_api_btnu(tic, 4));
+    printf("\nconsole.c - processGamepad : btnd on index 5 = %d", tic_api_btnd(tic, 5));
+    printf("\nconsole.c - processGamepad : btnu on index 5 = %d", tic_api_btnu(tic, 5));
+    printf("\nconsole.c - processGamepad : btnd on index 2 = %d", tic_api_btnd(tic, 2));
+    printf("\nconsole.c - processGamepad : btnu on index 2 = %d", tic_api_btnu(tic, 2));
 
     if(tic->ram->input.keyboard.data == 0 && tic_api_btnd(tic, 6))
     {

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4045,14 +4045,6 @@ static void processGamepad(Console* console)
     if(!console->active)
         return;
 
-    printf("\nconsole.c - processGamepad : testing btnd and btnu");
-    printf("\nconsole.c - processGamepad : btnd on index 4 = %d", tic_api_btnd(tic, 4));
-    printf("\nconsole.c - processGamepad : btnu on index 4 = %d", tic_api_btnu(tic, 4));
-    printf("\nconsole.c - processGamepad : btnd on index 5 = %d", tic_api_btnd(tic, 5));
-    printf("\nconsole.c - processGamepad : btnu on index 5 = %d", tic_api_btnu(tic, 5));
-    printf("\nconsole.c - processGamepad : btnd on index 2 = %d", tic_api_btnd(tic, 2));
-    printf("\nconsole.c - processGamepad : btnu on index 2 = %d", tic_api_btnu(tic, 2));
-
     if(tic->ram->input.keyboard.data == 0 && tic_api_btnd(tic, 6))
     {
         gotoSurf(console->studio);


### PR DESCRIPTION
Hello again!

This fixes issue 2561 (https://github.com/nesbox/TIC-80/issues/2561) which is an issue I inadvertently created, familiar territory for most of us here I'm sure lol.

I am still not very experienced with C and memory management, and while fixing this I found some security messages and other questions within `core.c`. While it seems like I didn't violate any security issues, it might be best if someone who understands this better checks in. I separated my changes to `core.c` in two commits. My attempt to solve 2561 requires those changes.

- `817e09c3299306c9ce88ac7fa6ad1607dfe0367f` before touching core.c
- `c3328075aa3d2bd1697f362a7cc340f473d4615f` after

To easily test the issue, I made a new lua cart called "breaktest"

```
x = 1
function TIC()
	if btn(6) then
		trace("breaking") 
		x = x + y 
	end
	cls(0)
end
```