### PR TITLE
Baremetal build fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,6 +242,9 @@ jobs:
           cd baremetalpi
           make -j$(nproc)
           cd ../../vendor/circle-stdlib/libs/circle/boot/
+          sed -i \
+            -e 's|https://github.com/raspberrypi/firmware/blob/$(FIRMWARE)/boot|https://raw.githubusercontent.com/raspberrypi/firmware/$(FIRMWARE)/boot|' \
+            -e 's/?raw=true//' Makefile
           make -j$(nproc)
 
       - name: Pack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,6 +306,9 @@ jobs:
           cd baremetalpi
           make -j$(nproc)
           cd ../../vendor/circle-stdlib/libs/circle/boot/
+          sed -i \
+            -e 's|https://github.com/raspberrypi/firmware/blob/$(FIRMWARE)/boot|https://raw.githubusercontent.com/raspberrypi/firmware/$(FIRMWARE)/boot|' \
+            -e 's/?raw=true//' Makefile
           make -j$(nproc)
 
       - name: Pack


### PR DESCRIPTION
```
make[1]: Leaving directory '/__w/TIC-80/TIC-80/vendor/circle-stdlib/libs/circle/boot/armstub'
Downloading LICENCE.broadcom ...
Downloading COPYING.linux ...
Downloading bootcode.bin ...
Downloading start.elf ...
Downloading fixup.dat ...
Downloading start4.elf ...
Downloading fixup4.dat ...
Downloading start_cd.elf ...
Downloading fixup_cd.dat ...
Downloading start4cd.elf ...
Downloading fixup4cd.dat ...
Downloading bcm2710-rpi-zero-2-w.dtb ...
Downloading bcm2711-rpi-4-b.dtb ...
Downloading bcm2711-rpi-400.dtb ...
Downloading bcm2711-rpi-cm4.dtb ...
Downloading bcm2712-rpi-5-b.dtb ...
make: *** [Makefile:29: firmware] Error 8
```

Baremetal basically fails on this `vendor/circle-stdlib/libs/circle/boot/Makefile`:
```Makefile
# Use firmware revision built/committed on: Feb 29 2024
FIRMWARE ?= dc94391863445ab867782d25ca6ae1e88579df5d

BASEURL = https://github.com/raspberrypi/firmware/blob/$(FIRMWARE)/boot

FILES = LICENCE.broadcom COPYING.linux \
        bootcode.bin start.elf fixup.dat start4.elf fixup4.dat \
        start_cd.elf fixup_cd.dat start4cd.elf fixup4cd.dat \
        bcm2710-rpi-zero-2-w.dtb bcm2711-rpi-4-b.dtb bcm2711-rpi-400.dtb bcm2711-rpi-cm4.dtb \
        bcm2712-rpi-5-b.dtb

FILES32 = armstub7-rpi4.bin kernel.img kernel7.img kernel7l.img
FILES64 = armstub8-rpi4.bin kernel8.img kernel8-rpi4.img kernel_2712.img

firmware: clean
        @for file in $(FILES) ; \
        do \
                echo Downloading $$file ... ; \
                wget -q -O $$file $(BASEURL)/$$file?raw=true ; \
        done
```

For some reason it seems github is deprecating the old url for raw data. so we change from:
`https://github.com/raspberrypi/firmware/blob/$(FIRMWARE)/boot/$(FILENAME)?raw=true`
to:
`https://raw.githubusercontent.com/raspberrypi/firmware/$(FIRMWARE)/boot/$(FILENAME)`
The first URL still works, but it seems that it has a redirect that doesn't work in some versions of wget.