### PR TITLE
 [Fix] [Android] restore external keyboard arrow keys by tightening joystick classification

### DIFF
--- a/build/android/app/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/build/android/app/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -102,6 +102,13 @@ public class SDLControllerManager
         }
         int sources = device.getSources();
 
+        // Some external keyboards report DPAD source for arrow keys.
+        // Keep alphabetic keyboards in the keyboard path to avoid swallowing arrows as pad input.
+        if ((sources & InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD &&
+            device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+            return false;
+        }
+
         /* This is called for every button press, so let's not spam the logs */
         /*
         if ((sources & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2292

External/Bluetooth keyboards on Android can expose both keyboard and DPAD sources. In that case, arrow keys may be routed through joystick handling and not behave as keyboard arrows in TIC-80.

## What

Added a guard in `SDLControllerManager.isDeviceSDLJoystick` to return `false` for alphabetic keyboards (`SOURCE_KEYBOARD` + `KEYBOARD_TYPE_ALPHABETIC`), so they stay on the keyboard path.

**Open question for reviewers:**
Do we want to keep non-alphabetic DPAD-capable devices classified as joystick by default, or add stricter filtering now?

## Impact

Low-risk Android input routing change, scoped to keyboard-vs-joystick classification. Real gamepad joystick-first behavior remains unchanged.