### PR TITLE
Fix TIC-80 when using a French AZERTY layout

### DIFF
--- a/include/tic80.h
+++ b/include/tic80.h
@@ -166,6 +166,16 @@ typedef union
     u32 data;
 } tic80_keyboard;
 
+typedef enum {
+    tic_layout_unknown = 0,
+    tic_layout_qwerty,
+    tic_layout_azerty,
+    tic_layout_qwertz,
+    tic_layout_qzerty,
+    tic_layout_de_neo,
+    tic_layout_de_bone
+} tic_layout;
+
 typedef struct
 {
     tic80_gamepads gamepads;

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -214,6 +214,7 @@ struct Studio
     tic_net* net;
 
     Bytebattle bytebattle;
+    bool isFrenchKeyboard;
 
 #endif
 
@@ -1816,6 +1817,7 @@ static void processShortcuts(Studio* studio)
 
     bool alt = tic_api_key(tic, tic_key_alt);
     bool ctrl = tic_api_key(tic, tic_key_ctrl);
+    bool isFrenchKeyboard = studio->isFrenchKeyboard;
 
 #if defined(CRT_SHADER_SUPPORT)
     if(keyWasPressedOnce(studio, tic_key_f6)) switchCrtMonitor(studio);
@@ -1825,8 +1827,9 @@ static void processShortcuts(Studio* studio)
     {
         if (enterWasPressedOnce(studio)) gotoFullscreen(studio);
 #if defined(BUILD_EDITORS)
-        else if(studio->mode != TIC_RUN_MODE)
+        else if(studio->mode != TIC_RUN_MODE && !isFrenchKeyboard)
         {
+            printf("We are in here even though the keyboard is not french\n");
             if(keyWasPressedOnce(studio, tic_key_grave)) setStudioMode(studio, TIC_CONSOLE_MODE);
             else if(keyWasPressedOnce(studio, tic_key_1)) setStudioMode(studio, TIC_CODE_MODE);
             else if(keyWasPressedOnce(studio, tic_key_2)) setStudioMode(studio, TIC_SPRITE_MODE);
@@ -2683,7 +2686,7 @@ static bool onEnumModule(const char* name, const char* title, const char* hash, 
 }
 #endif
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale)
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale, bool isFrenchKeyboard)
 {
     setbuf(stdout, NULL);
 
@@ -2737,6 +2740,7 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
         .net = tic_net_create(TIC_WEBSITE),
 
         .bytebattle = {0},
+        .isFrenchKeyboard = isFrenchKeyboard,
 #endif
         .tic = tic_core_create(samplerate, format),
     };

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -214,7 +214,6 @@ struct Studio
     tic_net* net;
 
     Bytebattle bytebattle;
-    bool isFrenchKeyboard;
 
 #endif
 
@@ -1817,7 +1816,7 @@ static void processShortcuts(Studio* studio)
 
     bool alt = tic_api_key(tic, tic_key_alt);
     bool ctrl = tic_api_key(tic, tic_key_ctrl);
-    bool isFrenchKeyboard = studio->isFrenchKeyboard;
+    bool isFrenchKeyboard = studio->config->data.isFrenchKeyboard;
 
 #if defined(CRT_SHADER_SUPPORT)
     if(keyWasPressedOnce(studio, tic_key_f6)) switchCrtMonitor(studio);
@@ -1829,7 +1828,6 @@ static void processShortcuts(Studio* studio)
 #if defined(BUILD_EDITORS)
         else if(studio->mode != TIC_RUN_MODE && !isFrenchKeyboard)
         {
-            printf("We are in here even though the keyboard is not french\n");
             if(keyWasPressedOnce(studio, tic_key_grave)) setStudioMode(studio, TIC_CONSOLE_MODE);
             else if(keyWasPressedOnce(studio, tic_key_1)) setStudioMode(studio, TIC_CODE_MODE);
             else if(keyWasPressedOnce(studio, tic_key_2)) setStudioMode(studio, TIC_SPRITE_MODE);
@@ -2655,6 +2653,12 @@ static void setPopupHide(void* data)
 
 #endif
 
+void studio_keymapchanged(Studio* studio, bool isFrenchKeyboard)
+{
+    studio->config->data.isFrenchKeyboard = isFrenchKeyboard;
+    printf("Keyboard layout change detected, isFrenchKeyboard: %d\n", isFrenchKeyboard);
+}
+
 bool studio_alive(Studio* studio)
 {
     return studio->alive;
@@ -2740,7 +2744,6 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
         .net = tic_net_create(TIC_WEBSITE),
 
         .bytebattle = {0},
-        .isFrenchKeyboard = isFrenchKeyboard,
 #endif
         .tic = tic_core_create(samplerate, format),
     };
@@ -2861,6 +2864,7 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
     studio->config->data.fft = args.fft;
     studio->config->data.fftcaptureplaybackdevices = args.fftcaptureplaybackdevices;
     studio->config->data.fftdevice = args.fftdevice;
+    studio->config->data.isFrenchKeyboard = isFrenchKeyboard;
 #endif
 
     studioConfigChanged(studio);

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -1816,7 +1816,6 @@ static void processShortcuts(Studio* studio)
 
     bool alt = tic_api_key(tic, tic_key_alt);
     bool ctrl = tic_api_key(tic, tic_key_ctrl);
-    bool isFrenchKeyboard = studio->config->data.isFrenchKeyboard;
 
 #if defined(CRT_SHADER_SUPPORT)
     if(keyWasPressedOnce(studio, tic_key_f6)) switchCrtMonitor(studio);
@@ -1826,7 +1825,7 @@ static void processShortcuts(Studio* studio)
     {
         if (enterWasPressedOnce(studio)) gotoFullscreen(studio);
 #if defined(BUILD_EDITORS)
-        else if(studio->mode != TIC_RUN_MODE && !isFrenchKeyboard)
+        else if(studio->mode != TIC_RUN_MODE && strcmp(studio->config->data.keyboardLayout, "azerty") != 0)
         {
             if(keyWasPressedOnce(studio, tic_key_grave)) setStudioMode(studio, TIC_CONSOLE_MODE);
             else if(keyWasPressedOnce(studio, tic_key_1)) setStudioMode(studio, TIC_CODE_MODE);
@@ -2653,10 +2652,9 @@ static void setPopupHide(void* data)
 
 #endif
 
-void studio_keymapchanged(Studio* studio, bool isFrenchKeyboard)
+void studio_keymapchanged(Studio* studio, char* keyboardLayout)
 {
-    studio->config->data.isFrenchKeyboard = isFrenchKeyboard;
-    printf("Keyboard layout change detected, isFrenchKeyboard: %d\n", isFrenchKeyboard);
+    studio->config->data.keyboardLayout = keyboardLayout;
 }
 
 bool studio_alive(Studio* studio)
@@ -2690,7 +2688,7 @@ static bool onEnumModule(const char* name, const char* title, const char* hash, 
 }
 #endif
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale, bool isFrenchKeyboard)
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale, char* keyboardLayout)
 {
     setbuf(stdout, NULL);
 
@@ -2864,7 +2862,7 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
     studio->config->data.fft = args.fft;
     studio->config->data.fftcaptureplaybackdevices = args.fftcaptureplaybackdevices;
     studio->config->data.fftdevice = args.fftdevice;
-    studio->config->data.isFrenchKeyboard = isFrenchKeyboard;
+    studio->config->data.keyboardLayout = keyboardLayout;
 #endif
 
     studioConfigChanged(studio);

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -1825,7 +1825,7 @@ static void processShortcuts(Studio* studio)
     {
         if (enterWasPressedOnce(studio)) gotoFullscreen(studio);
 #if defined(BUILD_EDITORS)
-        else if(studio->mode != TIC_RUN_MODE && strcmp(studio->config->data.keyboardLayout, "azerty") != 0)
+        else if(studio->mode != TIC_RUN_MODE && studio->config->data.keyboardLayout != tic_layout_azerty)
         {
             if(keyWasPressedOnce(studio, tic_key_grave)) setStudioMode(studio, TIC_CONSOLE_MODE);
             else if(keyWasPressedOnce(studio, tic_key_1)) setStudioMode(studio, TIC_CODE_MODE);
@@ -2652,7 +2652,7 @@ static void setPopupHide(void* data)
 
 #endif
 
-void studio_keymapchanged(Studio* studio, char* keyboardLayout)
+void studio_keymapchanged(Studio* studio, tic_layout keyboardLayout)
 {
     studio->config->data.keyboardLayout = keyboardLayout;
 }
@@ -2688,7 +2688,7 @@ static bool onEnumModule(const char* name, const char* title, const char* hash, 
 }
 #endif
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale, char* keyboardLayout)
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* folder, s32 maxscale, tic_layout keyboardLayout)
 {
     setbuf(stdout, NULL);
 

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -153,6 +153,8 @@ typedef struct
     int fftcaptureplaybackdevices;
     const char *fftdevice;
 
+    bool isFrenchKeyboard;
+
 } StudioConfig;
 
 typedef struct Studio Studio;
@@ -163,6 +165,7 @@ const tic_mem* studio_mem(Studio* studio);
 void studio_tick(Studio* studio, tic80_input input);
 void studio_sound(Studio* studio);
 void studio_load(Studio* studio, const char* file);
+void studio_keymapchanged(Studio *studio, bool isFrenchKeyboard);
 bool studio_alive(Studio* studio);
 void studio_exit(Studio* studio);
 void studio_delete(Studio* studio);

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -152,6 +152,7 @@ typedef struct
     int fft;
     int fftcaptureplaybackdevices;
     const char *fftdevice;
+
 } StudioConfig;
 
 typedef struct Studio Studio;
@@ -167,7 +168,7 @@ void studio_exit(Studio* studio);
 void studio_delete(Studio* studio);
 const StudioConfig* studio_config(Studio* studio);
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale);
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale, bool isFrenchKeyboard);
 
 #ifdef __cplusplus
 }

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -153,8 +153,7 @@ typedef struct
     int fftcaptureplaybackdevices;
     const char *fftdevice;
 
