### PR TITLE
Fix ttri in low bpp, use segment offsets in tilesheet accessors

### DIFF
--- a/src/core/draw.c
+++ b/src/core/draw.c
@@ -909,10 +909,10 @@ static tic_color triTexTileShader(const ShaderAttr* a, s32 pixel)
     if(!shaderStart(a, &vars, pixel))
         return TRANSPARENT_COLOR;
 
-    enum { WMask = TIC_SPRITESHEET_SIZE - 1, HMask = TIC_SPRITESHEET_SIZE * TIC_SPRITE_BANKS - 1 };
+    enum { HMask = TIC_SPRITESHEET_SIZE * TIC_SPRITE_BANKS - 1 };
 
     return shaderEnd(a, &vars, pixel, data->mapping[tic_tilesheet_getpix(&data->sheet,
-                     (s32)floor(vars.x) & WMask, (s32)floor(vars.y) & HMask)]);
+                     (s32)floor(vars.x) & (TIC_SPRITESHEET_SIZE * data->sheet.segment->nb_pages - 1) , (s32)floor(vars.y) & HMask)]);
 }
 
 static tic_color triTexVbankShader(const ShaderAttr* a, s32 pixel)

--- a/src/studio/editors/sprite.c
+++ b/src/studio/editors/sprite.c
@@ -59,7 +59,7 @@ static void clearCanvasSelection(Sprite* sprite)
 static void initTileSheet(Sprite* sprite)
 {
     sprite->blit.page %= sprite->blit.pages;
-    sprite->sheet = tic_tilesheet_get((( sprite->blit.pages + sprite->blit.page) << 1) + sprite->blit.bank, (u8*)sprite->src);
+    sprite->sheet = tic_tilesheet_get( tic_blit_calc_segment(&sprite->blit), (u8*)sprite->src);
 }
 
 static void updateIndex(Sprite* sprite)
@@ -102,12 +102,12 @@ static void rightViewport(Sprite* sprite)
 
 static s32 getIndexPosX(Sprite* sprite)
 {
-    return (sprite->x + sprite->blit.page * TIC_SPRITESHEET_COLS) * TIC_SPRITESIZE;
+    return sprite->x * TIC_SPRITESIZE;
 }
 
 static s32 getIndexPosY(Sprite* sprite)
 {
-    return (sprite->y + sprite->blit.bank * TIC_SPRITESHEET_COLS) * TIC_SPRITESIZE;
+    return sprite->y * TIC_SPRITESIZE;
 }
 
 static void drawSelection(Sprite* sprite, s32 x, s32 y, s32 w, s32 h)

--- a/src/tilesheet.h
+++ b/src/tilesheet.h
@@ -56,8 +56,13 @@ tic_tileptr tic_tilesheet_gettile(const tic_tilesheet* sheet, s32 index, bool lo
 
 inline u8 tic_tilesheet_getpix(const tic_tilesheet* sheet, s32 x, s32 y)
 {
+    s32 bank_offset, page_offset;
+    bank_offset = (((y>>7) + sheet->segment->bank_orig) & 1) << 8;
+    page_offset = ((((x>>7) + sheet->segment->page_orig) % sheet->segment->nb_pages) << 4) / sheet->segment->nb_pages;
+
     // tile coord
-    u16 tile_index = ((y >> 3) << 4 ) + (x / sheet->segment->tile_width);
+    u16 tile_index = bank_offset + (((y & 127) >> 3) << 4 ) + page_offset + ((x & 127) / sheet->segment->tile_width);
+
     // coord in tile
     u32 pix_addr = ((x & (sheet->segment->tile_width - 1)) + ((y & 7) * sheet->segment->tile_width)) ;
     return sheet->segment->peek(sheet->ptr+tile_index * sheet->segment->ptr_size, pix_addr);
@@ -65,8 +70,13 @@ inline u8 tic_tilesheet_getpix(const tic_tilesheet* sheet, s32 x, s32 y)
 
 inline void tic_tilesheet_setpix(const tic_tilesheet* sheet, s32 x, s32 y, u8 value)
 {
+    s32 bank_offset, page_offset;
+    bank_offset = ((((y>>7) + sheet->segment->bank_orig) & 1) << 8);
+    page_offset = ((((x>>7) + sheet->segment->page_orig) % sheet->segment->nb_pages) << 4) / sheet->segment->nb_pages;
+
     // tile coord
-    u16 tile_index = ((y >> 3) << 4 ) + (x / sheet->segment->tile_width);
+    u16 tile_index = bank_offset + (((y & 127) >> 3) << 4 ) + page_offset + ((x & 127) / sheet->segment->tile_width);
+
     // coord in tile
     u32 pix_addr = ((x & (sheet->segment->tile_width - 1)) + ((y & 7) * sheet->segment->tile_width)) ;
     sheet->segment->poke(sheet->ptr + tile_index * sheet->segment->ptr_size, pix_addr, value);


### PR DESCRIPTION
This PR allows `ttri` to honor blit_segment correctly. Fixes #2325 

## This is a long standing limitation
For reference, [textri was implemented with total-coordinates system](https://github.com/nesbox/TIC-80/pull/1099#issuecomment-636648340), and this persisted in ttri. My comment at the time suggests that {bank=0,page=0} segments are the only one supported and incorrectly states that a full-width tilesheet can be considered (which is not the case, only full-height seems to be accessible in v0.80 and the bug fell through versions). 

## Changes
### Modifications of `tic_thilesheet` pixel accessors  in `tilesheet.c` read as follows :
- calculate the bank and page offsets based on xy coordinates and segment spec
- mask xy coordinates to segment-local (0-127) and calculate the tile id using local xy and bank/page offsets

### Modifications in `studio/editors/sprite.c` :
- use the correct segment calculation in `initTileSheet` (the discarded formula did not point to the right segment, it only seemed to work because applied offsets cancelled out)
- use segment-local coordinates in `getIndexPos*`

### Modifications in `core/draw.c`:
- extend the coordinate system to the full width of the sheet in segments where nb_pages > 1

## Resulting behavior
Blit segment can now point to any bank/page, which will be considered as the origin of the (looping) coordinate system. This allows access to any zone of the spritesheet at every bit depth.

## This is a BREAKING change fixing erroneous or underspecified behavior
`ttri` is the only user of the pixel accessors aside from the editor, and it's behavior towards `blit_segment` is incorrect.
As of now, the only usable portion of the tilesheet is {bank_orig=0, page_orig_=0,...} for each bpp, which corresponds to segments 2,4 and 8. With any other segment, it'll draw from the respective 0,0 portion.

This means that other segments are not likely to be in use, because of their non-support. This also means that any code that calls ttri on a segment other than 2,4 and 8 relies on underspecified behavior and will break after this fix.

## Relevant documentation :
- https://github.com/nesbox/TIC-80/wiki/ttri
- https://github.com/nesbox/TIC-80/wiki/Bits-Per-Pixel
- https://github.com/nesbox/TIC-80/wiki/blit-segment