### PR TITLE
Swap LUA_COMPAT_5_2 for LUA_COMPAT_5_3, since we're in Lua 5.4 now

### DIFF
--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -48,7 +48,7 @@ if(BUILD_WITH_LUA OR BUILD_WITH_MOON OR BUILD_WITH_FENNEL)
         ${CMAKE_SOURCE_DIR}/src/api/parse_note.c
     )
 
-    target_compile_definitions(luaapi PRIVATE LUA_COMPAT_5_2)
+    target_compile_definitions(luaapi PRIVATE LUA_COMPAT_5_3)
 
     target_include_directories(luaapi
         PUBLIC ${THIRDPARTY_DIR}/lua


### PR DESCRIPTION
This, among other things, fixes the `math.atan2` incompatibility that's been reported on the Discord. Notable imcompatibilities that will be harder to fix:

- `bit32` lib is gone
- `__ipairs` metamethod is completely gone