-    bool isFrenchKeyboard;
-
+    char* keyboardLayout;
 } StudioConfig;
 
 typedef struct Studio Studio;
@@ -165,13 +164,13 @@ const tic_mem* studio_mem(Studio* studio);
 void studio_tick(Studio* studio, tic80_input input);
 void studio_sound(Studio* studio);
 void studio_load(Studio* studio, const char* file);
-void studio_keymapchanged(Studio *studio, bool isFrenchKeyboard);
+void studio_keymapchanged(Studio *studio, char* keyboardLayout);
 bool studio_alive(Studio* studio);
 void studio_exit(Studio* studio);
 void studio_delete(Studio* studio);
 const StudioConfig* studio_config(Studio* studio);
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale, bool isFrenchKeyboard);
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale, char* keyboardLayout);
 
 #ifdef __cplusplus
 }

--- a/src/studio/system.h
+++ b/src/studio/system.h
@@ -153,7 +153,7 @@ typedef struct
     int fftcaptureplaybackdevices;
     const char *fftdevice;
 
-    char* keyboardLayout;
+    tic_layout keyboardLayout;
 } StudioConfig;
 
 typedef struct Studio Studio;
@@ -164,13 +164,13 @@ const tic_mem* studio_mem(Studio* studio);
 void studio_tick(Studio* studio, tic80_input input);
 void studio_sound(Studio* studio);
 void studio_load(Studio* studio, const char* file);
