### PR TITLE
[libretro] Fixes frametime (and weird bugs)

### DIFF
--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -163,7 +163,7 @@ void tic80_libretro_frame_time(retro_usec_t usec) {
 		return;
 	}
 
-	state->frameTime = usec;
+	state->frameTime += usec;
 }
 
 /**


### PR DESCRIPTION
"There is a critical bug in how the core handles game time, directly related to TIC80_FREQUENCY. The core incorrectly provides the TIC-80 engine with the time delta (time since last frame) instead of a continuously running counter. This causes the engine's internal clock to advance far too slowly, leading to the reported issues.

Because `state->frameTime` is being reset instead of accumulated, the TIC-80 engine sees a counter value that hovers around the same number every frame (e.g., ~16667 for 60 FPS). When the engine calculates the difference (`new_counter_value - old_counter_value`), the result is close to zero. The engine therefore concludes that almost no time has passed, causing game logic to run at a fraction of the intended speed."

Those are actually not my words, but of Gemini 2.5 Pro. I find it quite impressive, see it's complete reply at: https://g.co/gemini/share/c036af7b72fe

This fixes the regression problem mentioned in #2820, and it actually makes it better than what was before. Some games that were slower in libretro, gets the actual speed as the standalone version.