### PR TITLE
Creates the BUILD_SURF build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ option(BUILD_WITH_ZLIB "Build with zlib linked" ON)
 option(TIC80_TARGET "Target binary suffix")
 option(PREFER_SYSTEM_LIBRARIES "Prefer link with system libraries" OFF)
 
+if(BUILD_EDITORS)
+    set(BUILD_SURF ON)
+endif()
 
 if(NOT TIC80_TARGET)
     set(TIC80_TARGET tic80)

--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -27,7 +27,12 @@ android {
                 arguments "APP_PLATFORM=android-31"
             }
             cmake {
-                arguments "-DBUILD_WITH_RUBY=OFF", "-DBUILD_PRO=Off", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_WITH_ALL=ON"
+                arguments "-DBUILD_WITH_RUBY=OFF",
+                            "-DBUILD_PRO=OFF",
+                            "-DBUILD_EDITORS=OFF",
+                            "-DBUILD_SURF=ON",
+                            "-DCMAKE_BUILD_TYPE=Release",
+                            "-DBUILD_WITH_ALL=ON"
             }
         }
     }

--- a/cmake/studio.cmake
+++ b/cmake/studio.cmake
@@ -16,17 +16,28 @@ set(TIC80STUDIO_SRC
     ${TIC80LIB_DIR}/ext/png.c
 )
 
+if(BUILD_SURF)
+    set(TIC80STUDIO_SRC ${TIC80STUDIO_SRC}
+        ${TIC80LIB_DIR}/studio/screens/surf.c
+        ${TIC80LIB_DIR}/studio/net.c
+    )
+
+    if(NOT BUILD_EDITORS)
+        set(TIC80STUDIO_SRC ${TIC80STUDIO_SRC}
+            ${TIC80LIB_DIR}/studio/screens/console_minimal.c
+        )
+    endif()
+endif()
+
 if(BUILD_EDITORS)
     set(TIC80STUDIO_SRC ${TIC80STUDIO_SRC}
         ${TIC80LIB_DIR}/studio/screens/console.c
-        ${TIC80LIB_DIR}/studio/screens/surf.c
         ${TIC80LIB_DIR}/studio/editors/code.c
         ${TIC80LIB_DIR}/studio/editors/sprite.c
         ${TIC80LIB_DIR}/studio/editors/map.c
         ${TIC80LIB_DIR}/studio/editors/world.c
         ${TIC80LIB_DIR}/studio/editors/sfx.c
         ${TIC80LIB_DIR}/studio/editors/music.c
-        ${TIC80LIB_DIR}/studio/net.c
         ${TIC80LIB_DIR}/ext/history.c
         ${TIC80LIB_DIR}/ext/gif.c
     )
@@ -46,6 +57,8 @@ add_library(tic80studio STATIC
 target_include_directories(tic80studio
     PRIVATE ${THIRDPARTY_DIR}/jsmn
     PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+    PUBLIC ${TIC80LIB_DIR}
+    PUBLIC ${TIC80LIB_DIR}/studio
 )
 
 target_link_libraries(tic80studio PUBLIC tic80core PRIVATE zip wave_writer argparse giflib png)
@@ -65,4 +78,8 @@ endif()
 
 if(BUILD_EDITORS)
     target_compile_definitions(tic80studio PUBLIC BUILD_EDITORS)
+endif()
+
+if(BUILD_SURF)
+    target_compile_definitions(tic80studio PUBLIC BUILD_SURF)
 endif()

--- a/src/studio/fs.c
+++ b/src/studio/fs.c
@@ -405,7 +405,7 @@ void tic_fs_enum(tic_fs* fs, fs_list_callback onItem, fs_done_callback onDone, v
         return;
     }
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_SURF)
     if(isPublic(fs))
     {
         char request[TICNAME_MAX];
@@ -807,7 +807,7 @@ void tic_fs_hashload(tic_fs* fs, const char* name, const char* hash, fs_load_cal
         }
     }
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_SURF)
     char path[TICNAME_MAX];
     snprintf(path, sizeof path, "/cart/%s/%s", hash, name);
 

