### PR TITLE
Fix saving config in web version (wasm)

### DIFF
--- a/src/studio/config.c
+++ b/src/studio/config.c
@@ -140,7 +140,7 @@ static void reset(Config* config)
     saveConfig(config, true);
 }
 
-static void save(Config* config)
+static void saveConfigCart(Config* config)
 {
     *config->cart = config->tic->cart;
     readConfig(config);
@@ -199,7 +199,8 @@ void initConfig(Config* config, Studio* studio, tic_fs* fs)
         .studio = studio,
         .tic = getMemory(studio),
         .cart = realloc(config->cart, sizeof(tic_cartridge)),
-        .save = save,
+        .saveConfigCart = saveConfigCart,
+        .saveOptions = saveOptions,
         .reset = reset,
         .fs = fs,
     };

--- a/src/studio/config.c
+++ b/src/studio/config.c
@@ -192,45 +192,6 @@ static void loadOptions(Config* config)
     }
 }
 
-void initConfig(Config* config, Studio* studio, tic_fs* fs)
-{
-    *config = (Config)
-    {
-        .studio = studio,
-        .tic = getMemory(studio),
-        .cart = realloc(config->cart, sizeof(tic_cartridge)),
-        .saveConfigCart = saveConfigCart,
-        .saveOptions = saveOptions,
-        .reset = reset,
-        .fs = fs,
-    };
-
-    setDefault(config);
-
-    // read config.tic
-    {
-        s32 size = 0;
-        u8* data = (u8*)tic_fs_loadroot(fs, CONFIG_TIC_PATH, &size);
-
-        if(data)
-        {
-            update(config, data, size);
-
-            free(data);
-        }
-        else saveConfig(config, false);
-    }
-
-    loadOptions(config);
-
-#if defined(__TIC_LINUX__)
-    // do not load fullscreen option on Linux
-    config->data.options.fullscreen = false;
-#endif
-
-    tic_api_reset(config->tic);
-}
-
 static string data2str(const void* data, s32 size)
 {
     string res;
@@ -286,6 +247,45 @@ static void saveOptions(Config* config)
         );
 
     tic_fs_saveroot(config->fs, OptionsJsonPath, buf.data, strlen(buf.data), true);
+}
+
+void initConfig(Config* config, Studio* studio, tic_fs* fs)
+{
+    *config = (Config)
+    {
+        .studio = studio,
+        .tic = getMemory(studio),
+        .cart = realloc(config->cart, sizeof(tic_cartridge)),
+        .saveConfigCart = saveConfigCart,
+        .saveOptions = saveOptions,
+        .reset = reset,
+        .fs = fs,
+    };
+
+    setDefault(config);
+
+    // read config.tic
+    {
+        s32 size = 0;
+        u8* data = (u8*)tic_fs_loadroot(fs, CONFIG_TIC_PATH, &size);
+
+        if(data)
+        {
+            update(config, data, size);
+
+            free(data);
+        }
+        else saveConfig(config, false);
+    }
+
+    loadOptions(config);
+
+#if defined(__TIC_LINUX__)
+    // do not load fullscreen option on Linux
+    config->data.options.fullscreen = false;
+#endif
+
+    tic_api_reset(config->tic);
 }
 
 void freeConfig(Config* config)

--- a/src/studio/config.h
+++ b/src/studio/config.h
@@ -35,7 +35,8 @@ struct Config
     StudioConfig data;
     tic_cartridge* cart;
 
