### PR TITLE
[Fix] [macOS] correct horizontal scroll direction

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -2296,7 +2296,9 @@ static void processMouseStates(Studio* studio)
 
         state->dbl.ticks++;
     }
+#if !defined(__TIC_MACOSX__)
     tic->ram->input.mouse.scrollx *= -1;
+#endif
 }
 
 #if defined(BUILD_EDITORS)


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2855

Horizontal trackpad scrolling is inverted on macOS while vertical scrolling is already consistent.

## What

- Scoped `scrollx` inversion in `src/studio/studio.c` so it is not applied on macOS.
- Kept behavior unchanged on non-macOS platforms.

## Impact

- macOS horizontal scroll direction now follows expected OS behavior.
- No intended behavior change on non-macOS builds.