### PR TITLE
[web export] Fix Safari Arrow keys in HTML export/webapp

### DIFF
--- a/build/html/export.html
+++ b/build/html/export.html
@@ -28,11 +28,66 @@
 
         </div>
 
-        <canvas style="width: 100%; height: 100%; margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()"></canvas>
+        <canvas style="width: 100%; height: 100%; margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()" tabindex="0"></canvas>
     </div>
 
     <script type="text/javascript">
         var Module = {canvas: document.getElementById('canvas'), arguments:['cart.tic']}
+
+        // Safari/WebKit-only: remap Arrow keys with location 3 (numpad) to location 0.
+        (function(){
+            const ua = navigator.userAgent || '';
+            const isWebKit = /AppleWebKit/i.test(ua);
+            if (!isWebKit) return;
+
+            const synthesizeArrowWithLocation0 = (orig) => {
+                try {
+                    const ev = new KeyboardEvent(orig.type, {
+                        key: orig.key,
+                        code: orig.code,
+                        location: 0,
+                        repeat: orig.repeat,
+                        ctrlKey: orig.ctrlKey,
+                        shiftKey: orig.shiftKey,
+                        altKey: orig.altKey,
+                        metaKey: orig.metaKey,
+                        bubbles: true,
+                        cancelable: true,
+                    });
+                    Object.defineProperty(ev, 'which', { get: () => orig.which });
+                    Object.defineProperty(ev, 'keyCode', { get: () => orig.keyCode });
+                    return ev;
+                } catch { return null; }
+            };
+
+            const remapArrowLocationCapture = (e) => {
+                const isArrow = (e.key && e.key.startsWith('Arrow')) || (e.code && e.code.startsWith('Arrow'));
+                if (!isArrow) return;
+                if (e.location === 3) {
+                    const syn = synthesizeArrowWithLocation0(e);
+                    if (syn) {
+                        e.stopImmediatePropagation();
+                        e.preventDefault();
+                        (e.target || document.getElementById('canvas')).dispatchEvent(syn);
+                    }
+                }
+            };
+
+            ['keydown','keyup'].forEach(t => document.addEventListener(t, remapArrowLocationCapture, true));
+        })();
+
+        // Prevent page scrolling while the game canvas is focused
+        (function(){
+            const canvasEl = document.getElementById('canvas');
+            const preventArrowDefault = (e) => {
+                const key = e.key || e.code;
+                const kc = e.keyCode || e.which;
+                const isArrow = (key && ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(key)) || (kc >= 37 && kc <= 40);
+                if (isArrow && document.activeElement === canvasEl) e.preventDefault();
+            };
+            document.addEventListener('keydown', preventArrowDefault, { passive: false });
+            canvasEl.addEventListener('keydown', preventArrowDefault, { passive: false });
+        })();
 
         const gameFrame = document.getElementById('game-frame')
         const displayStyle = window.getComputedStyle(gameFrame).display;
@@ -43,6 +98,8 @@
             firstScriptTag = document.getElementsByTagName('script')[0]; // find the first script tag in the document
             scriptTag.src = 'tic80.js'; // set the source of the script to your script
             firstScriptTag.parentNode.insertBefore(scriptTag, firstScriptTag); // append the script to the DOM
+            // Focus canvas to ensure keyboard events are routed to the game
+            document.getElementById('canvas').focus()
         } else {
             gameFrame.addEventListener('click', function() {
                 let scriptTag = document.createElement('script'), // create a script tag
@@ -50,6 +107,8 @@
                 scriptTag.src = 'tic80.js'; // set the source of the script to your script
                 firstScriptTag.parentNode.insertBefore(scriptTag, firstScriptTag); // append the script to the DOM
                 this.remove()
+                // Focus canvas to ensure keyboard events are routed to the game
+                document.getElementById('canvas').focus()
             });
         }
     </script>

