### PR TITLE
Allows for '.' in lua outlines.

### DIFF
--- a/src/api/lua.c
+++ b/src/api/lua.c
@@ -99,7 +99,7 @@ static const tic_outline_item* getLuaOutline(const char* code, s32* size)
             {
                 char c = *ptr;
 
-                if(isalnum_(c) || c == ':');
+                if(isalnum_(c) || c == ':' || c == '.');
                 else if(c == '(')
                 {
                     end = ptr;


### PR DESCRIPTION
This allows to outline functions with valid dot notation.
<img width="519" height="253" alt="image" src="https://github.com/user-attachments/assets/e8a1f621-719e-49b7-b8e0-15bc02ca20a0" />
