### PR TITLE
Update lua to latest v5.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,7 @@ jobs:
           cd vendor
           git clone --recursive https://github.com/smuehlst/circle-stdlib
           cd circle-stdlib
+          git checkout fdb3c4a948421d47fddab8042a92f980cba43915
           git submodule update --recursive
           ./configure -r 4
           make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,6 @@ jobs:
           cd vendor
           git clone --recursive https://github.com/smuehlst/circle-stdlib
           cd circle-stdlib
-          git checkout fdb3c4a948421d47fddab8042a92f980cba43915
           git submodule update --recursive
           ./configure -r 4
           make -j$(nproc)

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -40,7 +40,6 @@ if(BUILD_WITH_LUA OR BUILD_WITH_MOON OR BUILD_WITH_FENNEL)
         ${LUA_DIR}/lutf8lib.c
         ${LUA_DIR}/loadlib.c
         ${LUA_DIR}/linit.c
-        ${LUA_DIR}/lbitlib.c
     )
 
     add_library(luaapi STATIC


### PR DESCRIPTION
This version of lua improves tic80 performance and is compatible with current carts. Here's a performance comparison:
lua 5.3:
![image](https://github.com/user-attachments/assets/27b92125-5a85-4028-a79f-9d8764dceebe)

lua 5.4:
![image](https://github.com/user-attachments/assets/0b570b82-165f-4841-ab40-6c532f529bf8)

There's also a lua performance comparison in these articles: 
https://eklausmeier.goip.de/blog/2020/05-14-performance-comparison-pallene-vs-lua-5-1-5-2-5-3-5-4-vs-c

https://muxup.com/2023q2/updating-wrens-benchmarks

Lua 5.4 changes: https://lwn.net/Articles/826134/


