### PR TITLE
Implement "resume reload" command.

### DIFF
--- a/src/api/fennel.c
+++ b/src/api/fennel.c
@@ -165,6 +165,10 @@ static void evalFennel(tic_mem* tic, const char* code) {
     tic_core* core = (tic_core*)tic;
     lua_State* fennel = core->currentVM;
 
+    /* if we proceed with an uninitialized VM it will segfault; however */
+    /* it could be better just to initialize here when needed instead! */
+    if (!fennel) return;
+
     lua_settop(fennel, 0);
 
     if (luaL_loadbuffer(fennel, execute_fennel_src, strlen(execute_fennel_src), "execute_fennel") != LUA_OK)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2667,6 +2667,23 @@ static void onRunCommand(Console* console)
 
 static void onResumeCommand(Console* console)
 {
+    if(console->desc->count)
+    {
+        const char* param = console->desc->params->key;
+
+        if(strcmp(param, "reload") == 0)
+        {
+            const tic_script* script_config = tic_get_script(console->tic);
+            if (script_config->eval)
+            {
+                script_config->eval(console->tic, console->tic->cart.code.data);
+            }
+            else
+            {
+                printError(console, "eval not implemented for the script");
+            }
+        }
+    }
     commandDone(console);
 
     resumeGame(console->studio);


### PR DESCRIPTION
When resuming, you can pass "reload" as the argument, which causes the cart's code to be reloaded before resuming the game.

This allows for a much smoother iterative development style where you can pause the game, make changes, and see the effect of those changes without restarting the game. It does require some special handling in the cart to support saving state to a global and avoiding that state being reinitialized if it's already set; for instance:

    state = state or {x=25, y=100, shots={}}

This implements the reload method for the Lua and Fennel scripts, but it will need to be implemented for other scripts independently.