### PR TITLE
Fix crash when pressing ESC during code editor popup hide animation (Fixes #2881)

### DIFF
--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -3770,6 +3770,9 @@ static void escape(Code* code)
         setCodeMode(code, TEXT_EDIT_MODE);
         break;
     default:
+		if(code->popup.prevPos == NULL)
+			return;
+		
         code->anim.movie = resetMovie(&code->anim.hide);
 
         code->cursor.position = code->popup.prevPos;


### PR DESCRIPTION
### Problem
TIC-80 crashes when you close a code editor popup (Find/Goto/Bookmarks/Outline) and press ESC again while the popup is still animating closed.

Studio routes ESC to `code->escape()` whenever `code->mode != TEXT_EDIT_MODE` therefore ESC can call `escape()` multiple times during the popup hide animation. On the first call, `escape()` restores `popup.prevPos/prevSel` and clears them; the second call would attempt to restore NULL into the pointers and crash during the editor update.

### Fix
Make the popup-close path in `Code::escape()` safe against being invoked again mid-animation:
- If `popup.prevPos` is already NULL, don't restart the hide animation, don't touch cursor pointers.

This keeps the behavior the same for a normal single ESC, but prevents the crash from repeated ESC during the hide animation.
No behavioral changes outside the timing window (repeated ESC while the popup is already closing).

Fixes #2881