### PR TITLE
use modulus to loop map

### DIFF
--- a/src/core/draw.c
+++ b/src/core/draw.c
@@ -279,13 +279,12 @@ static void drawMap(tic_core* core, const tic_map* src, s32 x, s32 y, s32 width,
     for (s32 j = y, jj = sy; j < y + height; j++, jj += size)
         for (s32 i = x, ii = sx; i < x + width; i++, ii += size)
         {
-            s32 mi = i;
-            s32 mj = j;
-
-            while (mi < 0) mi += TIC_MAP_WIDTH;
-            while (mj < 0) mj += TIC_MAP_HEIGHT;
-            while (mi >= TIC_MAP_WIDTH) mi -= TIC_MAP_WIDTH;
-            while (mj >= TIC_MAP_HEIGHT) mj -= TIC_MAP_HEIGHT;
+            s32 mi = i % TIC_MAP_WIDTH;
+            if (mi < 0)
+                mi += TIC_MAP_WIDTH;
+            s32 mj = j % TIC_MAP_HEIGHT;
+            if (mj < 0)
+                mj += TIC_MAP_HEIGHT;
 
             s32 index = mi + mj * TIC_MAP_WIDTH;
             RemapResult retile = { *(src->data + index), tic_no_flip, tic_no_rotate };


### PR DESCRIPTION
Large values for map offsets can cause slowdown due to being unwound with increment loops on each tile drawn. This change unwinds the coordinates with modulus instead.