-    void(*save)(Config*);
+    void(*saveConfigCart)(Config*);
+    void(*saveOptions)(Config*);
     void(*reset)(Config*);
 };
 

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2493,7 +2493,7 @@ static CartSaveResult saveCartName(Console* console, const char* name)
         {
             if(strcmp(name, CONFIG_TIC_PATH) == 0)
             {
-                console->config->save(console->config);
+                console->config->saveConfigCart(console->config);
                 studioRomSaved(console->studio);
                 free(buffer);
                 return CART_SAVE_OK;

--- a/src/studio/screens/mainmenu.c
+++ b/src/studio/screens/mainmenu.c
@@ -441,15 +441,23 @@ static inline s32 mainMenuOffset(StudioMainMenu* menu)
     return 1;
 }
 
+static void saveConfig(StudioMainMenu* main)
+{
+    Config* config = studio_config_get(main->studio);
+    config->save(config);
+}
+
 static void onResumeGame(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
+    saveConfig(main);
     resumeGame(main->studio);
 }
 
 static void onResetGame(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
+    saveConfig(main);
     tic_api_reset(main->tic);
     setStudioMode(main->studio, TIC_RUN_MODE);
 }
@@ -457,18 +465,21 @@ static void onResetGame(void* data, s32 pos)
 static void onExitStudio(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
+    saveConfig(main);
     exitStudio(main->studio);
 }
 
 static void onExitGame(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
+    saveConfig(main);
     exitGame(main->studio);
 }
 
 static void onSurf(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
+    saveConfig(main);
     setStudioMode(main->studio, TIC_SURF_MODE);
 }
 

--- a/src/studio/screens/mainmenu.c
+++ b/src/studio/screens/mainmenu.c
@@ -444,7 +444,7 @@ static inline s32 mainMenuOffset(StudioMainMenu* menu)
 static void saveConfig(StudioMainMenu* main)
 {
     Config* config = studio_config_get(main->studio);
-    config->save(config);
+    config->saveOptions(config);
 }
 
 static void onResumeGame(void* data, s32 pos)

--- a/src/studio/screens/mainmenu.c
+++ b/src/studio/screens/mainmenu.c
@@ -50,6 +50,7 @@ struct StudioMainMenu
     .count = COUNT_OF(((const char*[])__VA_ARGS__))
 
 static void showMainMenu(void* data, s32 pos);
+static void onBackFromOptionsMenu(void* data, s32 pos);
 
 StudioMainMenu* studio_mainmenu_init(Menu *menu, Config *config)
 {
@@ -330,7 +331,7 @@ static const MenuItem OptionMenu[] =
 #endif
     {"SETUP GAMEPAD",       showGamepadMenu},
     {""},
-    {"BACK",            showMainMenu, .back = true},
+    {"BACK",            onBackFromOptionsMenu, .back = true},
 };
 
 static void showOptionsMenu(void* data, s32 pos);
@@ -441,23 +442,24 @@ static inline s32 mainMenuOffset(StudioMainMenu* menu)
     return 1;
 }
 
-static void saveConfig(StudioMainMenu* main)
+static void onBackFromOptionsMenu(void* data, s32 pos)
 {
+    StudioMainMenu* main = data;
     Config* config = studio_config_get(main->studio);
     config->saveOptions(config);
+
+    showMainMenu(data, pos);
 }
 
 static void onResumeGame(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
-    saveConfig(main);
     resumeGame(main->studio);
 }
 
 static void onResetGame(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
-    saveConfig(main);
     tic_api_reset(main->tic);
     setStudioMode(main->studio, TIC_RUN_MODE);
 }
@@ -465,21 +467,18 @@ static void onResetGame(void* data, s32 pos)
 static void onExitStudio(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
-    saveConfig(main);
     exitStudio(main->studio);
 }
 
 static void onExitGame(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
-    saveConfig(main);
     exitGame(main->studio);
 }
 
 static void onSurf(void* data, s32 pos)
 {
     StudioMainMenu* main = data;
-    saveConfig(main);
     setStudioMode(main->studio, TIC_SURF_MODE);
 }
 
@@ -529,7 +528,7 @@ static void showOptionsMenuPos(void* data, s32 pos)
     StudioMainMenu* main = data;
 
     s32 offset = mainMenuOffset(main);
