### PR TITLE
Persist config across updates

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -764,7 +764,7 @@ static void loadCartSection(Console* console, const tic_cartridge* cart, const c
 
 static char* getDemoCartPath(char* path, const tic_script* script)
 {
-    strcpy(path, TIC_LOCAL_VERSION "default_");
+    strcpy(path, TIC_LOCAL "default_");
 
     if(script && script->name)
         strcat(path, script->name);

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -2942,7 +2942,6 @@ Studio* studio_create(s32 argc, char **argv, s32 samplerate, tic80_pixel_color_f
     }
     studio->mainmenu = NULL;
     tic_fs_makedir(studio->fs, TIC_LOCAL);
-    tic_fs_makedir(studio->fs, TIC_LOCAL_VERSION);
 
     initConfig(studio->config, studio, studio->fs);
 

--- a/src/studio/studio.h
+++ b/src/studio/studio.h
@@ -47,7 +47,6 @@
 #else
 #define TIC_LOCAL ".local/"
 #endif
-#define TIC_LOCAL_VERSION TIC_LOCAL TIC_VERSION_HASH "/"
 #define TIC_CACHE TIC_LOCAL "cache/"
 
 #define TOOLBAR_SIZE 7
@@ -61,7 +60,7 @@
 #define TIC_COLOR_BG tic_color_black
 
 #define CONFIG_TIC "config.tic"
-#define CONFIG_TIC_PATH TIC_LOCAL_VERSION CONFIG_TIC
+#define CONFIG_TIC_PATH TIC_LOCAL CONFIG_TIC
 
 #define CART_EXT ".tic"
 #define PNG_EXT ".png"


### PR DESCRIPTION
This closes #2531.

I understand that this was probably done in a way to avoid breaking changes between versions, but this also seems to be a source of complain of what the default settings should be, specially regarding if the ESC key should go to the menu or console.