### PR TITLE
Allow build with system libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13)
 
 include(cmake/version.cmake)
 
@@ -49,6 +49,8 @@ option(BUILD_NO_OPTIMIZATION "Build without optimizations for debugging" OFF)
 option(BUILD_ASAN_DEBUG "Build with AddressSanitizer" OFF)
 option(BUILD_WITH_ZLIB "Build with zlib linked" ON)
 option(TIC80_TARGET "Target binary suffix")
+option(PREFER_SYSTEM_LIBRARIES "Prefer link with system libraries" OFF)
+
 
 if(NOT TIC80_TARGET)
     set(TIC80_TARGET tic80)
@@ -69,6 +71,7 @@ endif()
 
 target_compile_definitions(runtime INTERFACE BUILD_DEPRECATED)
 
+message("PREFER_SYSTEM_LIBRARIES: ${PREFER_SYSTEM_LIBRARIES}")
 message("BUILD_STATIC: ${BUILD_STATIC}")
 message("BUILD_SDLGPU: ${BUILD_SDLGPU}")
 message("BUILD_TOUCH_INPUT: ${BUILD_TOUCH_INPUT}")

--- a/cmake/argparse.cmake
+++ b/cmake/argparse.cmake
@@ -2,5 +2,21 @@
 # ArgParse lib
 ################################
 
