### PR TITLE
Add POOR_CLIB condition for quickjs build

### DIFF
--- a/cmake/quickjs.cmake
+++ b/cmake/quickjs.cmake
@@ -49,7 +49,7 @@ if(BUILD_WITH_JS)
         target_compile_definitions(quickjs PRIVATE DUMP_LEAKS)
     endif()
 
-    if(BAREMETALPI OR NINTENDO_3DS OR NINTENDO_SWITCH)
+    if(BAREMETALPI OR NINTENDO_3DS OR NINTENDO_SWITCH OR POOR_CLIB)
         target_compile_definitions(quickjs PRIVATE POOR_CLIB)
     endif()
 


### PR DESCRIPTION
I'm trying to help update the libretro build pipelines https://github.com/libretro/TIC-80/pull/28

And when trying to build with JS support, by default it tries to use multi-thread pthread. Some devices doesn't support it.

I thought to add each device on the list, but this may cause other problems when trying to distinguish between standalone version vs libretro version.

so I thought just to allow to use `cmake -DPOOR_CLIB`.
