### PR TITLE
Add a check to draw.c:getPalette so it does not write out of bounds past the mapping static array into whatever static happens to come after: Fixes #2611 segfault

### DIFF
--- a/src/core/draw.c
+++ b/src/core/draw.c
@@ -51,7 +51,12 @@ static u8* getPalette(tic_mem* tic, u8* colors, u8 count)
 {
     static u8 mapping[TIC_PALETTE_SIZE];
     for (s32 i = 0; i < TIC_PALETTE_SIZE; i++) mapping[i] = tic_tool_peek4(tic->ram->vram.mapping, i);
-    for (s32 i = 0; i < count; i++) mapping[colors[i]] = TRANSPARENT_COLOR;
+    for (s32 i = 0; i < count; i++) {
+        if (colors[i] < TIC_PALETTE_SIZE)
+        {
+            mapping[colors[i]] = TRANSPARENT_COLOR;
+        }
+    }
     return mapping;
 }
 


### PR DESCRIPTION
Fixes #2611 segfault

Please see that related issues for full details about this static memory corruption issue.

This is not a complete fix, but it at least no-ops the memory corruption by performing a bounds check on user supplied input.