### PR TITLE
Update `sdl-gpu`; unbreak Wayland (partially)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,11 +18,6 @@
 	path = vendor/lua
 	url = https://github.com/lua/lua.git
 	shallow = true
-[submodule "vendor/sdl-gpu"]
-	path = vendor/sdl-gpu
-	url = https://github.com/aliceisjustplaying/sdl-gpu.git
-	shallow = true
-	branch = glew-update
 [submodule "vendor/squirrel"]
 	path = vendor/squirrel
 	url = https://github.com/albertodemichelis/squirrel.git
@@ -91,3 +86,7 @@
 	path = vendor/jsmn
 	url = https://github.com/zserge/jsmn.git
 	shallow = true
+[submodule "vendor/sdl-gpu"]
+	path = vendor/sdl-gpu
+	url = https://github.com/aliceisjustplaying/sdl-gpu.git
+	branch = master


### PR DESCRIPTION
This updates `sdl-gpu` to the `master` branch of my fork which at this point is in sync with upstream except for a minor fix that's needed to compile it on some systems. 

This also unbreaks Wayland (if TIC-80 is launched with `SDL_VIDEODRIVER=wayland` the first place, that is) partially. I'm saying partially because if the user is using scaling, CRT mode will look off as if it wasn't scaled. I have yet to track down the exact source of that issue, but the above is already an improvement.