### PR TITLE
Updates verdor/zip from v0.1.19 to v0.3.5

### DIFF
--- a/cmake/zip.cmake
+++ b/cmake/zip.cmake
@@ -20,3 +20,11 @@ endif()
 
 set(CMAKE_DISABLE_TESTING ON CACHE BOOL "" FORCE)
 add_subdirectory(${THIRDPARTY_DIR}/zip)
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+    target_compile_options(zip PRIVATE -Wno-type-limits)
+
+#  -Wno-type-limits due to:
+#     zip/src/miniz.h:8503:30: error: comparison is always false due to limited range of data type [-Werror=type-limits]
+#  8503 |     if (((mz_uint64)buf_size > 0xFFFFFFFF) || (uncomp_size > 0xFFFFFFFF)) {
+endif()


### PR DESCRIPTION
no need for the -DCMAKE_POLICY_VERSION_MINIMUM=3.5 flag anymore.