### PR TITLE
Fix faulty implementation of pmemset

### DIFF
--- a/demos/bunny/wasmmark/src/tic80.zig
+++ b/demos/bunny/wasmmark/src/tic80.zig
@@ -422,8 +422,8 @@ pub fn nosfx() void {
 // ------
 // MEMORY
 
-pub fn pmemset(index: u32, value: u3) void {
-    raw.pmem(index, value);
+pub fn pmemset(index: u32, value: u32) void {
+    _ = raw.pmem(index, value);
 }
 
 pub fn pmemget(index: u32) u32 {

--- a/demos/wasm/src/tic80.zig
+++ b/demos/wasm/src/tic80.zig
@@ -422,8 +422,8 @@ pub fn nosfx() void {
 // ------
 // MEMORY
 
-pub fn pmemset(index: u32, value: u3) void {
-    raw.pmem(index, value);
+pub fn pmemset(index: u32, value: u32) void {
+    _ = raw.pmem(index, value);
 }
 
 pub fn pmemget(index: u32) u32 {

--- a/templates/zig/src/tic80.zig
+++ b/templates/zig/src/tic80.zig
@@ -422,8 +422,8 @@ pub fn nosfx() void {
 // ------
 // MEMORY
 
-pub fn pmemset(index: u32, value: u3) void {
-    raw.pmem(index, value);
+pub fn pmemset(index: u32, value: u32) void {
+    _ = raw.pmem(index, value);
 }
 
 pub fn pmemget(index: u32) u32 {


### PR DESCRIPTION
Fixed two typos in the Zig `pmemset()` function that made it unusable.