### PR TITLE
#include mach-o/dyld.h when on macOS for _NSGetExecutablePath (needed for Clang 18)

### DIFF
--- a/src/studio/fs.c
+++ b/src/studio/fs.c
@@ -58,6 +58,10 @@
 #define SLASH_SYMBOL ('/')
 #endif
 
+#if defined (__TIC_MACOSX__)
+#include <mach-o/dyld.h>
+#endif
+
 static const char* PublicDir = TIC_HOST;
 
 struct tic_fs

--- a/src/studio/screens/start.c
+++ b/src/studio/screens/start.c
@@ -30,10 +30,6 @@
 #include <unistd.h>
 #endif
 
-#if defined (__TIC_MACOSX__)
-#include <mach-o/dyld.h>
-#endif
-
 static void reset(Start* start)
 {
     u8* tile = (u8*)start->tic->ram->tiles.data;


### PR DESCRIPTION
Got lost in the refactors, I guess :)