### PR TITLE
Don't run CI jobs twice on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   # === Windows XP ===
   winxp:
     runs-on: windows-2019
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +45,7 @@ jobs:
   # === Windows ===
   windows:
     runs-on: windows-2019
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v4
@@ -80,6 +82,7 @@ jobs:
   # === Windows MinGW-64 ===
   windows-mingw:
     runs-on: windows-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     defaults:
       run:
         shell: msys2 {0}
@@ -114,6 +117,7 @@ jobs:
   # === Ubuntu ===
   linux:
     runs-on: ubuntu-20.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v4
@@ -153,6 +157,7 @@ jobs:
   # === Raspberry PI ===
   rpi:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     container: nesbox/rpi-tic80:latest
 
     steps:
@@ -189,6 +194,7 @@ jobs:
   # === Raspberry PI 1-4 Bare Metal ===
   rpi-baremetal:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     container: nesbox/baremetalpi-tic80:latest
 
     steps:
@@ -249,6 +255,7 @@ jobs:
   # === Raspberry PI 4 Bare Metal ===
   rpi4-baremetal:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     container: nesbox/baremetalpi-tic80:latest
 
     steps:
@@ -312,6 +319,7 @@ jobs:
   # === Nintendo 3DS build ===
   nintendo-3ds:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     container: nesbox/devkitpro-tic80:latest
 
     steps:
@@ -340,6 +348,7 @@ jobs:
   # === MacOS 12 ===
   macos:
     runs-on: macos-12
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v4
@@ -373,6 +382,7 @@ jobs:
   # === MacOS 14 / arm64 ===
   macos-arm64:
     runs-on: macos-14
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v4
@@ -406,6 +416,7 @@ jobs:
   # === Android ===
   android:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v4
@@ -446,6 +457,7 @@ jobs:
   # === HTML ===
   html:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: mymindstorm/setup-emsdk@v14


### PR DESCRIPTION
Because of `on: [push, pull_request]`, CI jobs get triggered twice on PRs, this fixes that.

This is a simple fix; may be able to refactor the CI jobs into something nicer in the future that doesn't need it.