+if(PREFER_SYSTEM_LIBRARIES)
+    find_path(argparse_INCLUDE_DIR NAMES argparse.h)
+    find_library(argparse_LIBRARY NAMES argparse)
+    if(argparse_INCLUDE_DIR AND argparse_LIBRARY)
+        add_library(argparse UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(argparse PROPERTIES
+            IMPORTED_LOCATION "${argparse_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${argparse_INCLUDE_DIR}"
+        )
+        message(STATUS "Use system library: argparse")
+        return()
+    else()
+        message(WARNING "System library argparse not found")
+    endif()
+endif()
+
 add_library(argparse STATIC ${THIRDPARTY_DIR}/argparse/argparse.c)
 target_include_directories(argparse INTERFACE ${THIRDPARTY_DIR}/argparse)

--- a/cmake/gif.cmake
+++ b/cmake/gif.cmake
@@ -2,6 +2,22 @@
 # GIFLIB
 ################################
 
+if(PREFER_SYSTEM_LIBRARIES)
+    find_path(giflib_INCLUDE_DIR NAMES gif_lib.h)
+    find_library(giflib_LIBRARY NAMES gif)
+    if(giflib_INCLUDE_DIR AND giflib_LIBRARY)
+        add_library(giflib UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(giflib PROPERTIES
+            IMPORTED_LOCATION "${giflib_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${giflib_INCLUDE_DIR};${THIRDPARTY_DIR}/msf_gif"
+        )
+        message(STATUS "Use system library: giflib")
+        return()
+    else()
+        message(WARNING "System library giflib not found")
+    endif()
+endif()
+
 set(GIFLIB_DIR ${THIRDPARTY_DIR}/giflib)
 set(GIFLIB_SRC
     ${GIFLIB_DIR}/dgif_lib.c

--- a/cmake/janet.cmake
+++ b/cmake/janet.cmake
@@ -5,6 +5,29 @@
 option(BUILD_WITH_JANET "Janet Enabled" ${BUILD_WITH_ALL})
 message("BUILD_WITH_JANET: ${BUILD_WITH_JANET}")
 
+if(BUILD_WITH_JANET AND PREFER_SYSTEM_LIBRARIES)
+    find_path(janet_INCLUDE_DIR NAMES janet.h)
+    find_library(janet_LIBRARY NAMES janet)
+    if(janet_INCLUDE_DIR AND janet_LIBRARY)
+        add_library(janet STATIC
+            ${CMAKE_SOURCE_DIR}/src/api/janet.c
+            ${CMAKE_SOURCE_DIR}/src/api/parse_note.c
+        )
+        target_compile_definitions(janet INTERFACE TIC_BUILD_WITH_JANET)
+        target_link_libraries(janet PRIVATE runtime ${janet_LIBRARY})
+        target_include_directories(janet
+            PUBLIC ${janet_INCLUDE_DIR}
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_SOURCE_DIR}/src
+        )
+        message(STATUS "Use sytem library: janet")
+        return()
+    else()
+        message(WARNING "System library janet not found")
+    endif()
+endif()
+
 if(BUILD_WITH_JANET)
 
     if(MINGW)

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -5,6 +5,30 @@
 option(BUILD_WITH_LUA "Lua Enabled" ON)
 message("BUILD_WITH_LUA: ${BUILD_WITH_LUA}")
 
+if(BUILD_WITH_LUA AND PREFER_SYSTEM_LIBRARIES)
+    find_path(lua_INCLUDE_DIR NAMES lua.h)
+    find_library(lua_LIBRARY NAMES lua)
+    if(lua_INCLUDE_DIR AND lua_LIBRARY)
+        add_library(luaapi STATIC
+            ${CMAKE_SOURCE_DIR}/src/api/luaapi.c
+            ${CMAKE_SOURCE_DIR}/src/api/parse_note.c
+        )
+        target_link_libraries(luaapi PRIVATE ${lua_LIBRARY})
+        target_include_directories(luaapi PUBLIC
+            ${lua_INCLUDE_DIR}
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src
+        )
+        add_library(lua STATIC ${CMAKE_SOURCE_DIR}/src/api/lua.c)
+        target_compile_definitions(lua INTERFACE TIC_BUILD_WITH_LUA)
+        target_link_libraries(lua PRIVATE runtime luaapi)
+        message(STATUS "Use system library: lua")
+        return()
+    else()
+        message(WARNING "System library lua not found")
+    endif()
+endif()
+
 if(BUILD_WITH_LUA OR BUILD_WITH_MOON OR BUILD_WITH_FENNEL)
     set(LUA_DIR ${THIRDPARTY_DIR}/lua)
     set(LUA_SRC

--- a/cmake/mruby.cmake
+++ b/cmake/mruby.cmake
@@ -5,6 +5,29 @@
 option(BUILD_WITH_RUBY "Ruby Enabled" ${BUILD_WITH_ALL})
 message("BUILD_WITH_RUBY: ${BUILD_WITH_RUBY}")
 
+if(BUILD_WITH_RUBY AND PREFER_SYSTEM_LIBRARIES)
+    find_path(mruby_INCLUDE_DIR NAMES mruby.h)
+    find_library(mruby_LIBRARY NAMES mruby)
+    if(mruby_INCLUDE_DIR AND mruby_LIBRARY)
+        add_library(ruby STATIC
+            ${CMAKE_SOURCE_DIR}/src/api/mruby.c
+            ${CMAKE_SOURCE_DIR}/src/api/parse_note.c
+        )
+        target_compile_definitions(ruby INTERFACE TIC_BUILD_WITH_RUBY)
+        target_link_libraries(ruby PRIVATE runtime ${mruby_LIBRARY})
+        target_include_directories(ruby
+            PUBLIC ${mruby_INCLUDE_DIR}
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_SOURCE_DIR}/src
+        )
+        message(STATUS "Use sytem library: mruby")
+        return()
+    else()
+        message(WARNING "System library mruby not found")
+    endif()
+endif()
+
 if(BUILD_WITH_RUBY)
 
     find_program(RUBY ruby)

--- a/cmake/naett.cmake
+++ b/cmake/naett.cmake
@@ -14,6 +14,23 @@ if(LINUX)
     endif()
 endif()
 
+if(PREFER_SYSTEM_LIBRARIES)
+    find_path(naett_INCLUDE_DIR NAMES naett.h)
+    find_library(naett_LIBRARY NAMES naett)
+    if(naett_INCLUDE_DIR AND naett_LIBRARY)
+        add_library(naett UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(naett PROPERTIES
+            IMPORTED_LOCATION "${naett_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${naett_INCLUDE_DIR}"
+        )
+        message(STATUS "Use system library: naett")
+        set(USE_NAETT TRUE)
+        return()
+    else()
+        message(WARNING "System library naett not found")
+    endif()
+endif()
+
 if(USE_NAETT)
     add_library(naett STATIC ${THIRDPARTY_DIR}/naett/naett.c)
     target_include_directories(naett PUBLIC ${THIRDPARTY_DIR}/naett)

--- a/cmake/png.cmake
+++ b/cmake/png.cmake
@@ -2,6 +2,19 @@
 # PNG
 ################################
 
+if(PREFER_SYSTEM_LIBRARIES)
+    find_package(PkgConfig)
+    pkg_check_modules(libpng IMPORTED_TARGET GLOBAL libpng)
+    if (libpng_FOUND)
+        add_library(png ALIAS PkgConfig::libpng)
+        message(STATUS "Use system library: libpng")
+        return()
+    else()
+        message(WARNING "System library libpng not found")
+    endif()
+endif()
+
+
 set(LIBPNG_DIR ${THIRDPARTY_DIR}/libpng)
 set(LIBPNG_SRC
     ${LIBPNG_DIR}/png.c

--- a/cmake/quickjs.cmake
+++ b/cmake/quickjs.cmake
@@ -5,6 +5,29 @@
 option(BUILD_WITH_JS "JS Enabled" ${BUILD_WITH_ALL})
 message("BUILD_WITH_JS: ${BUILD_WITH_JS}")
 
+if(BUILD_WITH_JS AND PREFER_SYSTEM_LIBRARIES)
+    find_path(quickjs_INLCUDE_DIR NAMES quickjs.h PATH_SUFFIXES quickjs)
+    find_library(quickjs_LIBRARY NAMES quickjs PATH_SUFFIXES quickjs)
+    if(quickjs_INLCUDE_DIR AND quickjs_LIBRARY)
+        add_library(js STATIC
+            ${CMAKE_SOURCE_DIR}/src/api/js.c
+            ${CMAKE_SOURCE_DIR}/src/api/parse_note.c
+        )
+        target_compile_definitions(js INTERFACE TIC_BUILD_WITH_JS)
+        target_link_libraries(js PRIVATE runtime ${quickjs_LIBRARY})
+        target_include_directories(js
+            PUBLIC ${quickjs_INLCUDE_DIR}
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_SOURCE_DIR}/src
+        )
+        message(STATUS "Use system library: quickjs")
+        return()
+    else()
+        message(WARNING "System library quickjs not found")
+    endif()
+endif()
+
 if(BUILD_WITH_JS)
 
     set(QUICKJS_DIR ${THIRDPARTY_DIR}/quickjs)

--- a/cmake/sdl.cmake
+++ b/cmake/sdl.cmake
@@ -1,7 +1,19 @@
 ################################
 # SDL2
 ################################
-if(BUILD_SDL AND NOT EMSCRIPTEN AND NOT RPI)
+if(PREFER_SYSTEM_LIBRARIES)
+    find_package(SDL2)
+    if(SDL2_FOUND)
+        add_library(SDL2 ALIAS SDL2::SDL2)
+        add_library(SDL2-static ALIAS SDL2::SDL2)
+        message(STATUS "Use system library: SDL2")
+    else()
+        message(WARNING "System library SDL2 not found")
+    endif()
+endif()
+
+
+if(BUILD_SDL AND NOT EMSCRIPTEN AND NOT RPI AND NOT PREFER_SYSTEM_LIBRARIES)
 
     if(WIN32)
         set(HAVE_LIBC TRUE)

--- a/cmake/squirrel.cmake
+++ b/cmake/squirrel.cmake
@@ -5,6 +5,31 @@
 option(BUILD_WITH_SQUIRREL "Squirrel Enabled" ${BUILD_WITH_ALL})
 message("BUILD_WITH_SQUIRREL: ${BUILD_WITH_SQUIRREL}")
 
+if(BUILD_WITH_SQUIRREL AND PREFER_SYSTEM_LIBRARIES)
+    find_path(squirrel_INLCUDE_DIR NAMES squirrel.h PATH_SUFFIXES squirrel)
+    find_library(squirrel_LIBRARY NAMES squirrel)
+    find_library(sqstdlib_LIBRARY NAMES sqstdlib)
+    if(squirrel_INLCUDE_DIR AND squirrel_LIBRARY AND sqstdlib_LIBRARY)
+        add_library(squirrel STATIC
+            ${CMAKE_SOURCE_DIR}/src/api/squirrel.c
+            ${CMAKE_SOURCE_DIR}/src/api/parse_note.c
+        )
+        target_compile_definitions(squirrel INTERFACE TIC_BUILD_WITH_SQUIRREL)
+        target_link_libraries(squirrel PRIVATE runtime ${squirrel_LIBRARY} ${sqstdlib_LIBRARY})
+        target_include_directories(squirrel
+            PUBLIC ${squirrel_INLCUDE_DIR}
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_SOURCE_DIR}/src
+        )
+        message(STATUS "Use system library: squirrel")
+        return()
+    else()
+        message(WARNING "System library squirrel not found")
+    endif()
+endif()
+
+
 if(BUILD_WITH_SQUIRREL)
 
     set(SQUIRREL_DIR ${THIRDPARTY_DIR}/squirrel)

--- a/cmake/wasm.cmake
+++ b/cmake/wasm.cmake
@@ -5,6 +5,28 @@
 option(BUILD_WITH_WASM "Wasm Enabled" ${BUILD_WITH_ALL})
 message("BUILD_WITH_WASM: ${BUILD_WITH_WASM}")
 
+if(BUILD_WITH_WASM AND PREFER_SYSTEM_LIBRARIES)
+    find_path(wasm_INCLUDE_DIR NAMES wasm3.h)
+    find_library(wasm_LIBRARY NAMES m3)
+    if(wasm_INCLUDE_DIR AND wasm_LIBRARY)
+        add_library(wasm STATIC
+            ${CMAKE_SOURCE_DIR}/src/api/wasm.c
+        )
+        target_compile_definitions(wasm INTERFACE TIC_BUILD_WITH_WASM)
+        target_link_libraries(wasm PRIVATE runtime ${wasm_LIBRARY})
+        target_include_directories(wasm
+            PUBLIC ${wasm_INCLUDE_DIR}
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/include
+                ${CMAKE_SOURCE_DIR}/src
+        )
+        message(STATUS "Use system library: wasm")
+        return()
+    else()
+        message(WARNING "System library wasm not found")
+    endif()
+endif()
+
 if(BUILD_WITH_WASM)
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Dd_m3LogOutput=0")

--- a/cmake/zip.cmake
+++ b/cmake/zip.cmake
@@ -2,5 +2,21 @@
 # ZIP
 ################################
 
+if(PREFER_SYSTEM_LIBRARIES)
+    find_path(zip_INCLUDE_DIR NAMES zip.h PATH_SUFFIXES zip)
+    find_library(zip_LIBRARY NAMES zip)
+    if(zip_INCLUDE_DIR AND zip_LIBRARY)
+        add_library(zip UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(zip PROPERTIES
+            IMPORTED_LOCATION "${zip_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${zip_INCLUDE_DIR}"
+        )
+        message(STATUS "Use system library: kubazip")
+        return()
+    else()
+        message(WARNING "System library kubazip not found")
+    endif()
+endif()
+
 set(CMAKE_DISABLE_TESTING ON CACHE BOOL "" FORCE)
 add_subdirectory(${THIRDPARTY_DIR}/zip)

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -2,6 +2,18 @@
 # ZLIB
 ################################
 
+if(PREFER_SYSTEM_LIBRARIES)
+    find_package(PkgConfig)
+    pkg_check_modules(zlib IMPORTED_TARGET GLOBAL zlib)
+    if (zlib_FOUND)
+        add_library(zlib ALIAS PkgConfig::zlib)
+        message(STATUS "Use system library: zlib")
+        return()
+    else()
+        message(WARNING "System library zlib not found")
+    endif()
+endif()
+
 if (NOT NINTENDO_3DS)
 
 set(ZLIB_DIR ${THIRDPARTY_DIR}/zlib)


### PR DESCRIPTION
Hello, I'd like to package tic80 for a Linux distro (GNU Guix), which prefer use system libraries instead of vendor ones.

So here is a patch to introduce a `PREFER_SYSTEM_LIBRARIES` cmake option, when ON it will try to use system ones and fallback to vendor.
