### PR TITLE
[libretro] Reverting back to the use of clock()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,7 +403,7 @@ jobs:
       - name: Build
         run: |
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC=ON -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=ON ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC=ON -DBUILD_SDLGPU=On -DBUILD_WITH_ALL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
           cmake --build . --parallel
 
       - name: Deploy

--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -1107,16 +1107,6 @@ RETRO_API bool retro_load_game(const struct retro_game_info *info)
 		return false;
 	}
 
-	// Set up the frame time callback.
-	// struct retro_frame_time_callback frame_time = {
-	// 	.callback = tic80_libretro_frame_time,
-	// 	.reference = TIC80_FREQUENCY / TIC80_FRAMERATE,
-	// };
-	// if (!environ_cb(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &frame_time)) {
-	// 	log_cb(RETRO_LOG_ERROR, "[TIC-80] Failed to set frame time callback.\n");
-	// 	return false;
-	// }
-
 	// Set up the TIC-80 environment.
 #if RETRO_IS_BIG_ENDIAN
 	state->tic = tic80_create(TIC80_SAMPLERATE, TIC80_PIXEL_COLOR_ARGB8888);

--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -77,7 +77,6 @@ struct tic80_state
 	int mouseHideTimer;
 	int mouseHideTimerStart;
 	tic80* tic;
-	retro_usec_t frameTime;
 };
 static struct tic80_state* state = NULL;
 
@@ -86,11 +85,7 @@ static struct tic80_state* state = NULL;
  */
 static u64 tic80_libretro_counter()
 {
-	if (state == NULL) {
-		return 0;
-	}
-
-	return (u64)state->frameTime;
+	return clock();
 }
 
 /**
@@ -98,7 +93,7 @@ static u64 tic80_libretro_counter()
  */
 static u64 tic80_libretro_frequency()
 {
-	return TIC80_FREQUENCY;
+	return CLOCKS_PER_SEC;
 }
 
 /**
@@ -153,17 +148,6 @@ void tic80_libretro_fallback_log(enum retro_log_level level, const char *fmt, ..
 	va_start(va, fmt);
 	vfprintf(stderr, fmt, va);
 	va_end(va);
-}
-
-/**
- * libretro callback; Called to indicate how much time has passed since last retro_run().
- */
-void tic80_libretro_frame_time(retro_usec_t usec) {
-	if (state == NULL) {
-		return;
-	}
-
-	state->frameTime += usec;
 }
 
 /**
@@ -1113,16 +1097,6 @@ RETRO_API bool retro_load_game(const struct retro_game_info *info)
 	// Ensure content data is available.
 	if (info->data == NULL) {
 		log_cb(RETRO_LOG_ERROR, "[TIC-80] No content data provided.\n");
-		return false;
-	}
-
-	// Set up the frame time callback.
-	struct retro_frame_time_callback frame_time = {
-		.callback = tic80_libretro_frame_time,
-		.reference = TIC80_FREQUENCY / TIC80_FRAMERATE,
-	};
-	if (!environ_cb(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &frame_time)) {
-		log_cb(RETRO_LOG_ERROR, "[TIC-80] Failed to set frame time callback.\n");
 		return false;
 	}
 


### PR DESCRIPTION
`clock()` was previously replaced by frame time callback (1c8eb84 #2589)
It introduced a few bugs that I tried to fix (#2829)
But there is a benchmark cartridge ( [git:demos/benchmark.lua](https://github.com/nesbox/TIC-80/blob/81de993d66d20f478caf0177e275fbfc48225e53/demos/benchmark.lua) | [tic80.com/play](https://tic80.com/play?cart=153) ) that calls time() to measure itra-frame timing.
It was broken using the current libretro core, it's `runTime` was stuck in zero.

Reverting to the use of `clock()` fixes this issue.

Bellow is Gemini explanation:

-----

The situation involves two different timing requirements:

- Inter-Frame Timing (Game Speed): This is about ensuring the game logic advances correctly from one frame to the next. If 1/60th of a second has passed in the real world, the game should also advance its state by 1/60th of a second. The original fix (`state->frameTime += usec;`) solved this by correctly accumulating the time between frames.

- Intra-Frame Timing (Benchmark Measurement): This is what the benchmark cartridge needs. It uses TIC-80's `time()` function to measure how long an operation takes within a single frame. It records the start time, does a lot of drawing, records the end time, and calculates the difference.

The original fix failed the benchmark test because the `state->frameTime` value is only updated once per frame. For the entire duration of the `MAINTIC()` function, the value returned by `time()` would be constant. Therefore, `time() - stime` would always be zero.

--
The `clock()` solution is superior because it provides a high-resolution, continuously updating timer directly from the system's C library.

- `clock()`: This standard function returns the amount of processor time used by the program. Crucially, this value increases during the execution of a single frame.

- `CLOCKS_PER_SEC`: This constant provides the frequency of the clock() timer.

When the benchmark calls time() (`clock() / CLOCKS_PER_SEC`), it gets a precise timestamp. After it finishes its work and calls time() again, the value from clock() will have increased, yielding a correct, non-zero `runningTime`. This solves the intra-frame timing problem.

Simultaneously, because `clock()` is a consistently increasing counter, the TIC-80 engine can use it to perfectly measure the duration between frames, solving the inter-frame timing problem as well.