### PR TITLE
updated pkpy to v2.0.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -89,3 +89,4 @@
 [submodule "vendor/pocketpy"]
 	path = vendor/pocketpy
 	url = https://github.com/PrimedErwin/pocketpy.git
+	shallow = true

--- a/cmake/pocketpy.cmake
+++ b/cmake/pocketpy.cmake
@@ -9,6 +9,7 @@ if(BUILD_WITH_PYTHON)
 
     if(NOT WIN32)
         option(PK_BUILD_WITH_IPO "" OFF)
+        option(PK_BUILD_MODULE_LZ4 "" OFF)
     endif()
 
     add_subdirectory(${THIRDPARTY_DIR}/pocketpy)

--- a/cmake/pocketpy.cmake
+++ b/cmake/pocketpy.cmake
@@ -6,10 +6,10 @@ option(BUILD_WITH_PYTHON "Python Enabled" ${BUILD_WITH_ALL})
 message("BUILD_WITH_PYTHON: ${BUILD_WITH_PYTHON}")
 if(BUILD_WITH_PYTHON)
     option(PK_ENABLE_OS "" OFF)
+    option(PK_BUILD_MODULE_LZ4 "" OFF)
 
     if(NOT WIN32)
         option(PK_BUILD_WITH_IPO "" OFF)
-        option(PK_BUILD_MODULE_LZ4 "" OFF)
     endif()
 
     add_subdirectory(${THIRDPARTY_DIR}/pocketpy)

--- a/src/api/python.c
+++ b/src/api/python.c
@@ -136,6 +136,7 @@ static bool py_cls(int argc, py_Ref argv)
 
     color = py_toint(py_arg(0));
     core->api.cls(tic, color);
+    py_assign(py_retval(), py_None());
     return true;
 }
 
@@ -172,6 +173,7 @@ static bool py_spr(int argc, py_Ref argv)
         return TypeError("The given argument is not int or list");
 
     core->api.spr(tic, spr_id, x, y, w, h, colors, color_count, scale, flip, rotate);
+    py_assign(py_retval(), py_None());
     return true;
 }
 


### PR DESCRIPTION
The previous pr is https://github.com/nesbox/TIC-80/pull/2714 (1 month ago)

# What's changed from v2.0.1 to v2.0.4

### v2.0.2

1. Fix a bug of `random` module which uses a wrong initial seed.
2. Fix [#315](https://github.com/pocketpy/pocketpy/issues/315) about `py_switchvm`.
3. Improve `PK_ENABLE_OS` and add `PK_BUILD_WITH_IPO` to cmake options.
4. Add `conio` module which provides `_kbhit` and `_getch` functions for desktop platforms.
5. Fix `True not False` bug of parser.
6. Fix `**` associativity bug. `2**2**3` now evaluates to 256 instead of 64.
7. Add `__float__` and `__int__` and `__round__`.
8. Add `py_bindstaticmethod`.
9. Fix `str.split`. It behaves the same as cpython now.
10. Fix a bug of closure for generator functions.
11. Support `vec*` unpack, e.g. `x, y = vec2i(1, 2)`.

### v2.0.3

1. fix some type annotation usage e.g. `int | None`.
2. fix some builtins hash functions
3. fix a severe bug of `dict`
4. clean up `#defines`
5. improve `array2d`
6. fix a bug of `super`
7. fix a bug of context manager

### v2.0.4

1. add `pickle` module
2. raise error on mismatched eq/ne
3. fix a bug of 32-bit
4. support empty tuple `()`
5. improve `json`

**Full Changelog**: https://github.com/pocketpy/pocketpy/compare/v2.0.1...v2.0.4