### PR TITLE
libretro: Add `BUILD_WITH_ZLIB` option to allow disabling zlib link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(BUILD_PLAYER "Build standalone players" ${BUILD_PLAYER_DEFAULT})
 option(BUILD_TOUCH_INPUT "Build with touch input support" ${BUILD_TOUCH_INPUT_DEFAULT})
 option(BUILD_NO_OPTIMIZATION "Build without optimizations for debugging" OFF)
 option(BUILD_ASAN_DEBUG "Build with AddressSanitizer" OFF)
+option(BUILD_WITH_ZLIB "Build with zlib linked" ON)
 
 if (BUILD_NO_OPTIMIZATION)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0")

--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -51,7 +51,11 @@ target_include_directories(tic80core
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/src)
 
-target_link_libraries(tic80core PRIVATE blipbuf zlib)
+target_link_libraries(tic80core PRIVATE blipbuf)
+
+if(BUILD_WITH_ZLIB)
+    target_link_libraries(tic80core PRIVATE zlib)
+endif()
 
 if(BUILD_STATIC)
     if(BUILD_WITH_LUA)

--- a/cmake/libretro.cmake
+++ b/cmake/libretro.cmake
@@ -17,58 +17,8 @@ if(BUILD_LIBRETRO)
         else()
             set(LIBRETRO_EXTENSION "a")
         endif()
-        set_target_properties(tic80_libretro PROPERTIES SUFFIX "_partial.a")
-        include(CheckCSourceCompiles)
-        check_c_source_compiles(
-"#ifndef __MSDOS__
-#error \"Not DOS\"
-#endif"
-IS_DOS
-)
 
-        # Build a list of language libraries to link against.
-        if(BUILD_WITH_FENNEL)
-            set(LIBRETRO_FENNEL_LIB ${CMAKE_BINARY_DIR}/lib/libfennel.a)
-        endif()
-        if(BUILD_WITH_JANET)
-            set(LIBRETRO_JANET_LIB ${CMAKE_BINARY_DIR}/lib/libjanet.a)
-        endif()
-        if(BUILD_WITH_LUA)
-            set(LIBRETRO_LUA_LIB ${CMAKE_BINARY_DIR}/lib/liblua.a)
-        endif()
-        if(BUILD_WITH_MOON)
-            set(LIBRETRO_MOON_LIB ${CMAKE_BINARY_DIR}/lib/libmoon.a)
-        endif()
-        if(BUILD_WITH_MRUBY)
-            set(LIBRETRO_MRUBY_LIB ${CMAKE_BINARY_DIR}/lib/libmruby.a)
-        endif()
-        if(BUILD_WITH_JS)
-            set(LIBRETRO_JS_LIB ${CMAKE_BINARY_DIR}/lib/libquickjs.a)
-        endif()
-        if(BUILD_WITH_SCHEME)
-            set(LIBRETRO_SCHEME_LIB ${CMAKE_BINARY_DIR}/lib/libscheme.a)
-        endif()
-        if(BUILD_WITH_SQUIRREL)
-            set(LIBRETRO_SQUIRREL_LIB ${CMAKE_BINARY_DIR}/lib/libsquirrel.a)
-        endif()
-        if(BUILD_WITH_WASM)
-            set(LIBRETRO_WASM_LIB ${CMAKE_BINARY_DIR}/lib/libwasm.a)
-        endif()
-        if(BUILD_WITH_WREN)
-            set(LIBRETRO_WREN_LIB ${CMAKE_BINARY_DIR}/lib/libwren.a)
-        endif()
-        set(LIBRETRO_LANG_LIBS ${LIBRETRO_FENNEL_LIB} ${LIBRETRO_JANET_LIB} ${LIBRETRO_LUA_LIB} ${LIBRETRO_MOON_LIB} ${LIBRETRO_MRUBY_LIB} ${LIBRETRO_JS_LIB} ${LIBRETRO_SCHEME_LIB} ${LIBRETRO_SQUIRREL_LIB} ${LIBRETRO_WASM_LIB} ${LIBRETRO_WREN_LIB})
-
-        # Exact way to detect NGC/Wii depends on version of cmake files
-        if("${CMAKE_SYSTEM_NAME}" STREQUAL "NintendoWii" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "NintendoGameCube" OR GAMECUBE OR WII OR IS_DOS)
-          add_custom_command(TARGET tic80_libretro
-               POST_BUILD
-                   COMMAND ${CMAKE_SOURCE_DIR}/build/libretro/merge_static.sh $(AR) ${CMAKE_BINARY_DIR}/lib/tic80_libretro${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION} ${CMAKE_BINARY_DIR}/lib/tic80_libretro_partial.a ${CMAKE_BINARY_DIR}/lib/libtic80core.a ${CMAKE_BINARY_DIR}/lib/libblipbuf.a ${CMAKE_BINARY_DIR}/lib/libgiflib.a ${CMAKE_BINARY_DIR}/lib/liblpeg.a ${LIBRETRO_LANG_LIBS} ${CMAKE_BINARY_DIR}/lib/libzlib.a)
-        else()
-          add_custom_command(TARGET tic80_libretro
-               POST_BUILD
-                   COMMAND ${CMAKE_SOURCE_DIR}/build/libretro/merge_static.sh $(AR) ${CMAKE_BINARY_DIR}/lib/tic80_libretro${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION} ${CMAKE_BINARY_DIR}/lib/tic80_libretro_partial.a ${CMAKE_BINARY_DIR}/lib/libtic80core.a ${CMAKE_BINARY_DIR}/lib/libblipbuf.a ${CMAKE_BINARY_DIR}/lib/libgiflib.a ${CMAKE_BINARY_DIR}/lib/liblpeg.a ${LIBRETRO_LANG_LIBS})
-        endif()
+        set_target_properties(tic80_libretro PROPERTIES SUFFIX "${LIBRETRO_SUFFIX}.${LIBRETRO_EXTENSION}")
     else()
         add_library(tic80_libretro SHARED
             ${LIBRETRO_SRC}
@@ -77,7 +27,8 @@ IS_DOS
 
     target_include_directories(tic80_libretro PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
-        ${TIC80CORE_DIR})
+        ${TIC80CORE_DIR}
+    )
 
     if(MINGW)
         target_link_libraries(tic80_libretro mingw32)


### PR DESCRIPTION
There are a few platforms that when `BUILD_STATIC` is enabled, require not linking zlib. Hopefully with an option to toggle disabling it, it will clean up this cmake config a bit.
