### PR TITLE
Fixes libretro NSwitch build

### DIFF
--- a/cmake/nswitch.cmake
+++ b/cmake/nswitch.cmake
@@ -10,23 +10,25 @@ if(NINTENDO_SWITCH)
             PRIVATE ${TIC80LIB_DIR}/studio)
     endif()
 
-    target_sources(${TIC80_TARGET} PRIVATE
-        src/system/nswitch/runtime.c)
-
-    find_package(PkgConfig)
-    pkg_search_module(CURL libcurl IMPORTED_TARGET)
-    target_link_libraries(tic80 PkgConfig::CURL)
-
-    nx_generate_nacp(tic80.nacp
-        NAME    "TIC-80 tiny computer"
-        AUTHOR  "Nesbox, carstene1ns"
-        VERSION ${PROJECT_VERSION})
-
-    nx_create_nro(${TIC80_TARGET}
-        NACP   tic80.nacp
-        ICON   ${CMAKE_SOURCE_DIR}/build/nswitch/icon.jpg
-        #ROMFS  ${CMAKE_SOURCE_DIR}/build/nswitch/romfs
-        OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tic80.nro)
-
-    dkp_target_generate_symbol_list(${TIC80_TARGET})
+    if(NOT ${BUILD_LIBRETRO})
+        target_sources(${TIC80_TARGET} PRIVATE
+            src/system/nswitch/runtime.c)
+    
+        find_package(PkgConfig)
+        pkg_search_module(CURL libcurl IMPORTED_TARGET)
+        target_link_libraries(tic80 PkgConfig::CURL)
+    
+        nx_generate_nacp(tic80.nacp
+            NAME    "TIC-80 tiny computer"
+            AUTHOR  "Nesbox, carstene1ns"
+            VERSION ${PROJECT_VERSION})
+    
+        nx_create_nro(${TIC80_TARGET}
+            NACP   tic80.nacp
+            ICON   ${CMAKE_SOURCE_DIR}/build/nswitch/icon.jpg
+            #ROMFS  ${CMAKE_SOURCE_DIR}/build/nswitch/romfs
+            OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tic80.nro)
+    
+        dkp_target_generate_symbol_list(${TIC80_TARGET})
+    endif()
 endif()


### PR DESCRIPTION
Trying to fix the libretro build, main thread at: https://github.com/libretro/TIC-80/pull/28

by making this change, I was able to compile using this dockerfile:

```dockerfile
FROM git.libretro.com:5050/libretro-infrastructure/libretro-build-libnx-devkitpro:v4-10-0

USER root

WORKDIR /wrk

#RUN git clone --recursive https://github.com/nesbox/TIC-80.git core
COPY . core

WORKDIR /wrk/core

RUN git submodule update --init --recursive

ENV CORENAME=tic80
ENV BUILD_DIR=build/libnx
ENV EXTRA_PATH=bin
ENV CMAKE_SOURCE_ROOT=.

ENV CORE_ARGS="-DBUILD_LIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_PLAYER=OFF -DBUILD_PRO=OFF -DBUILD_SDL=OFF -DBUILD_TOOLS=OFF -DBUILD_TOUCH_INPUT=OFF -DBUILD_STATIC=ON  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_WITH_RUBY=OFF -DBUILD_WITH_SCHEME=OFF -DBUILD_WITH_ALL=OFF"


RUN cmake $CORE_ARGS "$CMAKE_SOURCE_ROOT" -B$BUILD_DIR -DCMAKE_BUILD_TYPE=Release -DLIBRETRO_STATIC=ON -DLIBRETRO_SUFFIX=_libnx -DCMAKE_TOOLCHAIN_FILE=/opt/devkitpro/cmake/Switch.cmake -DNSWITCH=ON -DCFLAGS=-DHAVE_LIBNX=1 -DCXXFLAGS=-DHAVE_LIBNX=1

RUN cmake --build $BUILD_DIR --target ${CORENAME}_libretro --config Release -- -j $(nproc)

CMD ["/bin/bash"]
```