### PR TITLE
[Fix] [Export] prefer local native template for same-platform export

### DIFF
--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2200,8 +2200,67 @@ static void exportGame(Console* console, const char* name, const char* system, n
     tic_net_get(console->net, url, callback, MOVE(data));
 }
 
+static bool canExportNativeFromLocalTemplate(const char* system)
+{
+#if defined(__TIC_WINDOWS__)
+    return strcmp(system, "win") == 0;
+#elif defined(__TIC_LINUX__)
+    return strcmp(system, "linux") == 0;
+#elif defined(__TIC_MACOSX__)
+    return strcmp(system, "mac") == 0;
+#else
+    return false;
+#endif
+}
+
+// Same-platform native export prefers the local executable template.
+// If the local template is not applicable or unavailable, caller falls back to server export.
+static bool tryExportNativeFromLocalTemplate(Console* console, const char* name, const char* system)
+{
+    if(!canExportNativeFromLocalTemplate(system))
+        return false;
+
+    const char* appPath = fs_apppath();
+
+    if(!appPath)
+        return false;
+
+    s32 appSize = 0;
+    u8* app = fs_read(appPath, &appSize);
+
+    if(!app || appSize <= 0)
+        return false;
+
+    if(app) SCOPE(free(app))
+    {
+        s32 size = appSize;
+        void* buf = embedCart(console, app, &size);
+
+        printLine(console);
+        printBack(console, "\nusing local native template...");
+
+        const char* path = tic_fs_path(console->fs, name);
+        bool success = buf && fs_write(path, buf, size);
+
+        if(success)
+            chmod(path, DEFAULT_CHMOD);
+
+        onFileExported(console, name, success);
+
+        if(buf)
+            free(buf);
+    }
+
+    return true;
+}
+
 static inline void exportNativeGame(Console* console, const char* name, const char* system, ExportParams params)
 {
+    if(tryExportNativeFromLocalTemplate(console, name, system))
+        return;
+
+    printLine(console);
+    printBack(console, "\nlocal native template unavailable, fallback to server template...");
     exportGame(console, name, system, onNativeExportGet, params);
 }
 

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -2228,30 +2228,40 @@ static bool tryExportNativeFromLocalTemplate(Console* console, const char* name,
     s32 appSize = 0;
     u8* app = fs_read(appPath, &appSize);
 
-    if(!app || appSize <= 0)
+    if(!app)
         return false;
 
-    if(app) SCOPE(free(app))
+    if(appSize <= 0)
+    {
+        free(app);
+        return false;
+    }
+
+    bool success = false;
+
+    SCOPE(free(app))
     {
         s32 size = appSize;
         void* buf = embedCart(console, app, &size);
 
-        printLine(console);
-        printBack(console, "\nusing local native template...");
+        if(buf) SCOPE(free(buf))
+        {
+            const char* path = tic_fs_path(console->fs, name);
 
-        const char* path = tic_fs_path(console->fs, name);
-        bool success = buf && fs_write(path, buf, size);
+            success = fs_write(path, buf, size);
 
-        if(success)
-            chmod(path, DEFAULT_CHMOD);
+            if(success)
+            {
+                chmod(path, DEFAULT_CHMOD);
 
-        onFileExported(console, name, success);
-
-        if(buf)
-            free(buf);
+                printLine(console);
+                printBack(console, "\nusing local native template...");
+                onFileExported(console, name, true);
+            }
+        }
     }
 
-    return true;
+    return success;
 }
 
 static inline void exportNativeGame(Console* console, const char* name, const char* system, ExportParams params)
@@ -2259,8 +2269,12 @@ static inline void exportNativeGame(Console* console, const char* name, const ch
     if(tryExportNativeFromLocalTemplate(console, name, system))
         return;
 
-    printLine(console);
-    printBack(console, "\nlocal native template unavailable, fallback to server template...");
+    if(canExportNativeFromLocalTemplate(system))
+    {
+        printLine(console);
+        printBack(console, "\nlocal native template failed, using server template...");
+    }
+
     exportGame(console, name, system, onNativeExportGet, params);
 }
 


### PR DESCRIPTION
## Why

Original issue: https://github.com/nesbox/TIC-80/issues/2615

Native export templates fetched from the server can become stale and may ship outdated runtime behavior.  
This PR does not change the server export pipeline itself; it mitigates the issue on the client side for same-platform native exports.

## What

- Added a same-platform local-template path in `src/studio/screens/console.c`:
  - `win` on Windows
  - `linux` on Linux
  - `mac` on macOS
- Same-platform native export now tries embedding into the local executable template (`fs_apppath()`) first.
- If local template use is not applicable or unavailable, behavior falls back to the existing server export flow.
- Added explicit console messages to show whether export used:
  - local native template
  - server fallback template

## Impact

Same-platform native exports are less sensitive to stale server artifacts, while cross-platform export behavior remains unchanged.

**Reviewer question:** should we also enable local-template fallback for `rpi` on Raspberry Pi builds, or keep `rpi` strictly server-backed for now?