### PR TITLE
fix horribly broken command line parsing

### DIFF
--- a/src/studio/studio.h
+++ b/src/studio/studio.h
@@ -67,17 +67,17 @@
 #endif
 
 #define CMD_PARAMS_LIST(macro)                                                              \
-    macro(skip,         bool,   BOOLEAN,    "",         "skip startup animation")           \
+    macro(skip,         int,    BOOLEAN,    "",         "skip startup animation")           \
     macro(volume,       s32,    INTEGER,    "=<int>",   "global volume value [0-15]")       \
-    macro(cli,          bool,   BOOLEAN,    "",         "console only output")              \
-    macro(fullscreen,   bool,   BOOLEAN,    "",         "enable fullscreen mode")           \
-    macro(vsync,        bool,   BOOLEAN,    "",         "enable VSYNC")                     \
-    macro(soft,         bool,   BOOLEAN,    "",         "use software rendering")           \
+    macro(cli,          int,    BOOLEAN,    "",         "console only output")              \
+    macro(fullscreen,   int,    BOOLEAN,    "",         "enable fullscreen mode")           \
+    macro(vsync,        int,    BOOLEAN,    "",         "enable VSYNC")                     \
+    macro(soft,         int,    BOOLEAN,    "",         "use software rendering")           \
     macro(fs,           char*,  STRING,     "=<str>",   "path to the file system folder")   \
     macro(scale,        s32,    INTEGER,    "=<int>",   "main window scale")                \
     macro(cmd,          char*,  STRING,     "=<str>",   "run commands in the console")      \
-    macro(keepcmd,      bool,   BOOLEAN,    "",         "re-execute commands on every run") \
-    macro(version,      bool,   BOOLEAN,    "",         "print program version")            \
+    macro(keepcmd,      int,    BOOLEAN,    "",         "re-execute commands on every run") \
+    macro(version,      int,    BOOLEAN,    "",         "print program version")            \
     CRT_CMD_PARAM(macro)
 
 #define SHOW_TOOLTIP(STUDIO, FORMAT, ...)   \


### PR DESCRIPTION
The version of `argparse` you're pinned to wants `int`-s when `ARGPARSE_OPT_BOOLEAN` is used: https://github.com/cofyc/argparse/blob/0d5f5d0745df14a3f373f7eed85bf524714f4524/argparse.c#L57-L66 but you're using `bool`-s: https://github.com/nesbox/TIC-80/blob/main/src/studio/studio.h#L71-L81
If there's a size-mismatch between `bool` and `int` (depending on compiler, platform, etc etc), then whatever garbage may be in the padding gets treated as part of the `int` - I suspect this is why command line fullscreen hasn't worked for a loooooong time now.