### PR TITLE
libretro: Update the list of static language libraries

### DIFF
--- a/cmake/libretro.cmake
+++ b/cmake/libretro.cmake
@@ -26,19 +26,52 @@ if(BUILD_LIBRETRO)
 IS_DOS
 )
 
+        # Build a list of language libraries to link against.
+        if(BUILD_WITH_FENNEL)
+            set(LIBRETRO_FENNEL_LIB ${CMAKE_BINARY_DIR}/lib/libfennel.a)
+        endif()
+        if(BUILD_WITH_JANET)
+            set(LIBRETRO_JANET_LIB ${CMAKE_BINARY_DIR}/lib/libjanet.a)
+        endif()
+        if(BUILD_WITH_LUA)
+            set(LIBRETRO_LUA_LIB ${CMAKE_BINARY_DIR}/lib/liblua.a)
+        endif()
+        if(BUILD_WITH_MOON)
+            set(LIBRETRO_MOON_LIB ${CMAKE_BINARY_DIR}/lib/libmoon.a)
+        endif()
+        if(BUILD_WITH_MRUBY)
+            set(LIBRETRO_MRUBY_LIB ${CMAKE_BINARY_DIR}/lib/libmruby.a)
+        endif()
+        if(BUILD_WITH_JS)
+            set(LIBRETRO_JS_LIB ${CMAKE_BINARY_DIR}/lib/libquickjs.a)
+        endif()
+        if(BUILD_WITH_SCHEME)
+            set(LIBRETRO_SCHEME_LIB ${CMAKE_BINARY_DIR}/lib/libscheme.a)
+        endif()
+        if(BUILD_WITH_SQUIRREL)
+            set(LIBRETRO_SQUIRREL_LIB ${CMAKE_BINARY_DIR}/lib/libsquirrel.a)
+        endif()
+        if(BUILD_WITH_WASM)
+            set(LIBRETRO_WASM_LIB ${CMAKE_BINARY_DIR}/lib/libwasm.a)
+        endif()
+        if(BUILD_WITH_WREN)
+            set(LIBRETRO_WREN_LIB ${CMAKE_BINARY_DIR}/lib/libwren.a)
+        endif()
+        set(LIBRETRO_LANG_LIBS ${LIBRETRO_FENNEL_LIB} ${LIBRETRO_JANET_LIB} ${LIBRETRO_LUA_LIB} ${LIBRETRO_MOON_LIB} ${LIBRETRO_MRUBY_LIB} ${LIBRETRO_JS_LIB} ${LIBRETRO_SCHEME_LIB} ${LIBRETRO_SQUIRREL_LIB} ${LIBRETRO_WASM_LIB} ${LIBRETRO_WREN_LIB})
+
         # Exact way to detect NGC/Wii depends on version of cmake files
         if("${CMAKE_SYSTEM_NAME}" STREQUAL "NintendoWii" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "NintendoGameCube" OR GAMECUBE OR WII OR IS_DOS)
           add_custom_command(TARGET tic80_libretro
                POST_BUILD
-                   COMMAND ${CMAKE_SOURCE_DIR}/build/libretro/merge_static.sh $(AR) ${CMAKE_BINARY_DIR}/lib/tic80_libretro${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION} ${CMAKE_BINARY_DIR}/lib/tic80_libretro_partial.a ${CMAKE_BINARY_DIR}/lib/libtic80core.a ${CMAKE_BINARY_DIR}/lib/liblua.a ${CMAKE_BINARY_DIR}/lib/libblipbuf.a ${CMAKE_BINARY_DIR}/lib/libquickjs.a ${CMAKE_BINARY_DIR}/lib/libwren.a ${CMAKE_BINARY_DIR}/lib/libwasm.a ${CMAKE_BINARY_DIR}/lib/libjanet.a ${CMAKE_BINARY_DIR}/lib/libsquirrel.a ${CMAKE_BINARY_DIR}/lib/libscheme.a ${CMAKE_BINARY_DIR}/lib/libgiflib.a ${CMAKE_BINARY_DIR}/lib/liblpeg.a ${CMAKE_BINARY_DIR}/lib/libzlib.a ${MRUBY_LIB})
+                   COMMAND ${CMAKE_SOURCE_DIR}/build/libretro/merge_static.sh $(AR) ${CMAKE_BINARY_DIR}/lib/tic80_libretro${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION} ${CMAKE_BINARY_DIR}/lib/tic80_libretro_partial.a ${CMAKE_BINARY_DIR}/lib/libtic80core.a ${CMAKE_BINARY_DIR}/lib/libblipbuf.a ${CMAKE_BINARY_DIR}/lib/libgiflib.a ${CMAKE_BINARY_DIR}/lib/liblpeg.a ${LIBRETRO_LANG_LIBS} ${CMAKE_BINARY_DIR}/lib/libzlib.a)
         else()
           add_custom_command(TARGET tic80_libretro
                POST_BUILD
-                   COMMAND ${CMAKE_SOURCE_DIR}/build/libretro/merge_static.sh $(AR) ${CMAKE_BINARY_DIR}/lib/tic80_libretro${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION} ${CMAKE_BINARY_DIR}/lib/tic80_libretro_partial.a ${CMAKE_BINARY_DIR}/lib/libtic80core.a ${CMAKE_BINARY_DIR}/lib/liblua.a ${CMAKE_BINARY_DIR}/lib/libblipbuf.a ${CMAKE_BINARY_DIR}/lib/libquickjs.a ${CMAKE_BINARY_DIR}/lib/libwren.a ${CMAKE_BINARY_DIR}/lib/libwasm.a ${CMAKE_BINARY_DIR}/lib/libsquirrel.a ${CMAKE_BINARY_DIR}/lib/libscheme.a ${CMAKE_BINARY_DIR}/lib/libjanet.a ${CMAKE_BINARY_DIR}/lib/libgiflib.a ${CMAKE_BINARY_DIR}/lib/liblpeg.a ${MRUBY_LIB})
+                   COMMAND ${CMAKE_SOURCE_DIR}/build/libretro/merge_static.sh $(AR) ${CMAKE_BINARY_DIR}/lib/tic80_libretro${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION} ${CMAKE_BINARY_DIR}/lib/tic80_libretro_partial.a ${CMAKE_BINARY_DIR}/lib/libtic80core.a ${CMAKE_BINARY_DIR}/lib/libblipbuf.a ${CMAKE_BINARY_DIR}/lib/libgiflib.a ${CMAKE_BINARY_DIR}/lib/liblpeg.a ${LIBRETRO_LANG_LIBS})
         endif()
     else()
         add_library(tic80_libretro SHARED
-        ${LIBRETRO_SRC}
+            ${LIBRETRO_SRC}
         )
     endif()
 


### PR DESCRIPTION
I'm unsure if this is the correct approach, but I've updated the cmake definition for libretro to construct a list of language libraries to static link against. Found that on some platforms, since JS was disabled, it wasn't able to find libquickjs.a, so hopefully this fixes it.