--- a/src/studio/screens/console_minimal.c
+++ b/src/studio/screens/console_minimal.c
@@ -11,6 +11,7 @@
 #include "studio/config.h"
 #include "ext/json.h"
 #include "retro_endianness.h"
+#include "start.h"
 
 static void load(Console* console, const char* path)
 {
@@ -80,7 +81,16 @@ void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Con
         .updateProject = empty,
         .trace = emptyTrace,
         .error = emptyError,
+        .args = args,
     };
+
+    if (args.cart)
+    {
+        load(console, args.cart);
+        struct Start* start = getStartScreen(studio);
+        if (start)
+            start->embed = true;
+    }
 }
 
 void freeConsole(Console* console)

--- a/src/studio/screens/console_minimal.c
+++ b/src/studio/screens/console_minimal.c
@@ -1,0 +1,91 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "studio/studio.h"
+#include "cart.h"
+#include "console.h"
+#include "tools.h"
+#include "studio/fs.h"
+#include "studio/net.h"
+#include "studio/config.h"
+#include "ext/json.h"
+#include "retro_endianness.h"
+
+static void load(Console* console, const char* path)
+{
+    s32 size = 0;
+    void* data = tic_fs_load(console->fs, path, &size);
+
+    if(data) SCOPE(free(data))
+    {
+        tic_cart_load(&console->tic->cart, data, size);
+        tic_api_reset(console->tic);
+
+        strcpy(console->rom.name, path);
+        studioRomLoaded(console->studio);
+    }
+}
+
+typedef struct
+{
+    Console* console;
+    char* name;
+    fs_done_callback callback;
+    void* calldata;
+} LoadByHashData;
+
+static void loadByHashDone(const u8* buffer, s32 size, void* data)
+{
+    LoadByHashData* loadByHashData = data;
+    Console* console = loadByHashData->console;
+
+    tic_cart_load(&console->tic->cart, buffer, size);
+    tic_api_reset(console->tic);
+
+    strcpy(console->rom.name, loadByHashData->name);
+    studioRomLoaded(console->studio);
+
+    if (loadByHashData->callback)
+        loadByHashData->callback(loadByHashData->calldata);
+
+    free(loadByHashData->name);
+    free(loadByHashData);
+}
+
+static void loadByHash(Console* console, const char* name, const char* hash, const char* section, fs_done_callback callback, void* data)
+{
+    LoadByHashData* loadByHashData = malloc(sizeof(LoadByHashData));
+    *loadByHashData = (LoadByHashData){ console, strdup(name), callback, data};
+    tic_fs_hashload(console->fs, name, hash, loadByHashDone, loadByHashData);
+}
+
+static void empty(Console* console) {}
+static void emptyTrace(Console* console, const char* text, u8 color) {}
+static void emptyError(Console* console, const char* text) {}
+
+void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Config* config, StartArgs args)
+{
+    *console = (Console)
+    {
+        .studio = studio,
+        .tic = getMemory(studio),
+        .fs = fs,
+        .net = net,
+        .config = config,
+        .load = load,
+        .loadByHash = loadByHash,
+        .done = empty,
+        .tick = empty,
+        .updateProject = empty,
+        .trace = emptyTrace,
+        .error = emptyError,
+    };
+}
+
+void freeConsole(Console* console)
+{
+    free(console);
+}
+
+void forceAutoSave(Console* console, const char* cart_name) {}

--- a/src/studio/screens/mainmenu.c
+++ b/src/studio/screens/mainmenu.c
@@ -461,6 +461,12 @@ static void onExitGame(void* data, s32 pos)
     exitGame(main->studio);
 }
 
