### PR TITLE
Fix WASM btnp and fget return type

### DIFF
--- a/src/api/wasm.c
+++ b/src/api/wasm.c
@@ -379,8 +379,9 @@ m3ApiRawFunction(wasmtic_btnp)
     // -1 is the "default" placeholder for index, hold, and period but the TIC side API
     // knows this so we don't need to do any transaction, we can just pass the -1 values
     // straight thru
-
-    m3ApiReturn((int32_t)core->api.btnp((tic_mem *)core, index, hold, period));
+    
+    u32 pressed = core->api.btnp((tic_mem*)core, index, hold, period);
+    m3ApiReturn((int32_t)(pressed ? 1 : 0));
 
     m3ApiSuccess();
 }


### PR DESCRIPTION
Fixes https://github.com/nesbox/TIC-80/issues/2183

`btnp` and `fget` are linked as returning i32:

https://github.com/nesbox/TIC-80/blob/df226e6a0f7708c262c1ec980b94cd6f17315f33/src/api/wasm.c#L1009

but  m3ApiReturnType(bool) only writes 1 byte and leaves the remaining 3 bytes uninitialized

This can cause those functions to randomly return true in release builds.

~~I'm not sure if the btnp return value should preserve the bitmask values or not, I've kept them here.~~ Looks like 1 needs to be returned for true to be picked up from a C cartridge. Also tested using Rust.