### PR TITLE
Fix buffer overflow in `tic_fs_changedir`

### DIFF
--- a/src/studio/fs.c
+++ b/src/studio/fs.c
@@ -498,7 +498,7 @@ void tic_fs_dir(tic_fs* fs, char* dir)
 
 void tic_fs_changedir(tic_fs* fs, const char* dir)
 {
-    char temp[TICNAME_MAX];
+    char temp[TICNAME_MAX+1];
 
     if (strlen(fs->work) > 0) {
         snprintf(temp, TICNAME_MAX+1, "%s/%s", fs->work, dir);


### PR DESCRIPTION
Entering a subdirectory more than one level would cause a buffer overflow and crash TIC-80. This bug was originally introduced in https://github.com/nesbox/TIC-80/pull/2648.