-void studio_keymapchanged(Studio *studio, char* keyboardLayout);
+void studio_keymapchanged(Studio *studio, tic_layout keyboardLayout);
 bool studio_alive(Studio* studio);
 void studio_exit(Studio* studio);
 void studio_delete(Studio* studio);
 const StudioConfig* studio_config(Studio* studio);
 
-Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale, char* keyboardLayout);
+Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_format format, const char* appFolder, s32 maxscale, tic_layout keyboardLayout);
 
 #ifdef __cplusplus
 }

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -392,7 +392,7 @@ TShutdownMode Run(void)
         char* argv[] = { &arg0[0], NULL };
         int argc = 1;
         malloc(88);
-        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX, "qwerty");
+        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX, tic_layout_qwerty);
         malloc(99);
 
     }
@@ -404,7 +404,7 @@ TShutdownMode Run(void)
         char* argv[] = { &arg0[0], &arg1[0], NULL };
         int argc = 2;
         dbg("Without keyboard\n");
-        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX, "qwerty");
+        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX, tic_layout_qwerty);
     }
     dbg("studio_create OK\n");
 

--- a/src/system/baremetalpi/kernel.cpp
+++ b/src/system/baremetalpi/kernel.cpp
@@ -392,7 +392,7 @@ TShutdownMode Run(void)
         char* argv[] = { &arg0[0], NULL };
         int argc = 1;
         malloc(88);
-        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX);
+        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX, "qwerty");
         malloc(99);
 
     }
@@ -404,7 +404,7 @@ TShutdownMode Run(void)
         char* argv[] = { &arg0[0], &arg1[0], NULL };
         int argc = 2;
         dbg("Without keyboard\n");
