### PR TITLE
[cmake/mruby.cmake] Replace `exec_program` (deprecated)

### DIFF
--- a/cmake/mruby.cmake
+++ b/cmake/mruby.cmake
@@ -75,7 +75,7 @@ if(BUILD_WITH_RUBY)
     endif()
 
     if(APPLE)
-        exec_program(xcrun ARGS --sdk macosx --show-sdk-path OUTPUT_VARIABLE MRUBY_SYSROOT)
+        execute_process(COMMAND xcrun --sdk macosx --show-sdk-path OUTPUT_VARIABLE MRUBY_SYSROOT OUTPUT_STRIP_TRAILING_WHITESPACE)
     endif()
 
     if(ANDROID_NDK_HOME)


### PR DESCRIPTION
[The `exec_program` command has been deprecated](https://cmake.org/cmake/help/latest/command/exec_program.html) since CMake 3.0, in favor of [`execute_process`](https://cmake.org/cmake/help/latest/command/execute_process.html).

This change will also fix [the build failure](https://hydra.nixos.org/build/314546451) in [the Nixpkgs `tic-80` derivation](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ti/tic-80/package.nix) on macOS, although that's not really related to the deprecation. (Nixpkgs is using a fake `xcrun` command from [`xcbuild`](https://github.com/facebookarchive/xcbuild), which outputs a warning message before returning the SDK path. `exec_command` captures both stdout and stderr in the same variable, causing the warning to end up in the Makefile and breaking things. `execute_process` handles stdout and stderr separately, so it doesn't have this problem.)