+static void onSurf(void* data, s32 pos)
+{
+    StudioMainMenu* main = data;
+    setStudioMode(main->studio, TIC_SURF_MODE);
+}
+
 enum MainMenu
 {
     MainMenu_GameMenu,
@@ -468,6 +474,9 @@ enum MainMenu
     MainMenu_ResetGame,
 #if defined(BUILD_EDITORS)
     MainMenu_CloseGame,
+#endif
+#if defined(BUILD_SURF)
+    MainMenu_Surf,
 #endif
     MainMenu_Options,
     MainMenu_Separator,
@@ -481,6 +490,9 @@ static const MenuItem MainMenu[] =
     {"RESET GAME",  onResetGame},
 #if defined(BUILD_EDITORS)
     {"CLOSE GAME",  onExitGame, NULL, "Press F1 to switch to editor"},
+#endif
+#if defined(BUILD_SURF)
+    {"SURF",        onSurf},
 #endif
     {"OPTIONS",     showOptionsMenu},
     {""},

--- a/src/studio/screens/mainmenu.c
+++ b/src/studio/screens/mainmenu.c
@@ -433,7 +433,12 @@ static void showGameMenu(void* data, s32 pos)
 
 static inline s32 mainMenuOffset(StudioMainMenu* menu)
 {
-    return menu->count ? 0 : 1;
+    if (menu->count > 0) return 0;
+
+    if (!studio_is_cart_loaded(menu->studio))
+        return 3;
+
+    return 1;
 }
 
 static void onResumeGame(void* data, s32 pos)
@@ -505,8 +510,7 @@ static void showMainMenu(void* data, s32 pos)
     initGameMenu(main);
 
     s32 offset = mainMenuOffset(main);
-
-    studio_menu_init(main->menu, MainMenu + offset, COUNT_OF(MainMenu) - offset, 0, 0, onResumeGame, main);
+    studio_menu_init(main->menu, MainMenu + offset, COUNT_OF(MainMenu) - offset, 0, 0, studio_is_cart_loaded(main->studio) ? onResumeGame : NULL, main);
 }
 
 static void showOptionsMenuPos(void* data, s32 pos)

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -22,24 +22,20 @@
 
 #include "studio.h"
 
-#if defined(BUILD_EDITORS)
-
 #if defined(_WIN32)
 #include <windows.h>
 #else
 #include <sys/time.h>
 #endif
 
+#if defined(BUILD_EDITORS)
 #include "editors/code.h"
 #include "editors/sprite.h"
 #include "editors/map.h"
 #include "editors/world.h"
 #include "editors/sfx.h"
 #include "editors/music.h"
-#include "screens/console.h"
-#include "screens/surf.h"
 #include "ext/history.h"
-#include "net.h"
 #include "wave_writer.h"
 #include "ext/gif.h"
 #define MSF_GIF_IMPL
@@ -47,7 +43,15 @@
 
 #include "../fftdata.h"
 #include "ext/fft.h"
+#endif
 
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
+#include "screens/console.h"
+#endif
+
+#if defined(BUILD_SURF)
+#include "screens/surf.h"
+#include "net.h"
 #endif
 
 #include "ext/md5.h"
@@ -82,7 +86,7 @@
 #define TIC_EDITOR_BANKS 1
 #endif
 
-#ifdef BUILD_EDITORS
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
 typedef struct
 {
     u8 data[MD5_HASHSIZE];
@@ -140,16 +144,20 @@ struct Studio
         MouseState state[3];
     } mouse;
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
     EditorMode menuMode;
+#endif
+#if defined(BUILD_EDITORS)
     ViMode viMode;
-
+#endif
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
     struct
     {
         CartHash hash;
         u64 mdate;
     }cart;
-
+#endif
+#if defined(BUILD_EDITORS)
     struct
     {
         bool show;
@@ -216,14 +224,17 @@ struct Studio
         Music*  music[TIC_EDITOR_BANKS];
     } banks;
 
-    Console*    console;
     World*      world;
-    Surf*       surf;
-
-    tic_net* net;
-
     Bytebattle bytebattle;
