### PR TITLE
[Fix] [SDL] Reset keyboard state on focus loss to avoid stuck keys

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1082,6 +1082,19 @@ static void handleKeydown(SDL_Keycode keycode, bool down, bool* state, bool* pre
 #endif
 }
 
+static void resetKeyboardStateOnFocusLoss()
+{
+    // Workaround for #2614: clear stuck keys when KEYUP is missed during window grab/focus loss.
+    ZEROMEM(platform.keyboard.state);
+    ZEROMEM(platform.keyboard.pressed);
+    platform.keyboard.text = '\0';
+    SDL_SetModState(KMOD_NONE);
+
+#if defined(TOUCH_INPUT_SUPPORT)
+    ZEROMEM(platform.keyboard.touch.state);
+#endif
+}
+
 tic_layout detect_keyboard_layout()
 {
     char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
@@ -1207,6 +1220,9 @@ static void pollEvents()
                     updateGamepadParts();
 #endif
                 }
+                break;
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                resetKeyboardStateOnFocusLoss();
                 break;
 #if defined(__LINUX__)
             case SDL_WINDOWEVENT_FOCUS_GAINED:


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2614

Keys can remain logically pressed if `SDL_KEYUP` is missed during window focus/grab transitions.

## What

- Add `resetKeyboardStateOnFocusLoss()` in `src/system/sdl/main.c`.
- Clear keyboard and SDL modifier state on `SDL_WINDOWEVENT_FOCUS_LOST`.
- Keep existing Linux focus-gain input lock behavior unchanged.

## Impact

- Prevents stuck keys after losing window focus.
- No change to normal in-focus input handling.

**Reviewer question**: should the reset stay limited to `FOCUS_LOST`, or also trigger on other window events (e.g. move/resize)?