### PR TITLE
[Fix] [Android] prevent extra character insertion on Ctrl shortcuts

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -409,10 +409,15 @@ void sfx_stop(tic_mem* tic, s32 channel)
 
 char getKeyboardText(Studio* studio)
 {
+    tic_mem* tic = studio->tic;
+
+    // Ctrl-based shortcuts should not also inject printable characters.
+    if(tic_api_key(tic, tic_key_ctrl) && !tic_api_key(tic, tic_key_alt))
+        return '\0';
+
     char text;
     if(!tic_sys_keyboard_text(&text))
     {
-        tic_mem* tic = studio->tic;
         tic80_input* input = &tic->ram->input;
 
 #ifdef KEYBOARD_LAYOUT_ES


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2439

On Android, pressing `Ctrl+S` saves but also inserts an unwanted `s` in editor text (`#2439`).

## What

- Added a guard in `getKeyboardText` (`src/studio/studio.c`) to prevent printable character injection when `Ctrl` is pressed without `Alt`.
- Kept the fix at studio/input layer so behavior is consistent across editor surfaces using shared text-entry flow.
- Verified build: `cmake --build /tmp/tic80-plan-check --target tic80 --parallel 4`.

**Open question for reviewers:**
Should we keep this as `Ctrl && !Alt` only, or block printable text for all `Ctrl` combinations (including `Ctrl+Alt`)?

## Impact

- Fixes `Ctrl+S` adding extra `s` while keeping shortcut behavior.
- May affect other `Ctrl+<key>` combos by preventing accidental printable character insertion (intended).