### PR TITLE
[Fix] [Code] align mouse cursor mapping with tab width

### DIFF
--- a/src/studio/editors/code.c
+++ b/src/studio/editors/code.c
@@ -814,6 +814,51 @@ static s32 getLineSize(const char* line)
     return size;
 }
 
+static s32 getTabColumnWidth(Code* code, s32 column)
+{
+    s32 tabSize = getConfig(code->studio)->options.tabSize;
+    if(tabSize <= 0) tabSize = 1;
+
+    return tabSize - column % tabSize;
+}
+
+static char* getVisualPosByLine(Code* code, char* line, s32 column)
+{
+    if(column <= 0) return line;
+
+    s32 visual = 0;
+    char* ptr = line;
+
+    while(*ptr && *ptr != '\n')
+    {
+        if(*ptr == '\t')
+        {
+            s32 width = getTabColumnWidth(code, visual);
+
+            if(column < visual + width)
+            {
+                s32 left = column - visual;
+                s32 right = visual + width - column;
+
+                return right <= left ? ptr + 1 : ptr;
+            }
+
+            visual += width;
+            ptr++;
+
+            continue;
+        }
+
+        if(column == visual)
+            return ptr;
+
+        visual++;
+        ptr++;
+    }
+
+    return ptr;
+}
+
 static void updateColumn(Code* code)
 {
     code->cursor.column = (s32)(code->cursor.position - getLine(code));
@@ -824,6 +869,12 @@ static void updateCursorPosition(Code* code, char* position)
     code->cursor.position = position;
     updateColumn(code);
     updateEditor(code);
+}
+
+static void setCursorPositionVisual(Code* code, s32 cx, s32 cy)
+{
+    char* line = getPosByLine(code->src, cy);
+    updateCursorPosition(code, getVisualPosByLine(code, line, cx));
 }
 
 static void setCursorPosition(Code* code, s32 cx, s32 cy)
@@ -3140,7 +3191,7 @@ static void processMouse(Code* code)
                     s32 y = (my - rect.y) / STUDIO_TEXT_HEIGHT;
 
                     char* position = code->cursor.position;
-                    setCursorPosition(code, x + code->scroll.x, y + code->scroll.y);
+                    setCursorPositionVisual(code, x + code->scroll.x, y + code->scroll.y);
 
                     if(tic_api_key(tic, tic_key_shift))
                     {


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2330

Mouse cursor placement in the code editor is misaligned when `tabSize > 1` because tab expansion was not considered.

## What

- Add tab-aware visual column mapping in `src/studio/editors/code.c`.
- Add a mouse-specific cursor placement path (`setCursorPositionVisual(...)`).
- Use this mapping for mouse click/drag handling.
- Keep keyboard cursor logic unchanged.

## Impact

- Mouse placement and selection now align with rendered tab width when `tabSize > 1`.
- Keyboard behavior remains unchanged.

**Reviewer question**: when clicking inside a tab visual span, should the tie-breaking stay biased to the right boundary (current behavior) or switch to the left?