+#endif
 
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
+    Console*    console;
+#endif
+
+#if defined(BUILD_SURF)
+    Surf*       surf;
+    tic_net* net;
 #endif
 
     Start*      start;
@@ -1208,7 +1219,7 @@ void drawBitIcon(Studio* studio, s32 id, s32 x, s32 y, u8 color)
 static void initRunMode(Studio* studio)
 {
     initRun(studio->run,
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
         studio->console,
 #else
         NULL,
@@ -1222,6 +1233,13 @@ static void initWorldMap(Studio* studio)
     initWorld(studio->world, studio, studio->banks.map[studio->bank.index.map]);
 }
 
+void gotoCode(Studio* studio)
+{
+    setStudioMode(studio, TIC_CODE_MODE);
+}
+#endif
+
+#if defined(BUILD_SURF)
 static void initSurfMode(Studio* studio)
 {
     initSurf(studio->surf, studio, studio->console);
@@ -1232,12 +1250,6 @@ void gotoSurf(Studio* studio)
     initSurfMode(studio);
     setStudioMode(studio, TIC_SURF_MODE);
 }
-
-void gotoCode(Studio* studio)
-{
-    setStudioMode(studio, TIC_CODE_MODE);
-}
-
 #endif
 
 void setStudioMode(Studio* studio, EditorMode mode)
@@ -1261,31 +1273,39 @@ void setStudioMode(Studio* studio, EditorMode mode)
         default: studio->prevMode = prev; break;
         }
 
-#if defined(BUILD_EDITORS)
-        switch(mode)
-        {
-        case TIC_RUN_MODE: initRunMode(studio); break;
-        case TIC_CONSOLE_MODE:
-            if (prev == TIC_SURF_MODE)
-                studio->console->done(studio->console);
-            break;
-        case TIC_WORLD_MODE: initWorldMap(studio); break;
-        case TIC_SURF_MODE: studio->surf->resume(studio->surf); break;
-        default: break;
-        }
-
-        studio->mode = mode;
-#else
+#if !defined(BUILD_EDITORS)
         switch (mode)
         {
         case TIC_START_MODE:
         case TIC_MENU_MODE:
-            studio->mode = mode;
+#if defined(BUILD_SURF)
+        case TIC_SURF_MODE:
+#endif
+        case TIC_RUN_MODE:
             break;
         default:
-            studio->mode = TIC_RUN_MODE;
+            mode = TIC_RUN_MODE;
+            break;
         }
 #endif
+
+        switch(mode)
+        {
+        case TIC_RUN_MODE:      initRunMode(studio); break;
+#if defined(BUILD_EDITORS)
+        case TIC_CONSOLE_MODE:
+            if (prev == TIC_SURF_MODE)
+                studio->console->done(studio->console);
+            break;
+        case TIC_WORLD_MODE:    initWorldMap(studio); break;
+#endif
+#if defined(BUILD_SURF)
+        case TIC_SURF_MODE:     studio->surf->resume(studio->surf); break;
+#endif
+        default: break;
+        }
+
+        studio->mode = mode;
     }
 
 #if defined(BUILD_EDITORS)
@@ -1400,7 +1420,7 @@ void setCursor(Studio* studio, tic_cursor id)
     }
 }
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
 
 typedef struct
 {
@@ -1471,13 +1491,16 @@ void confirmDialog(Studio* studio, const char** text, s32 rows, ConfirmCallback 
     }
 }
 
+#if defined(BUILD_EDITORS)
 static void resetBanks(Studio* studio)
 {
     memset(studio->bank.indexes, 0, sizeof studio->bank.indexes);
 }
+#endif
 
 static void initModules(Studio* studio)
 {
+#if defined(BUILD_EDITORS)
     tic_mem* tic = studio->tic;
 
     resetBanks(studio);
@@ -1493,6 +1516,7 @@ static void initModules(Studio* studio)
     }
 
     initWorldMap(studio);
+#endif
 }
 
 static void updateHash(Studio* studio)
