### PR TITLE
Add openSUSE instructions and refactor README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ run the following commands in the Terminal
 ```
 sudo pacman -S cmake ruby mesa libglvnd glu
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
-cmake -DBUILD_WITH_ALL=On ..
+cmake -DBUILD_WITH_ALL=On .. && cmake --build . --parallel
 ```
 
 Install with [Install Instructions](#install-instructions)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     - [Arch](#arch)
     - [Fedora 36](#fedora-36)
     - [Fedora 40](#fedora-40)
+    - [openSUSE Tumbleweed / Leap 16.0](#opensuse-tumbleweed--leap-160)
     - [Raspberry Pi OS (64-Bit) (Bookworm)](#raspberry-pi-os-64-bit-bookworm)
     - [Raspberry Pi (Retropie)](#raspberry-pi-retropie)
   - [Mac](#mac)
@@ -260,6 +261,19 @@ sudo dnf -y groupinstall "Development Tools" "Development Libraries"
 sudo dnf -y install ruby-devel rubygem-rake cmake clang pipewire-devel SDL2-devel SDL2_sound-devel SDL2_gfx-devel wayland-devel libXext-devel pipewire-jack-audio-connection-kit-devel pipewire-jack-audio-connection-kit-devel pulseaudio-libs-devel rubygems-devel libdecor-devel libdrm-devel mesa-libgbm-devel esound-devel freeglut-devel
 cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On ..
 cmake --build . --parallel
+```
+
+Install with [Install instructions](#install-instructions)
+
+### openSUSE Tumbleweed / Leap 16.0
+
+Run the following commands from a terminal:
+```
+sudo zypper refresh
+sudo zypper install --no-confirm --type pattern devel_basis
+sudo zypper install --no-confirm cmake glu-devel libXext-devel pipewire-devel libcurl-devel
+git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
+cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On .. && cmake --build . --parallel
 ```
 
 Install with [Install instructions](#install-instructions)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 [![Build Status](https://github.com/nesbox/TIC-80/workflows/Build/badge.svg)](https://github.com/nesbox/TIC-80/actions?query=workflow%3ABuild)
 
 ![TIC-80](https://tic80.com/img/logo64.png)
-**TIC-80 TINY COMPUTER** - [https://tic80.com](https://tic80.com)
+**TIC-80 TINY COMPUTER** — [tic80.com](https://tic80.com)
 
 - [About](#about)
-    - [Features](#features)
+  - [Features](#features)
 - [Binary Downloads](#binary-downloads)
   - [Nightly builds](#nightly-builds)
   - [Unofficial Linux/arm64 nightly builds](#unofficial-linuxarm64-nightly-builds)
 - [Pro Version](#pro-version)
-  - [Pro features](#pro-features)
+  - [Pro Features](#pro-features)
 - [Community](#community)
 - [Contributing](#contributing)
-- [Build instructions](#build-instructions)
+- [Build Instructions](#build-instructions)
   - [Windows](#windows)
     - [MSVC (Microsoft Visual C++)](#msvc-microsoft-visual-c)
       - [Windows XP / Windows 7 32-bit (x86)](#windows-xp--windows-7-32-bit-x86)
@@ -20,21 +20,24 @@
     - [MSYS2 / MINGW](#msys2--mingw)
       - [Windows 10 / 11 64-bit (x64)](#windows-10--11-64-bit-x64-1)
   - [Linux](#linux)
-    - [Ubuntu 22.04 (Jammy Jellyfish)](#ubuntu-2204-jammy-jellyfish)
-    - [Ubuntu 24.04 (Noble Numbat)](#ubuntu-2404-noble-numbat)
+    - [Ubuntu](#ubuntu)
+      - [Ubuntu 22.04 (Jammy Jellyfish)](#ubuntu-2204-jammy-jellyfish)
+      - [Ubuntu 24.04 (Noble Numbat)](#ubuntu-2404-noble-numbat)
     - [Arch](#arch)
-    - [Fedora 36](#fedora-36)
-    - [Fedora 40](#fedora-40)
-    - [openSUSE Tumbleweed / Leap 16.0](#opensuse-tumbleweed--leap-160)
-    - [Raspberry Pi OS (64-Bit) (Bookworm)](#raspberry-pi-os-64-bit-bookworm)
-    - [Raspberry Pi (Retropie)](#raspberry-pi-retropie)
+    - [Fedora](#fedora)
+      - [Fedora 36](#fedora-36)
+      - [Fedora 40](#fedora-40)
+    - [openSUSE](#opensuse)
+      - [openSUSE Tumbleweed / Leap 16.0](#opensuse-tumbleweed--leap-160)
+    - [Raspberry Pi](#raspberry-pi)
+      - [Raspberry Pi OS (64-Bit) (Bookworm)](#raspberry-pi-os-64-bit-bookworm)
+      - [Raspberry Pi (Retropie)](#raspberry-pi-retropie)
   - [Mac](#mac)
   - [FreeBSD](#freebsd)
-- [Install instructions](#install-instructions)
+- [Install Instructions](#install-instructions)
   - [Linux](#linux-1)
   - [iOS / tvOS](#ios--tvos)
   - [Credits](#credits)
-
 
 # About
 TIC-80 is a free and open source fantasy computer for making, playing and sharing tiny games.
@@ -51,12 +54,12 @@ To make a retro styled game, the whole process of creation and execution takes p
 - Multiple programming languages: [Lua](https://www.lua.org),
   [Moonscript](https://moonscript.org),
   [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript),
-  [Ruby](https://www.ruby-lang.org/en/),
-  [Wren](http://wren.io/),
+  [Ruby](https://www.ruby-lang.org/en),
+  [Wren](https://wren.io/),
   [Fennel](https://fennel-lang.org),
-  [Squirrel](http://www.squirrel-lang.org),
+  [Squirrel](https://www.squirrel-lang.org),
   [Janet](https://janet-lang.org), and
-  [Python](https://www.python.org/).
+  [Python](https://www.python.org).
 - Games can have mouse and keyboard as input
 - Games can have up to 4 controllers as input (with up to 8 buttons, each)
 - Built-in editors: for code, sprites, world maps, sound effects and music
@@ -64,37 +67,38 @@ To make a retro styled game, the whole process of creation and execution takes p
 - Moderated community
 
 # Binary Downloads
-You can download compiled versions for the major operating systems directly from our [releases page](https://github.com/nesbox/TIC-80/releases).
 
-## Nightly builds
-Can be downloaded from [nightly builds](https://nightly.link/nesbox/TIC-80/workflows/build/main) page or from the [Github Actions](https://github.com/nesbox/TIC-80/actions?query=branch%3Amain) page.
+## Stable Builds
+You can download compiled versions for the major operating systems directly from our [Releases](https://github.com/nesbox/TIC-80/releases) page.
 
-## Unofficial Linux/arm64 nightly builds
-Can be downloaded from [this nightly.link](https://nightly.link/aliceisjustplaying/TIC-80/workflows/build-linux-arm64/main?preview) page. Tested on Raspberry Pi OS (64-bit) (Bookworm), Asahi Linux (Fedora Remix), Ubuntu 22.04 and Fedora 40.
+## Nightly Builds
+Can be downloaded from official [nightly.link](https://nightly.link/nesbox/TIC-80/workflows/build/main) page or from the [Github Actions](https://github.com/nesbox/TIC-80/actions?query=branch%3Amain) page.
+
+## Unofficial Builds
+Linux (arm64) builds can be downloaded from _aliceisjustplaying_ [nightly.link](https://nightly.link/aliceisjustplaying/TIC-80/workflows/build-linux-arm64/main?preview) page. Tested on Raspberry Pi OS (64-bit) (Bookworm), Asahi Linux (Fedora Remix), Ubuntu 22.04 and Fedora 40.
 
 # Pro Version
 To help support TIC-80 development, we have a [PRO Version](https://nesbox.itch.io/tic80).
 
-This version has a few additional features and binaries can only be downloaded on our Itch.io page.
+This version has a few additional features and binaries can only be downloaded on our itch.io page.
 
-For users who can't spend the money, we made it easy to build the pro version from the source code: (`cmake .. -DBUILD_PRO=On`)
+For users who can't afford the program can easily build the pro version from the source code using `cmake .. -DBUILD_PRO=On` command.
 
-## Pro features
-
+## Pro Features
 - Save/load cartridges in text format, and create your game in any editor you want, also useful for version control systems.
 - Even more memory banks: instead of having only 1 memory bank you have 8.
 - Export your game without editors, and then publish it to app stores.
 
 # Community
-You can play and share games, tools and music at [https://tic80.com/play](https://tic80.com/play).
+You can play and share games, tools and music at [tic80.com/play](https://tic80.com/play).
 
 The community also hangs out and discusses on [Telegram](https://t.me/tic80) or [Discord](https://discord.gg/HwZDw7n4dN).
 
 # Contributing
-You can contribute by reporting a bug or requesting a new feature on our [issues page](https://github.com/nesbox/TIC-80/issues).
+You can contribute by reporting a bug or requesting a new feature on our [Issues](https://github.com/nesbox/TIC-80/issues) page.
 Keep in mind when engaging on a discussion to follow our [Code of Conduct](https://github.com/nesbox/TIC-80/blob/main/CODE_OF_CONDUCT.md).
 
-You can also contribute by reviewing or improving our [wiki](https://github.com/nesbox/TIC-80/wiki).
+You can also contribute by reviewing or improving our [Wiki](https://github.com/nesbox/TIC-80/wiki).
 The wiki holds TIC-80 documentation, code snippets and game development tutorials.
 
 # Build instructions
@@ -104,10 +108,9 @@ The wiki holds TIC-80 documentation, code snippets and game development tutorial
 ### MSVC (Microsoft Visual C++)
 
 #### Windows XP / Windows 7 32-bit (x86)
-
 The build process has been tested on Windows 11 64-bit (x64); all this should run on Windows 7 SP1 32-bit (x86) as well. This guide assumes you're running an elevated Command Prompt.
 
-- Install [Git](https://git-scm.com/download/win), [CMake](https://cmake.org/download/), [Visual Studio 2019 Build Tools](https://winstall.app/apps/Microsoft.VisualStudio.2019.BuildTools) and [Ruby+Devkit 2.7.8 x86](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.8-1/rubyinstaller-devkit-2.7.8-1-x86.exe)
+- Install [Git](https://git-scm.com/download/win), [CMake](https://cmake.org/download), [Visual Studio 2019 Build Tools](https://winstall.app/apps/Microsoft.VisualStudio.2019.BuildTools) and [Ruby+Devkit 2.7.8 x86](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.8-1/rubyinstaller-devkit-2.7.8-1-x86.exe)
 - Install the neccessary dependencies within VS2019:
   - Launch "Visual Studio Installer"
   - Click "Modify"
@@ -118,8 +121,8 @@ The build process has been tested on Windows 11 64-bit (x64); all this should ru
     - C++ Windows XP Support for VS 2017 (v141) tools [Deprecated]
     - MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16)
   - Click "Modify"
-- Run `ridk install` with options `1,3` to set up [MSYS2](https://www.msys2.org/) and development toolchain
-- Add MSYS2's [`gcc`](https://gcc.gnu.org/) at `C:\Ruby27\msys32\mingw32\bin` to your `$PATH` [(guide)](https://www.java.com/en/download/help/path.html#:~:text=your%20java%20code.-,Windows%207,-From%20the%20desktop)
+- Run `ridk install` with options `1,3` to set up [MSYS2](https://www.msys2.org) and development toolchain
+- Add MSYS2's [`gcc`](https://gcc.gnu.org) at `C:\Ruby27\msys32\mingw32\bin` to your `$PATH` [(guide)](https://www.java.com/en/download/help/path.html#:~:text=your%20java%20code.-,Windows%207,-From%20the%20desktop)
 
 - Open a new elevated Command Prompt and run the following commands:
 
@@ -133,10 +136,9 @@ cmake --build . --parallel
 You'll find `tic80.exe` in `TIC-80\build\bin`.
 
 #### Windows 10 / 11 64-bit (x64)
-
 This guide assumes you're running PowerShell with an elevated prompt.
 
-- Install [Git](https://git-scm.com/download/win), [CMake](https://cmake.org/download/), [Visual Studio 2019 Build Tools](https://winstall.app/apps/Microsoft.VisualStudio.2019.BuildTools) and [Ruby+Devkit 2.7.8 x64](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.8-1/rubyinstaller-devkit-2.7.8-1-x64.exe) manually or with [WinGet](https://github.com/microsoft/winget-cli):
+- Install [Git](https://git-scm.com/download/win), [CMake](https://cmake.org/download), [Visual Studio 2019 Build Tools](https://winstall.app/apps/Microsoft.VisualStudio.2019.BuildTools) and [Ruby+Devkit 2.7.8 x64](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.8-1/rubyinstaller-devkit-2.7.8-1-x64.exe) manually or with [WinGet](https://github.com/microsoft/winget-cli):
 ```
 winget install Git.Git Kitware.CMake Microsoft.VisualStudio.2019.BuildTools RubyInstallerTeam.RubyWithDevKit.2.7
 ```
@@ -148,8 +150,8 @@ winget install Git.Git Kitware.CMake Microsoft.VisualStudio.2019.BuildTools Ruby
     - Windows 10 SDK (10.0.19041.0)
     - MSVC v142 - VS 2019 C+ + x64/x86 build tools (Latest)
   - Click "Modify"
-- Run `ridk install` with options `1,3` to set up [MSYS2](https://www.msys2.org/) and development toolchain
-- Add MSYS2's [`gcc`](https://gcc.gnu.org/) at `C:\Ruby27-x64\msys64\mingw64\bin` to your `$PATH` [manually](https://www.java.com/en/download/help/path.html#:~:text=Mac%20OS%20X.-,Windows,-Windows%2010%20and) or with the following PowerShell command:
+- Run `ridk install` with options `1,3` to set up [MSYS2](https://www.msys2.org) and development toolchain
+- Add MSYS2's [`gcc`](https://gcc.gnu.org) at `C:\Ruby27-x64\msys64\mingw64\bin` to your `$PATH` [manually](https://www.java.com/en/download/help/path.html#:~:text=Mac%20OS%20X.-,Windows,-Windows%2010%20and) or with the following PowerShell command:
 
 ```
 [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\Ruby27-x64\msys64\mingw64\bin', [EnvironmentVariableTarget]::Machine)
@@ -168,15 +170,14 @@ You'll find `tic80.exe` in `TIC-80\build\bin`.
 ### MSYS2 / MINGW
 
 #### Windows 10 / 11 64-bit (x64)
-
 This guide assumes you're running PowerShell with an elevated prompt.
 
-- Install [Git](https://git-scm.com/download/win), [CMake](https://cmake.org/download/) and [Ruby+Devkit 2.7.8 x64](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.8-1/rubyinstaller-devkit-2.7.8-1-x64.exe) manually or with [WinGet](https://github.com/microsoft/winget-cli):
+- Install [Git](https://git-scm.com/download/win), [CMake](https://cmake.org/download) and [Ruby+Devkit 2.7.8 x64](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.8-1/rubyinstaller-devkit-2.7.8-1-x64.exe) manually or with [WinGet](https://github.com/microsoft/winget-cli):
 ```
 winget install Git.Git Kitware.CMake RubyInstallerTeam.RubyWithDevKit.2.7
 ```
-- Run `ridk install` with options `1,3` to set up [MSYS2](https://www.msys2.org/) and development toolchain
-- Add MSYS2's [`gcc`](https://gcc.gnu.org/) at `C:\Ruby27-x64\msys64\mingw64\bin` to your `$PATH` [manually](https://www.java.com/en/download/help/path.html#:~:text=Mac%20OS%20X.-,Windows,-Windows%2010%20and) or with the following PowerShell command:
+- Run `ridk install` with options `1,3` to set up [MSYS2](https://www.msys2.org) and development toolchain
+- Add MSYS2's [`gcc`](https://gcc.gnu.org) at `C:\Ruby27-x64\msys64\mingw64\bin` to your `$PATH` [manually](https://www.java.com/en/download/help/path.html#:~:text=Mac%20OS%20X.-,Windows,-Windows%2010%20and) or with the following PowerShell command:
 
 ```
 [Environment]::SetEnvironmentVariable('Path', $env:Path + ';C:\Ruby27-x64\msys64\mingw64\bin', [EnvironmentVariableTarget]::Machine)
@@ -195,12 +196,13 @@ You'll find `tic80.exe` in `TIC-80\build\bin`.
 
 ## Linux
 
-### Ubuntu 22.04 (Jammy Jellyfish)
+### Ubuntu
 
+#### Ubuntu 22.04 (Jammy Jellyfish)
 Run the following commands from a terminal:
 
 ```
-# Install the latest CMake from https://apt.kitware.com/
+# Install the latest CMake from https://apt.kitware.com
 test -f /usr/share/doc/kitware-archive-keyring/copyright ||
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
@@ -214,11 +216,9 @@ git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On .. && cmake --build . --parallel
 ```
 
-Install with [Install instructions](#install-instructions)
+Install with [Install Instructions](#install-instructions)
 
-
-### Ubuntu 24.04 (Noble Numbat)
-
+#### Ubuntu 24.04 (Noble Numbat)
 Run the following commands from a terminal:
 
 ```
@@ -227,34 +227,32 @@ git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On .. && cmake --build . --parallel
 ```
 
-Install with [Install instructions](#install-instructions)
-
+Install with [Install Instructions](#install-instructions)
 
 ### Arch
-
 run the following commands in the Terminal
 ```
 sudo pacman -S cmake ruby mesa libglvnd glu
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_WITH_ALL=On ..
-make -j4
 ```
 
-### Fedora 36
+Install with [Install Instructions](#install-instructions)
 
+### Fedora
+
+#### Fedora 36
 run the following commands in the Terminal
 ```
 sudo dnf -y groupinstall "Development Tools" "Development Libraries"
 sudo dnf -y install ruby rubygem-{tk{,-doc},rake,test-unit} cmake libglvnd-devel libglvnd-gles freeglut-devel clang libXext-devel SDL_sound pipewire-devel pipewire-jack-audio-connection-kit-devel pulseaudio-libs-devel
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DCMAKE_CXX_COMPILER=clang++ -DSDL_ALSA=On -DBUILD_WITH_ALL=On ..
-make -j4
 ```
 
-Install with [Install instructions](#install-instructions)
+Install with [Install Instructions](#install-instructions)
 
-### Fedora 40
-
+#### Fedora 40
 Run the following commands from a terminal:
 ```
 sudo dnf -y groupinstall "Development Tools" "Development Libraries"
@@ -263,10 +261,11 @@ cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On ..
 cmake --build . --parallel
 ```
 
-Install with [Install instructions](#install-instructions)
+Install with [Install Instructions](#install-instructions)
 
-### openSUSE Tumbleweed / Leap 16.0
+### openSUSE
 
+#### openSUSE Tumbleweed / Leap 16.0
 Run the following commands from a terminal:
 ```
 sudo zypper refresh
@@ -276,10 +275,11 @@ git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On .. && cmake --build . --parallel
 ```
 
-Install with [Install instructions](#install-instructions)
+Install with [Install Instructions](#install-instructions)
 
-### Raspberry Pi OS (64-Bit) (Bookworm)
+### Raspberry Pi
 
+#### Raspberry Pi OS (64-Bit) (Bookworm)
 Run the following commands from a terminal:
 
 ```
@@ -287,10 +287,10 @@ sudo apt update && sudo apt -y install cmake libpipewire-0.3-dev libwayland-dev 
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=On .. && cmake --build . --parallel 2
 ```
-Install with [Install instructions](#install-instructions)
 
-### Raspberry Pi (Retropie)
+Install with [Install Instructions](#install-instructions)
 
+#### Raspberry Pi (Retropie)
 First, add jessie-backports repo to your `/etc/apt/sources.list`
 
 `deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main`
@@ -313,7 +313,6 @@ sudo apt-get install git build-essential ruby-full libsdl2-dev zlib1g-dev
 sudo apt-get install -t jessie-backports liblua5.3-dev
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_WITH_ALL=On ..
-make -j4
 
 # install software ubuntu 22.04.3 LTS
 sudo apt-get install git build-essential ruby-full libsdl2-dev zlib1g-dev
@@ -321,9 +320,9 @@ sudo apt-get install liblua5.3-dev
 sudo apt-get install libcurl4-openssl-dev
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
 cmake -DBUILD_WITH_ALL=On ..
-make -j4
 ```
-Install with [Install instructions](#install-instructions)
+
+Install with [Install Instructions](#install-instructions)
 
 _Note:_ If you are using a normal Raspberry Pi image (not Retropie) you may not
 have OpenGL drivers enabled. Run `sudo raspi-config`, then select 7
@@ -373,9 +372,11 @@ sudo ln -s /usr/local/lib/dri/swrast_dri.so /usr/local/lib/dri-devel/
 # Install instructions
 
 ## Linux
-To install run `sudo make install -j4`
+- To make an executable file `./tic80` without installation run `make` and locate the output in `TIC-80/build/bin`.
+- To install system-wide run `sudo make install`
+- You can append `-j4` if you have a modern system, or `-j2` for a Raspberry Pi to speed up the process.
 
-TIC-80 can now be run with `tic80`
+TIC-80 can now be run with `tic80` (if installed) or `./tic80` (with no installation).
 
 ## iOS / tvOS
 You can find iOS/tvOS version here
@@ -383,37 +384,36 @@ You can find iOS/tvOS version here
 - 0.45.0: https://github.com/CliffsDover/TIC-80
 
 ## Credits
-
-* Filippo Rivato - [Twitter @HomineLudens](https://twitter.com/HomineLudens)
-* Fred Bednarski - [Twitter @FredBednarski](https://twitter.com/FredBednarski)
-* Al Rado - [Twitter @alrado2](https://twitter.com/alrado2)
-* Trevor Martin - [Twitter @trelemar](https://twitter.com/trelemar)
-* MonstersGoBoom - [Twitter @MonstersGoBoom](https://twitter.com/MonstersGo)
-* Matheus Lessa - [Twitter @matheuslrod](https://twitter.com/matheuslrod)
-* CliffsDover - [Twitter @DancingBottle](https://twitter.com/DancingBottle)
-* Frantisek Jahoda - [GitHub @jahodfra](https://github.com/jahodfra)
-* Guilherme Medeiros - [GitHub @frenetic](https://github.com/frenetic)
-* Andrei Rudenko - [GitHub @RudenkoArts](https://github.com/RudenkoArts)
-* Phil Hagelberg - [@technomancy](https://technomancy.us/colophon)
-* Rob Loach - [Twitter @RobLoach](https://twitter.com/RobLoach) [GitHub @RobLoach](https://github.com/RobLoach)
-* Wade Brainerd - [GitHub @wadetb](https://github.com/wadetb)
-* Paul Robinson - [GitHub @paul59](https://github.com/paul59)
-* Stefan Devai - [GitHub @stefandevai](https://github.com/stefandevai) [Blog stefandevai.me](https://stefandevai.me)
-* Damien de Lemeny - [GitHub @ddelemeny](https://github.com/ddelemeny)
-* Adrian Siekierka - [GitHub @asiekierka](https://github.com/asiekierka) [Website](https://asie.pl/)
-* Jay Em (Sweetie16 palette) - [Twitter @GrafxKid](https://twitter.com/GrafxKid)
-* msx80 - [Twitter @msx80](https://twitter.com/msx80) [Github msx80](https://github.com/msx80)
-* Josh Goebel - [Twitter @dreamer3](https://twitter.com/dreamer3) [Github joshgoebel](https://github.com/joshgoebel)
-* Joshua Minor - [GitHub @jminor](https://github.com/jminor)
-* Julia Nelz - [Github @remi6397](https://github.com/remi6397) [WWW](https://nelz.pl)
-* Thorben Krüger - [Mastodon @benthor@chaos.social](https://chaos.social/@benthor)
-* David St-Hilaire - [GitHub @sthilaid](https://github.com/sthilaid)
-* Alec Troemel - [Github @alectroemel](https://github.com/AlecTroemel)
-* Kolten Pearson - [Github @koltenpearson](https://github.com/koltenpearson)
-* Cort Stratton - [Github @cdwfs](https://github.com/cdwfs)
-* Alice - [Github @aliceisjustplaying](https://github.com/aliceisjustplaying)
-* Sven Knebel - [Github @sknebel](https://github.com/sknebel)
-* Graham Bates - [Github @grahambates](https://github.com/grahambates)
-* Kii - [Github @kiikrindar](https://github.com/kiikrindar)
-* Matt Westcott - [Github @gasman](https://github.com/gasman)
-* NuSan - [Github @TheNuSan](https://github.com/thenusan)
+* Filippo Rivato — [Twitter @HomineLudens](https://twitter.com/HomineLudens)
+* Fred Bednarski — [Twitter @FredBednarski](https://twitter.com/FredBednarski)
+* Al Rado — [Twitter @alrado2](https://twitter.com/alrado2)
+* Trevor Martin — [Twitter @trelemar](https://twitter.com/trelemar)
+* MonstersGoBoom — [Twitter @MonstersGoBoom](https://twitter.com/MonstersGo)
+* Matheus Lessa — [Twitter @matheuslrod](https://twitter.com/matheuslrod)
+* CliffsDover — [Twitter @DancingBottle](https://twitter.com/DancingBottle)
+* Frantisek Jahoda — [GitHub @jahodfra](https://github.com/jahodfra)
+* Guilherme Medeiros — [GitHub @frenetic](https://github.com/frenetic)
+* Andrei Rudenko — [GitHub @RudenkoArts](https://github.com/RudenkoArts)
+* Phil Hagelberg — [@technomancy](https://technomancy.us/colophon)
+* Rob Loach — [Twitter @RobLoach](https://twitter.com/RobLoach) [GitHub @RobLoach](https://github.com/RobLoach)
+* Wade Brainerd — [GitHub @wadetb](https://github.com/wadetb)
+* Paul Robinson — [GitHub @paul59](https://github.com/paul59)
+* Stefan Devai — [GitHub @stefandevai](https://github.com/stefandevai) [Blog stefandevai.me](https://stefandevai.me)
+* Damien de Lemeny — [GitHub @ddelemeny](https://github.com/ddelemeny)
+* Adrian Siekierka — [GitHub @asiekierka](https://github.com/asiekierka) [Website](https://asie.pl/)
+* Jay Em (Sweetie16 palette) — [Twitter @GrafxKid](https://twitter.com/GrafxKid)
+* msx80 — [Twitter @msx80](https://twitter.com/msx80) [Github msx80](https://github.com/msx80)
+* Josh Goebel — [Twitter @dreamer3](https://twitter.com/dreamer3) [Github joshgoebel](https://github.com/joshgoebel)
+* Joshua Minor — [GitHub @jminor](https://github.com/jminor)
+* Julia Nelz — [Github @remi6397](https://github.com/remi6397) [WWW](https://nelz.pl)
+* Thorben Krüger — [Mastodon @benthor@chaos.social](https://chaos.social/@benthor)
+* David St—Hilaire — [GitHub @sthilaid](https://github.com/sthilaid)
+* Alec Troemel — [Github @alectroemel](https://github.com/AlecTroemel)
+* Kolten Pearson — [Github @koltenpearson](https://github.com/koltenpearson)
+* Cort Stratton — [Github @cdwfs](https://github.com/cdwfs)
+* Alice — [Github @aliceisjustplaying](https://github.com/aliceisjustplaying)
+* Sven Knebel — [Github @sknebel](https://github.com/sknebel)
+* Graham Bates — [Github @grahambates](https://github.com/grahambates)
+* Kii — [Github @kiikrindar](https://github.com/kiikrindar)
+* Matt Westcott — [Github @gasman](https://github.com/gasman)
+* NuSan — [Github @TheNuSan](https://github.com/thenusan)


### PR DESCRIPTION
This pull request closes #2711 and also refactors the _README_ file according to these changes:

- Fixed uneven spacing and indentation
- Updated hyphens to em dashes where applicable
- Capitalized titles
- Removed `https://` from link titles
- Updated the headers structure and table of contents
- Updated _Install Instructions_ to include a no-installation method