### PR TITLE
Fix OPT_END() missing without BUILD_EDITORS flag

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -2622,8 +2622,8 @@ static StartArgs parseArgs(s32 argc, char **argv)
         OPT_BOOLEAN('\0', "fftlist", &args.fftlist, "list FFT devices"),
         OPT_BOOLEAN('\0', "fftcaptureplaybackdevices", &args.fftcaptureplaybackdevices, "Capture playback devices for loopback (Windows only)"),
         OPT_STRING('\0', "fftdevice", &args.fftdevice, "name of the device to use with FFT"),
-        OPT_END(),
 #endif
+        OPT_END(),
     };
 
     struct argparse argparse;


### PR DESCRIPTION
I built TIC-80 from source, with `BUILD_EDITORS` turned off. When I launched it, I noticed that there are 'wrong option type' warnings from argparse. After a little debugging, I found that `OPT_END` in the option list was under an `#ifdef`. So when I was building without editors, the list was unterminated.

I fixed this by moving `OPT_END` out of the `#ifdef`.