### PR TITLE
Update macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,20 +337,20 @@ run the following commands in the Terminal
 ```
 brew install git cmake
 git clone --recursive https://github.com/nesbox/TIC-80 && cd TIC-80/build
-cmake -DBUILD_WITH_ALL=On ..
+cmake -DBUILD_WITH_ALL=On -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
 make -j4
 ```
 
 to create application icon for development version
 ```
-mkdir -p ~/Applications/TIC80dev.app/Contents/{MacOS,Resources}
-cp -f macosx/tic80.plist ~/Applications/TIC80dev.app/Contents/Info.plist
-cp -f macosx/tic80.icns ~/Applications/TIC80dev.app/Contents/Resources
-cat > ~/Applications/TIC80dev.app/Contents/MacOS/tic80 <<EOF
+mkdir -p ~/Applications/tic80dev.app/Contents/{MacOS,Resources}
+cp -f macosx/tic80.plist ~/Applications/tic80dev.app/Contents/Info.plist
+cp -f macosx/tic80.icns ~/Applications/tic80dev.app/Contents/Resources
+cat > ~/Applications/tic80dev.app/Contents/MacOS/tic80 <<EOF
 #!/bin/sh
-exec /Users/nesbox/projects/TIC-80/build/bin/tic80 --skip --scale 2 >/dev/null
+exec /Users/nesbox/projects/TIC-80/build/bin/tic80 --skip >/dev/null
 EOF
-chmod +x ~/Applications/TIC80dev.app/Contents/MacOS/TIC80dev
+chmod +x ~/Applications/tic80dev.app/Contents/MacOS/tic80
 ```
 Make sure to update the absolute path to the tic80 binary in the script, or
 update the launch arguments.


### PR DESCRIPTION
Makes three README changes to help Mac users building tic80.

1. DCMAKE_POLICY_VERSION_MINIMUM=3.5 required with brew version of cmake
2. Correct binary name for chmod +x (binary is called tic80, not TIC80dev)
3. Renamed app from TIC80DEV to tic80dev for consistency with release name

I also removed the scale param from the exec script because it caused tic80 to open in a tiny window. The default scaling seems to work better.

 I have tested this with:
* cmake version 4.0.3 - from Brew
* Apple clang version 17.0.0 (clang-1700.0.13.5)
* macOS 15.5
* CPU M1 Max (arm64) 


Without the first change, builds with the current brew version of cmake fail with:

```
CMake Error at vendor/zip/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```