-        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX);
+        platform.studio = studio_create(argc, argv, 44100, TIC80_PIXEL_COLOR_BGRA8888, "tic80", INT32_MAX, "qwerty");
     }
     dbg("studio_create OK\n");
 

--- a/src/system/n3ds/main.c
+++ b/src/system/n3ds/main.c
@@ -580,7 +580,7 @@ int main(int argc, char **argv) {
     n3ds_draw_init();
     n3ds_keyboard_init(&platform.keyboard);
 
-    platform.studio = studio_create(argc_used, argv_used, AUDIO_FREQ, TIC80_PIXEL_COLOR_ABGR8888, "./", INT32_MAX);
+    platform.studio = studio_create(argc_used, argv_used, AUDIO_FREQ, TIC80_PIXEL_COLOR_ABGR8888, "./", INT32_MAX, "qwerty");
 
     n3ds_sound_init(AUDIO_FREQ);
 

--- a/src/system/n3ds/main.c
+++ b/src/system/n3ds/main.c
@@ -580,7 +580,7 @@ int main(int argc, char **argv) {
     n3ds_draw_init();
     n3ds_keyboard_init(&platform.keyboard);
 
-    platform.studio = studio_create(argc_used, argv_used, AUDIO_FREQ, TIC80_PIXEL_COLOR_ABGR8888, "./", INT32_MAX, "qwerty");
+    platform.studio = studio_create(argc_used, argv_used, AUDIO_FREQ, TIC80_PIXEL_COLOR_ABGR8888, "./", INT32_MAX, tic_layout_qwerty);
 
     n3ds_sound_init(AUDIO_FREQ);
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -145,6 +145,7 @@ static struct
     {
         bool state[tic_keys_count];
         bool pressed[tic_keys_count];
+        bool isFrenchKeyboard;
         char text;
 
 #if defined(TOUCH_INPUT_SUPPORT)
@@ -1062,6 +1063,21 @@ static void handleKeydown(SDL_Keycode keycode, bool down, bool* state, bool* pre
 #endif
 }
 
+bool is_french_keyboard() {
+	char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
+	char w = SDL_GetKeyFromScancode(SDL_SCANCODE_W);
+	char y = SDL_GetKeyFromScancode(SDL_SCANCODE_Y);
+
+    char* layout = "unknown";
+
+	if (q == 'q' && w == 'w' && y == 'y') layout = "qwerty";
+	if (q == 'a' && w == 'z' && y == 'y') layout = "azerty";
+	if (q == 'q' && w == 'w' && y == 'z') layout = "qwertz";
+	if (q == 'q' && w == 'z' && y == 'y') layout = "qzerty";
+	
+    return layout == "azerty";
+}
+
 static void pollEvents()
 {
     // check if releative mode was enabled
@@ -1192,6 +1208,9 @@ static void pollEvents()
             break;
         case SDL_KEYUP:
             handleKeydown(event.key.keysym.sym, false, platform.keyboard.state, platform.keyboard.pressed);
+            break;
+        case SDL_KEYMAPCHANGED:
+            studio_keymapchanged(platform.studio, is_french_keyboard());
             break;
         case SDL_TEXTINPUT:
             if(strlen(event.text.text) == 1)
@@ -1868,20 +1887,6 @@ s32 determineMaximumScale()
     {
         return maxScale;
     }
-}
-
-bool is_french_keyboard() {
-    SDL_Scancode scancode = SDL_SCANCODE_A;
-    SDL_Keycode key = SDL_GetKeyFromScancode(scancode);
-
-    // On a French AZERTY layout, SDL_SCANCODE_A should map to SDLK_q
-    // On a QWERTY layout, it maps to SDLK_a
-    if (key == SDLK_q) {
-        printf("French keyboard detected.\n");
-    } else {
-        printf("French keyboard not detected.\n");
-    }
-    return (key == SDLK_q);
 }
 
 static s32 start(s32 argc, char **argv, const char* folder)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1870,6 +1870,20 @@ s32 determineMaximumScale()
     }
 }
 
+bool is_french_keyboard() {
+    SDL_Scancode scancode = SDL_SCANCODE_A;
+    SDL_Keycode key = SDL_GetKeyFromScancode(scancode);
+
+    // On a French AZERTY layout, SDL_SCANCODE_A should map to SDLK_q
+    // On a QWERTY layout, it maps to SDLK_a
+    if (key == SDLK_q) {
+        printf("French keyboard detected.\n");
+    } else {
+        printf("French keyboard not detected.\n");
+    }
+    return (key == SDLK_q);
+}
+
 static s32 start(s32 argc, char **argv, const char* folder)
 {
 #if defined(__MACOSX__)
@@ -1894,7 +1908,7 @@ static s32 start(s32 argc, char **argv, const char* folder)
         SDL_Log("Unable to initialize SDL Game Controller: %i, %s\n", result, SDL_GetError());
     }
 
-    platform.studio = studio_create(argc, argv, TIC80_SAMPLERATE, SCREEN_FORMAT, folder, determineMaximumScale());
+    platform.studio = studio_create(argc, argv, TIC80_SAMPLERATE, SCREEN_FORMAT, folder, determineMaximumScale(), is_french_keyboard());
 
     SCOPE(studio_delete(platform.studio))
     {

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1062,22 +1062,22 @@ static void handleKeydown(SDL_Keycode keycode, bool down, bool* state, bool* pre
 #endif
 }
 
-char* detect_keyboard_layout() 
+tic_layout detect_keyboard_layout()
 {
     char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
     char w = SDL_GetKeyFromScancode(SDL_SCANCODE_W);
     char y = SDL_GetKeyFromScancode(SDL_SCANCODE_Y);
 
-    char* layout = "unknown";
+    tic_layout layout = tic_layout_unknown;
 
-    if (q == 'q' && w == 'w' && y == 'y') layout = "qwerty"; // US etc.
-    if (q == 'a' && w == 'z' && y == 'y') layout = "azerty"; // French
-    if (q == 'q' && w == 'w' && y == 'z') layout = "qwertz"; // German etc.
-    if (q == 'q' && w == 'z' && y == 'y') layout = "qzerty"; // Italian
+    if (q == 'q' && w == 'w' && y == 'y') layout = tic_layout_qwerty; // US etc.
+    if (q == 'a' && w == 'z' && y == 'y') layout = tic_layout_azerty; // French
+    if (q == 'q' && w == 'w' && y == 'z') layout = tic_layout_qwertz; // German etc.
+    if (q == 'q' && w == 'z' && y == 'y') layout = tic_layout_qzerty; // Italian
     // Don't ask me why it detects k instead of l
-    if (q == 'x' && w == 'v' && y == 'k') layout = "xvlcwk"; // German Neo 2
+    if (q == 'x' && w == 'v' && y == 'k') layout = tic_layout_de_neo; // xvlcwk - German Neo
     // ...or why it detects p instead of u
-    if (q == 'j' && w == 'd' && y == 'p') layout = "jduaxp"; // German Bone
+    if (q == 'j' && w == 'd' && y == 'p') layout = tic_layout_de_bone; // jduaxp - German Bone
 
     return layout;
 }

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1062,7 +1062,8 @@ static void handleKeydown(SDL_Keycode keycode, bool down, bool* state, bool* pre
 #endif
 }
 
-char* detect_keyboard_layout() {
+char* detect_keyboard_layout() 
+{
     char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
     char w = SDL_GetKeyFromScancode(SDL_SCANCODE_W);
     char y = SDL_GetKeyFromScancode(SDL_SCANCODE_Y);


### PR DESCRIPTION
Fixes https://github.com/nesbox/TIC-80/issues/2520. `alt+[grave]12345` is not triggered if an AZERTY layout is set (the user can still use esc + function keys). This allows AZERTY keyboards to fully (as far as I can tell) work with TIC-80.

There is also some groundwork laid for a potential fix of https://github.com/nesbox/TIC-80/issues/1761 in the future, as well as detecting other layouts; this is more work though and definitely a separate PR. Let me know if you'd rather not have this bit and I can dumb it down to strictly detecting AZERTY.

Tested on MacOS 14, Windows 11 and Linux (EndeavourOS/Arch + Wayland + KDE Plasma 6).

Notes for Linux:
* All SDL2 apps, therefore TIC-80 as well run under Xwayland by default. Keyboard layout change detection will only work if done via `setxkbmap` (or something that calls that). If I change the keyboard from KDE Plasma 6 directly, the layout change itself it is not passed down/detected. There isn't anything we can do about this.
* TIC-80 doesn't work when forced to Wayland (`SDL_VIDEODRIVER=wayland`), only Xwayland. It appears to start and has audio but no window is shown. That's a separate bug to track down. Created #2660.
* alt+1 will insert a `1` for some reason when already on the code tab.  That's a separate bug to track down. Created #2661.