@@ -1510,7 +1534,7 @@ static void updateTitle(Studio* studio)
 {
     char name[TICNAME_MAX] = TIC_TITLE;
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
     if(strlen(studio->console->rom.name))
         snprintf(name, TICNAME_MAX, "%s [%s]", TIC_TITLE, studio->console->rom.name);
 #endif
@@ -1518,7 +1542,7 @@ static void updateTitle(Studio* studio)
     tic_sys_title(name);
 }
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
 
 bool project_ext(const char* name)
 {
@@ -1592,7 +1616,7 @@ void runGame(Studio* studio)
 
         setStudioMode(studio, TIC_RUN_MODE);
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_SURF)
         if(studio->mode == TIC_SURF_MODE)
             studio->prevMode = TIC_SURF_MODE;
 #endif
@@ -1985,7 +2009,11 @@ static void processShortcuts(Studio* studio)
             switch(studio->mode)
             {
             case TIC_MENU_MODE: studio_menu_back(studio->menu); break;
-            case TIC_RUN_MODE: gotoMenu(studio); break;
+            case TIC_RUN_MODE:
+#if defined(BUILD_SURF)
+            case TIC_SURF_MODE:
+#endif
+                gotoMenu(studio); break;
             default: break;
             }
         }
@@ -2188,6 +2216,8 @@ static void renderStudio(Studio* studio)
         break;
 
     case TIC_WORLD_MODE:    studio->world->tick(studio->world); break;
+#endif
+#if defined(BUILD_SURF)
     case TIC_SURF_MODE:     studio->surf->tick(studio->surf); break;
 #endif
     default: break;
@@ -2444,6 +2474,8 @@ void studio_tick(Studio* studio, tic80_input input)
 #if defined(BUILD_EDITORS)
     processAnim(studio->anim.movie, studio);
     checkChanges(studio);
+#endif
+#if defined(BUILD_SURF)
     tic_net_start(studio->net);
 #endif
 
@@ -2470,6 +2502,8 @@ void studio_tick(Studio* studio, tic80_input input)
             [TIC_SPRITE_MODE]   = {sprite->scanline,        NULL, NULL, sprite},
             [TIC_MAP_MODE]      = {map->scanline,           NULL, NULL, map},
             [TIC_WORLD_MODE]    = {studio->world->scanline,    NULL, NULL, studio->world},
+#endif
+#if defined(BUILD_SURF)
             [TIC_SURF_MODE]     = {studio->surf->scanline,     NULL, NULL, studio->surf},
 #endif
         };
@@ -2494,8 +2528,10 @@ void studio_tick(Studio* studio, tic80_input input)
 #endif
     }
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_SURF)
     tic_net_end(studio->net);
+#endif
+#if defined(BUILD_EDITORS)
 
     {
         Bytebattle* bb = &(studio->bytebattle);
@@ -2545,15 +2581,17 @@ void studio_sound(Studio* studio)
     }
 }
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
 static void onStudioLoadConfirmed(Studio* studio, bool yes, void* data)
 {
     if(yes)
     {
         const char* file = data;
+#if defined(BUILD_EDITORS)
         showPopupMessage(studio, studio->console->loadCart(studio->console, file)
             ? "cart successfully loaded :)"
             : "error: cart not loaded :(");
+#endif
     }
 }
 
@@ -2573,7 +2611,7 @@ void confirmLoadCart(Studio* studio, ConfirmCallback callback, void* data)
 
 void studio_load(Studio* studio, const char* file)
 {
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
     studioCartChanged(studio)
         ? confirmLoadCart(studio, onStudioLoadConfirmed, (void*)file)
         : onStudioLoadConfirmed(studio, true, (void*)file);
@@ -2607,12 +2645,15 @@ void studio_delete(Studio* studio)
         freeCode    (studio->code);
         freeConsole (studio->console);
         freeWorld   (studio->world);
-        freeSurf    (studio->surf);
 
         FREE(studio->anim.show.items);
         FREE(studio->anim.hide.items);
 
 #endif
+#if defined(BUILD_SURF)
+        freeSurf    (studio->surf);
+#endif
+
 
         freeStart   (studio->start);
         freeRun     (studio->run);
@@ -2624,8 +2665,10 @@ void studio_delete(Studio* studio)
 
     tic_core_close(studio->tic);
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_SURF)
     tic_net_close(studio->net);
