### PR TITLE
[Fix] [Music] Route note preview to the active editor channel

### DIFF
--- a/src/studio/editors/music.c
+++ b/src/studio/editors/music.c
@@ -497,7 +497,9 @@ static void playNote(Music* music, const tic_track_row* row)
 
     if(getMusicState(music) == tic_music_stop && row->note >= NoteStart)
     {
-        s32 channel = music->piano.col;
+        s32 channel = music->tab == MUSIC_TRACKER_TAB
+            ? music->tracker.edit.x / CHANNEL_COLS
+            : music->piano.col;
         sfx_stop(tic, channel);
         tic_api_sfx(tic, tic_tool_get_track_row_sfx(row), row->note - NoteStart, row->octave, TIC80_FRAMERATE / 4, channel, MAX_VOLUME, MAX_VOLUME, 0);
     }


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2437

Note preview in the music editor could play on a different channel than the one targeted by the current editing context.

## What

- Update `playNote()` in `src/studio/editors/music.c`.
- Tracker tab: preview uses the tracker-selected channel.
- Piano tab: preview continues to use `piano.col`.

## Impact

- Fixes channel mismatch during note preview in the music editor.
- No behavior change outside preview routing.

**Reviewer question**: do we explicitly want tab-based routing (`Tracker → tracker channel`, `Piano → piano channel`) as the intended long-term behavior?