### PR TITLE
Fix music editor hex input with Caps Lock on

### DIFF
--- a/src/studio/editors/music.c
+++ b/src/studio/editors/music.c
@@ -928,7 +928,8 @@ static s32 sym2dec(char sym)
 static s32 sym2hex(char sym)
 {
     s32 val = sym2dec(sym);
-    if (sym >= 'a' && sym <= 'f') val = sym - 'a' + 10;
+    sym = toupper((unsigned char)sym);
+    if(sym >= 'A' && sym <= 'F') val = sym - 'A' + 10;
 
     return val;
 }


### PR DESCRIPTION
### Why

Original issue: https://github.com/nesbox/TIC-80/issues/2480

With Caps Lock enabled, typing `A-F` in music editor hex fields was ignored.  
Issue: #2480.

### What
- Updated hex conversion in `src/studio/editors/music.c` (`sym2hex`) to accept both lowercase and uppercase hex letters.

### Impact
- Tracker and Piano hex parameter input now accepts `A-F` when Caps Lock is on.
- No intended behavior change for decimal input or non-hex keys.