+#endif
+#if defined(BUILD_EDITORS)
     free(studio->video.buffer);
     if(studio->bytebattle.exp) free(studio->bytebattle.exp);
     if(studio->bytebattle.imp) free(studio->bytebattle.imp);
@@ -2776,6 +2819,10 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
 
 #if defined(BUILD_EDITORS)
         .menuMode = TIC_CONSOLE_MODE,
+#elif defined(BUILD_SURF)
+        .menuMode = TIC_RUN_MODE,
+#endif
+#if defined(BUILD_EDITORS)
 
         .bank =
         {
@@ -2800,10 +2847,14 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
         {
             .text = "\0",
         },
-
+#endif
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
         .samplerate = samplerate,
+#endif
+#if defined(BUILD_SURF)
         .net = tic_net_create(TIC_WEBSITE),
-
+#endif
+#if defined(BUILD_EDITORS)
         .bytebattle = {0},
 #endif
         .tic = tic_core_create(samplerate, format),
@@ -2815,7 +2866,7 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
         if (fs_isdir(path))
         {
             studio->fs = tic_fs_create(path,
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_SURF)
                 studio->net
 #else
                 NULL
@@ -2841,9 +2892,7 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
         }
 
         studio->code       = calloc(1, sizeof(Code));
-        studio->console    = calloc(1, sizeof(Console));
         studio->world      = calloc(1, sizeof(World));
-        studio->surf       = calloc(1, sizeof(Surf));
 
         studio->anim.show = (Movie)MOVIE_DEF(STUDIO_ANIM_TIME, setPopupWait,
         {
@@ -2857,6 +2906,14 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
         });
 
         studio->anim.movie = resetMovie(&studio->anim.idle);
+#endif
+
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
+        studio->console    = calloc(1, sizeof(Console));
+#endif
+
+#if defined(BUILD_SURF)
+        studio->surf       = calloc(1, sizeof(Surf));
 #endif
 
         studio->start      = calloc(1, sizeof(Start));
@@ -2879,9 +2936,13 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
     initStart(studio->start, studio, args.cart);
     initRunMode(studio);
 
-#if defined(BUILD_EDITORS)
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
     initConsole(studio->console, studio, studio->fs, studio->net, studio->config, args);
+#endif
+#if defined(BUILD_SURF)
     initSurfMode(studio);
+#endif
+#if defined(BUILD_EDITORS)
     initModules(studio);
 #endif
 

--- a/src/studio/studio.h
+++ b/src/studio/studio.h
@@ -262,6 +262,7 @@ void confirmLoadCart(Studio* studio, ConfirmCallback callback, void* data);
 
 bool studioCartChanged(Studio* studio);
 void playSystemSfx(Studio* studio, s32 id);
+bool studio_is_cart_loaded(Studio* studio);
 
 void gotoMenu(Studio* studio);
 void gotoCode(Studio* studio);


### PR DESCRIPTION
I'm trying to make TIC-80 a bit more friendly on handhelds.

For handhelds, I don't need all that is provided by BUILD_EDITORS, but I still want the SURF. So I tried to separate those options as much as I could. To prevent problems when trying to decouple it, I have set:
```cmake
if(BUILD_EDITORS)
    set(BUILD_SURF ON)
endif()
```
So BUILD_SURF is kind of an essential part of BUILD_EDITORS.

The trickiest problem is that `surf.c` is quite dependent on `console.c`, for that I just asked for help with the Antigravity AI editor, and its suggestion was to create `console_minimal.c`, Idk what you will think of that. In my opinion this is not ideal but it gets the job done, haha.

After succeeding, I just fixed up the menu.