### PR TITLE
docs: clarify map remap callback behavior across language bindings

### DIFF
--- a/demos/jsdemo.js
+++ b/demos/jsdemo.js
@@ -10,6 +10,8 @@ var t=0
 var x=96
 var y=24
 
+// map() remap callback in JavaScript receives (tile,x,y) and returns tile or [tile,flip,rotate].
+
 function TIC()
 {
 	if(btn(0))y--

--- a/demos/luademo.lua
+++ b/demos/luademo.lua
@@ -10,6 +10,8 @@ t=0
 x=96
 y=24
 
+-- map() remap callback in Lua receives (tile,x,y) and returns tile,flip,rotate.
+
 function TIC()
 
 	if btn(0) then y=y-1 end

--- a/demos/pythondemo.py
+++ b/demos/pythondemo.py
@@ -10,6 +10,8 @@ t=0
 x=96
 y=24
 
+# map() remap callback in Python (PocketPy) receives (x,y) and returns (tile,flip,rotate).
+
 def TIC():
  global t
  global x
@@ -59,4 +61,3 @@ def TIC():
 # <PALETTE>
 # 000:1a1c2c5d275db13e53ef7d57ffcd75a7f07038b76425717929366f3b5dc941a6f673eff7f4f4f494b0c2566c86333c57
 # </PALETTE>
-

--- a/src/api.h
+++ b/src/api.h
@@ -324,6 +324,16 @@ enum
         "animated tiles or replace them completely.\n"                                                                  \
         "Some examples include changing sprites to open doorways, "                                                     \
         "hiding sprites used to spawn objects in your game and even to emit the objects themselves.\n"                  \
+        "Remap callback behavior is binding specific.\n"                                                                \
+        "Lua, Fennel, Moon and Yue call remap(tile,x,y) and expect tile,flip,rotate as return values.\n"               \
+        "JavaScript calls remap(tile,x,y) and accepts tile or [tile,flip,rotate].\n"                                   \
+        "Python (PocketPy) calls remap(x,y) and expects a tuple (tile,flip,rotate).\n"                                 \
+        "Ruby (mruby) calls remap(tile,x,y) and accepts tile or [tile,flip,rotate].\n"                                 \
+        "Janet calls remap(tile,x,y) and accepts tile or an indexed collection with tile,flip,rotate.\n"               \
+        "Scheme calls remap(tile,x,y) and expects a list with tile,flip,rotate.\n"                                     \
+        "Squirrel calls remap(tile,x,y) and reads tile,flip,rotate from an indexed return object.\n"                   \
+        "Wren calls remap(tile,x,y) and accepts tile or [tile,flip,rotate].\n"                                         \
+        "WASM uses a low-level callback that updates the RemapResult structure in place.\n"                             \
         "The tilemap is laid out sequentially in RAM - writing 1 to 0x08000 "                                           \
         "will cause tile(sprite) #1 to appear at top left when map() is called.\n"                                      \
         "To set the tile immediately below this we need to write to 0x08000 + 240, ie 0x080F0.",                        \


### PR DESCRIPTION
> [!NOTE]
> I'm new to the project and just want to help fixing a few issues from the [v1.2 project](https://github.com/users/nesbox/projects/2) that _looked_ approachable. If you'd prefer batching these changes, discussing them in the issue first or anything else, let me know. 🙏

## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2478

`map(..., remap=...)` does not behave the same way across language bindings, and this was not clearly documented. This caused confusion, especially between Lua, JavaScript, and PocketPy/Python callback signatures and return conventions.

## What

- Documented binding-specific `remap` behavior in the canonical `help map` documentation (`src/api.h`).  (too verbose maybe?)
- Added concise language-specific reminders in `demos/luademo.lua`, `demos/jsdemo.js`, and `demos/pythondemo.py`.

## Impact

Documentation clarity is improved for contributors and users across supported script bindings. No runtime behavior was changed.