--- a/build/html/export.html
+++ b/build/html/export.html
@@ -32,7 +32,7 @@
     </div>
 
     <script type="text/javascript">
-        var Module = {canvas: document.getElementById('canvas'), arguments:['cart.tic']}
+        var Module = {canvas: document.getElementById('canvas'), arguments:['cart.tic']};
 
         // Safari/WebKit-only: remap Arrow keys with location 3 (numpad) to location 0.
         (function(){

--- a/build/html/index.html
+++ b/build/html/index.html
@@ -31,7 +31,7 @@
 
         </div>
 
-        <canvas style="width: 100%; height: 100%; margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()"></canvas>
+        <canvas style="width: 100%; height: 100%; margin: 0 auto; display: block; image-rendering: pixelated;" id="canvas" oncontextmenu="event.preventDefault()" onmousedown="window.focus()" tabindex="0"></canvas>
     </div>
 
     <div id="add-modal" class="modal">
@@ -45,6 +45,61 @@
     <script type="text/javascript">
         var Module = {canvas: document.getElementById('canvas')}
 
+        // Safari/WebKit-only: remap Arrow keys with location 3 (numpad) to location 0.
+        (function(){
+            const ua = navigator.userAgent || '';
+            const isWebKit = /AppleWebKit/i.test(ua);
+            if (!isWebKit) return;
+
+            const synthesizeArrowWithLocation0 = (orig) => {
+                try {
+                    const ev = new KeyboardEvent(orig.type, {
+                        key: orig.key,
+                        code: orig.code,
+                        location: 0,
+                        repeat: orig.repeat,
+                        ctrlKey: orig.ctrlKey,
+                        shiftKey: orig.shiftKey,
+                        altKey: orig.altKey,
+                        metaKey: orig.metaKey,
+                        bubbles: true,
+                        cancelable: true,
+                    });
+                    Object.defineProperty(ev, 'which', { get: () => orig.which });
+                    Object.defineProperty(ev, 'keyCode', { get: () => orig.keyCode });
+                    return ev;
+                } catch { return null; }
+            };
+
+            const remapArrowLocationCapture = (e) => {
+                const isArrow = (e.key && e.key.startsWith('Arrow')) || (e.code && e.code.startsWith('Arrow'));
+                if (!isArrow) return;
+                if (e.location === 3) {
+                    const syn = synthesizeArrowWithLocation0(e);
+                    if (syn) {
+                        e.stopImmediatePropagation();
+                        e.preventDefault();
+                        (e.target || document.getElementById('canvas')).dispatchEvent(syn);
+                    }
+                }
+            };
+
+            ['keydown','keyup'].forEach(t => document.addEventListener(t, remapArrowLocationCapture, true));
+        })();
+
+        // Prevent page scrolling while the game canvas is focused
+        (function(){
+            const canvasEl = document.getElementById('canvas');
+            const preventArrowDefault = (e) => {
+                const key = e.key || e.code;
+                const kc = e.keyCode || e.which;
+                const isArrow = (key && ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(key)) || (kc >= 37 && kc <= 40);
+                if (isArrow && document.activeElement === canvasEl) e.preventDefault();
+            };
+            document.addEventListener('keydown', preventArrowDefault, { passive: false });
+            canvasEl.addEventListener('keydown', preventArrowDefault, { passive: false });
+        })();
+
         const gameFrame = document.getElementById('game-frame')
 
         gameFrame.addEventListener('click', function() {
@@ -53,6 +108,8 @@
             scriptTag.src = 'tic80.js'; // set the source of the script to your script
             firstScriptTag.parentNode.insertBefore(scriptTag, firstScriptTag); // append the script to the DOM
             this.remove()
+            // Focus canvas to ensure keyboard events are routed to the game
+            document.getElementById('canvas').focus()
         });
     </script>
 </body>

--- a/build/html/index.html
+++ b/build/html/index.html
@@ -43,7 +43,7 @@
     </div>
 
     <script type="text/javascript">
-        var Module = {canvas: document.getElementById('canvas')}
+        var Module = {canvas: document.getElementById('canvas')};
 
         // Safari/WebKit-only: remap Arrow keys with location 3 (numpad) to location 0.
         (function(){

--- a/build/webapp/index.html
+++ b/build/webapp/index.html
@@ -32,7 +32,7 @@
         <script type="module">
         import startTic80 from './tic80.js'
 
-        navigator.serviceWorker.register('serviceworker.js')
+        navigator.serviceWorker.register('serviceworker.js');
 
         // Safari/WebKit-only: remap Arrow keys with location 3 (numpad) to location 0.
         (function(){

--- a/build/webapp/index.html
+++ b/build/webapp/index.html
@@ -34,6 +34,61 @@
 
         navigator.serviceWorker.register('serviceworker.js')
 
+        // Safari/WebKit-only: remap Arrow keys with location 3 (numpad) to location 0.
+        (function(){
+            const ua = navigator.userAgent || '';
+            const isWebKit = /AppleWebKit/i.test(ua);
+            if (!isWebKit) return;
+
+            const synthesizeArrowWithLocation0 = (orig) => {
+                try {
+                    const ev = new KeyboardEvent(orig.type, {
+                        key: orig.key,
+                        code: orig.code,
+                        location: 0,
+                        repeat: orig.repeat,
+                        ctrlKey: orig.ctrlKey,
+                        shiftKey: orig.shiftKey,
+                        altKey: orig.altKey,
+                        metaKey: orig.metaKey,
+                        bubbles: true,
+                        cancelable: true,
+                    });
+                    Object.defineProperty(ev, 'which', { get: () => orig.which });
+                    Object.defineProperty(ev, 'keyCode', { get: () => orig.keyCode });
+                    return ev;
+                } catch { return null; }
+            };
+
+            const remapArrowLocationCapture = (e) => {
+                const isArrow = (e.key && e.key.startsWith('Arrow')) || (e.code && e.code.startsWith('Arrow'));
+                if (!isArrow) return;
+                if (e.location === 3) {
+                    const syn = synthesizeArrowWithLocation0(e);
+                    if (syn) {
+                        e.stopImmediatePropagation();
+                        e.preventDefault();
+                        (e.target || document.getElementById('canvas')).dispatchEvent(syn);
+                    }
+                }
+            };
+
+            ['keydown','keyup'].forEach(t => document.addEventListener(t, remapArrowLocationCapture, true));
+        })();
+
+        // Prevent page scrolling while the canvas is focused
+        (function(){
+            const canvasEl = document.getElementById('canvas');
+            const preventArrowDefault = (e) => {
+                const key = e.key || e.code;
+                const kc = e.keyCode || e.which;
+                const isArrow = (key && ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(key)) || (kc >= 37 && kc <= 40);
+                if (isArrow && document.activeElement === canvasEl) e.preventDefault();
+            };
+            document.addEventListener('keydown', preventArrowDefault, { passive: false });
+            canvasEl.addEventListener('keydown', preventArrowDefault, { passive: false });
+        })();
+
         const initialize = () => {
             const canvasSelector = '#canvas'
             const canvasElement = document.querySelector(canvasSelector)


### PR DESCRIPTION
Safari/WebKit sometimes reports physical Arrow keys with KeyboardEvent.location === 3 (numpad). The Emscripten input glue ignores those for directional input, so arrows don't work in Safari.

This PR adds a small, WebKit-scoped capture-phase shim to remap Arrow key events with location 3 to location 0, prevents page scrolling on Arrow keys while the canvas is focused, and ensures the canvas is focusable and focused on start.

Changes:
- build/html/export.html: add WebKit remap + prevent scroll + focus; add tabindex=0
- build/html/index.html: same as above for the basic player
- build/webapp/index.html: same as above for the webapp

Tested locally in Safari: arrows now reach the game.

The preceding text and the patch written by Claude, but the fix does work.