-    studio_menu_init(main->menu, OptionMenu, COUNT_OF(OptionMenu), pos, MainMenu_Options - offset, showMainMenu, main);
+    studio_menu_init(main->menu, OptionMenu, COUNT_OF(OptionMenu), pos, MainMenu_Options - offset, onBackFromOptionsMenu, main);
 }
 
 static void showOptionsMenu(void* data, s32 pos)

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -711,6 +711,11 @@ const StudioConfig* getConfig(Studio* studio)
     return studio_config(studio);
 }
 
+Config* studio_config_get(Studio* studio)
+{
+    return studio->config;
+}
+
 struct Start* getStartScreen(Studio* studio)
 {
     return studio->start;

--- a/src/studio/studio.h
+++ b/src/studio/studio.h
@@ -284,7 +284,9 @@ bool enterWasPressed(Studio* studio);
 bool anyKeyWasPressed(Studio* studio);
 bool ticEnterWasPressed(tic_mem* tic, s32 hold, s32 period);
 
+typedef struct Config Config;
 const StudioConfig* getConfig(Studio* studio);
+Config* studio_config_get(Studio* studio);
 struct Start* getStartScreen(Studio* studio);
 struct Sprite* getSpriteEditor(Studio* studio);
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1878,10 +1878,14 @@ static void emsGpuTick()
 
     EM_ASM(
     {
-        if(FS.syncFSRequests == 0 && Module.syncFSRequests)
+        if(!Module.syncing && Module.syncFSRequests)
         {
+            Module.syncing = true;
             Module.syncFSRequests = 0;
-            FS.syncfs(false,function(){});
+            FS.syncfs(false, function()
+            {
+                Module.syncing = false;
+            });
         }
     });
 
@@ -2150,6 +2154,7 @@ s32 main(s32 argc, char **argv)
     (
         {
             Module.syncFSRequests = 0;
+            Module.syncing = false;
 
             var dir = UTF8ToString($0);
 


### PR DESCRIPTION
From what I could understand, the settings in the options menu were being saved on `freeConfig()`, called only by `studio_delete()`. I suspect this all happens when exiting the TIC80.

This was not being called in the web version. Even by going in the menu and Exit TIC80, it wasn't being saved. The way I was testing it was by checking the timestamp in the place shown in the screenshot bellow.

<img width="1336" height="389" alt="Screenshot from 2026-03-14 12-04-12" src="https://github.com/user-attachments/assets/2f56b9ad-34c0-4d8e-9416-3fe1d85e20ef" />

Gemini first suggested to do a change in `src/system/sdl/main.c`, that did not fix the issue, and I did not notice any change in saving behavior.

Then I mainly had to do some changes in the mainmenu.c, and I thought it would be a good idea to rename the (config.c)`save` to `saveConfigCart` so it would be a bit more descriptive and it would be a bit more distinctive than `saveOptions`.

Having that fixed, I started to wonder if I should have the initial changes in `src/system/sdl/main.c` kept or not.

Gemini initially game this explanation for that:
> The Emscripten logic in `src/system/sdl/main.c` was using an uninitialized internal variable `FS.syncFSRequests` to decide when to sync the in-memory filesystem to the browser's persistent storage (IDBFS). Since this variable was always undefined, the sync was never triggered, causing all changes (including settings) to be lost upon refreshing or closing the page.

Then I questioned it again using a clean context and I got:
> The changes the AI suggested are essentially a "guard" or "mutex" to prevent multiple filesystem sync operations from happening at the same time.
> 
> Should you keep it?
> Yes, you should keep it.
> 
> Even if it didn't solve your specific bug, the new version is technically more robust than the original. Here is why:
> 
> **Prevents Race Conditions**: `FS.syncfs` is asynchronous (it happens in the background). If your app requests a save, and then requests another save before the first one finishes, it can cause data corruption or browser errors in IndexedDB.
> **State Management**: The original code checked `FS.syncFSRequests == 0`, but `FS.syncFSRequests` is not a standard Emscripten property. It was likely a custom variable that wasn't being updated correctly. The new `Module.syncing` flag explicitly tracks the state.
> **Clean Callback**: The new version ensures that `Module.syncing` is set back to false only once the browser confirms the write is finished.

