### PR TITLE
Lua API: Explicitly zero local array

### DIFF
--- a/src/api/luaapi.c
+++ b/src/api/luaapi.c
@@ -576,7 +576,7 @@ static s32 lua_ttri(lua_State* lua)
             }
         }
 
-        float z[3];
+        float z[3] = {0, 0, 0};
         bool depth = false;
 
         if(top == 17)


### PR DESCRIPTION
Cherry-picked https://github.com/TASEmulators/BizHawk/commit/87a740d09a9f1284dd8ff9bbf3e9dddec9653693. The uninit read caused problems when compiled under our toolchain with `-O2`, see https://github.com/TASEmulators/BizHawk/issues/4190.