### PR TITLE
Allows to run TIC-80 commands from the system console

### DIFF
--- a/cmake/sdl.cmake
+++ b/cmake/sdl.cmake
@@ -175,7 +175,7 @@ if(BUILD_SDL)
         configure_file("${PROJECT_SOURCE_DIR}/build/windows/tic80.rc.in" "${PROJECT_SOURCE_DIR}/build/windows/tic80.rc")
         set(TIC80_SRC ${TIC80_SRC} "${PROJECT_SOURCE_DIR}/build/windows/tic80.rc")
 
-        add_executable(${TIC80_TARGET} ${SYSTEM_TYPE} ${TIC80_SRC})
+        add_executable(${TIC80_TARGET} WIN32 ${TIC80_SRC})
 
     elseif(ANDROID)
 
@@ -189,7 +189,7 @@ if(BUILD_SDL)
 
     if(MINGW)
         target_link_libraries(${TIC80_TARGET} mingw32)
-        target_link_options(${TIC80_TARGET} PRIVATE -static -mconsole)
+        target_link_options(${TIC80_TARGET} PRIVATE -static -mwindows)
     endif()
 
     if(EMSCRIPTEN)

--- a/cmake/sdl.cmake
+++ b/cmake/sdl.cmake
@@ -175,7 +175,7 @@ if(BUILD_SDL)
         configure_file("${PROJECT_SOURCE_DIR}/build/windows/tic80.rc.in" "${PROJECT_SOURCE_DIR}/build/windows/tic80.rc")
         set(TIC80_SRC ${TIC80_SRC} "${PROJECT_SOURCE_DIR}/build/windows/tic80.rc")
 
-        add_executable(${TIC80_TARGET} WIN32 ${TIC80_SRC})
+        add_executable(${TIC80_TARGET} ${SYSTEM_TYPE} ${TIC80_SRC})
 
     elseif(ANDROID)
 
@@ -189,7 +189,7 @@ if(BUILD_SDL)
 
     if(MINGW)
         target_link_libraries(${TIC80_TARGET} mingw32)
-        target_link_options(${TIC80_TARGET} PRIVATE -static -mwindows)
+        target_link_options(${TIC80_TARGET} PRIVATE -static -mconsole)
     endif()
 
     if(EMSCRIPTEN)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4003,7 +4003,14 @@ static void processConsoleCommand(Console* console)
 
     if(commandSize)
     {
+#ifdef BAREMETALPI
         printf("%s", console->input.text);
+#else
+        if (!console->args.cli)
+            printf("\n");
+        else
+            printf("%s", console->input.text);
+#endif
         appendHistory(console, console->input.text);
         processCommand(console, console->input.text);
     }
@@ -4448,6 +4455,31 @@ static void tick(Console* console)
                 exitStudio(console->studio);
         }
     }
+
+#ifndef BAREMETALPI
+    if (!console->args.cli)
+    {
+        static char last_text[CONSOLE_BUFFER_SCREEN] = {0};
+        static s32 last_pos = -1;
+        if (strcmp(last_text, console->input.text) != 0 || last_pos != console->input.pos || console->tickCounter == 1)
+        {
+            strcpy(last_text, console->input.text);
+            last_pos = console->input.pos;
+
+            char dir[TICNAME_MAX];
+            tic_fs_dir(console->fs, dir);
+            printf("\r\033[K");
+            if(strlen(dir))
+                printf("%s", dir);
+            printf(">%s", console->input.text);
+
+            s32 tailLen = strlen(console->input.text) - console->input.pos;
+            if (tailLen > 0)
+                printf("\033[%dD", tailLen);
+            fflush(stdout);
+        }
+    }
+#endif
 
     console->tickCounter++;
 }

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4006,9 +4006,7 @@ static void processConsoleCommand(Console* console)
 #ifdef BAREMETALPI
         printf("%s", console->input.text);
 #else
-        if (!console->args.cli)
-            printf("\n");
-        else
+        if (console->args.cli)
             printf("%s", console->input.text);
 #endif
         appendHistory(console, console->input.text);
@@ -4548,6 +4546,8 @@ static int apicmp(const void* a, const void* b)
     return strcmp(((const ApiItem*)a)->name, ((const ApiItem*)b)->name);
 }
 
+// Handle terminal input events directly, bypassing the regular SDL event loop for some keys.
+// This allows commands to be entered and executed even when the console is in the background.
 void console_terminal_input(Console* console, tic_key key, char text)
 {
     if(key == tic_key_return)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4456,31 +4456,6 @@ static void tick(Console* console)
         }
     }
 
-#ifndef BAREMETALPI
-    if (!console->args.cli)
-    {
-        static char last_text[CONSOLE_BUFFER_SCREEN] = {0};
-        static s32 last_pos = -1;
-        if (strcmp(last_text, console->input.text) != 0 || last_pos != console->input.pos || console->tickCounter == 1)
-        {
-            strcpy(last_text, console->input.text);
-            last_pos = console->input.pos;
-
-            char dir[TICNAME_MAX];
-            tic_fs_dir(console->fs, dir);
-            printf("\r\033[K");
-            if(strlen(dir))
-                printf("%s", dir);
-            printf(">%s", console->input.text);
-
-            s32 tailLen = strlen(console->input.text) - console->input.pos;
-            if (tailLen > 0)
-                printf("\033[%dD", tailLen);
-            fflush(stdout);
-        }
-    }
-#endif
-
     console->tickCounter++;
 }
 
@@ -4571,6 +4546,45 @@ static int cmdcmp(const void* a, const void* b)
 static int apicmp(const void* a, const void* b)
 {
     return strcmp(((const ApiItem*)a)->name, ((const ApiItem*)b)->name);
+}
+
+void console_terminal_input(Console* console, tic_key key, char text)
+{
+    if(key == tic_key_return)
+    {
+        processConsoleCommand(console);
+        while(console->commands.current < console->commands.count)
+        {
+             const char* command = console->commands.items[console->commands.current];
+             processCommand(console, command);
+             console->commands.current++;
+        }
+    }
+    else if(key == tic_key_backspace) processConsoleBackspace(console);
+    else if(key == tic_key_tab) processConsoleTab(console);
+    else if(key == tic_key_delete) processConsoleDel(console);
+    else if(key == tic_key_up) onHistoryUp(console);
+    else if(key == tic_key_down) onHistoryDown(console);
+    else if(key == tic_key_left) { if(console->input.pos > 0) console->input.pos--; }
+    else if(key == tic_key_right) { console->input.pos++; s32 len = (s32)strlen(console->input.text); if(console->input.pos > len) console->input.pos = (size_t)len; }
+    else if(text) insertInputText(console, (char[]){text, '\0'});
+
+#ifndef BAREMETALPI
+    if (!console->args.cli)
+    {
+        char dir[TICNAME_MAX];
+        tic_fs_dir(console->fs, dir);
+        printf("\r\033[K");
+        if(strlen(dir))
+            printf("%s", dir);
+        printf(">%s", console->input.text);
+
+        s32 tailLen = (s32)strlen(console->input.text) - (s32)console->input.pos;
+        if (tailLen > 0)
+            printf("\033[%dD", tailLen);
+        fflush(stdout);
+    }
+#endif
 }
 
 void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Config* config, StartArgs args)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4276,6 +4276,26 @@ static void backspaceWord(Console* console)
     console->input.pos = pos;
 }
 
+static void refreshTerminal(Console* console)
+{
+#ifndef BAREMETALPI
+    if (!console->args.cli)
+    {
+        char dir[TICNAME_MAX];
+        tic_fs_dir(console->fs, dir);
+        printf("\r\033[K");
+        if(strlen(dir))
+            printf("%s", dir);
+        printf(">%s", console->input.text);
+
+        s32 tailLen = (s32)strlen(console->input.text) - (s32)console->input.pos;
+        if (tailLen > 0)
+            printf("\033[%dD", tailLen);
+        fflush(stdout);
+    }
+#endif
+}
+
 static void processKeyboard(Console* console)
 {
     tic_mem* tic = console->tic;
@@ -4361,6 +4381,7 @@ static void processKeyboard(Console* console)
         console->cursor.delay = CONSOLE_CURSOR_DELAY;
     }
 
+    refreshTerminal(console);
 }
 
 static void processGamepad(Console* console)
@@ -4569,22 +4590,7 @@ void console_terminal_input(Console* console, tic_key key, char text)
     else if(key == tic_key_right) { console->input.pos++; s32 len = (s32)strlen(console->input.text); if(console->input.pos > len) console->input.pos = (size_t)len; }
     else if(text) insertInputText(console, (char[]){text, '\0'});
 
-#ifndef BAREMETALPI
-    if (!console->args.cli)
-    {
-        char dir[TICNAME_MAX];
-        tic_fs_dir(console->fs, dir);
-        printf("\r\033[K");
-        if(strlen(dir))
-            printf("%s", dir);
-        printf(">%s", console->input.text);
-
-        s32 tailLen = (s32)strlen(console->input.text) - (s32)console->input.pos;
-        if (tailLen > 0)
-            printf("\033[%dD", tailLen);
-        fflush(stdout);
-    }
-#endif
+    refreshTerminal(console);
 }
 
 void initConsole(Console* console, Studio* studio, tic_fs* fs, tic_net* net, Config* config, StartArgs args)

--- a/src/studio/screens/console.c
+++ b/src/studio/screens/console.c
@@ -4005,9 +4005,6 @@ static void processConsoleCommand(Console* console)
     {
 #ifdef BAREMETALPI
         printf("%s", console->input.text);
-#else
-        if (console->args.cli)
-            printf("%s", console->input.text);
 #endif
         appendHistory(console, console->input.text);
         processCommand(console, console->input.text);
@@ -4402,7 +4399,6 @@ static void tick(Console* console)
     tic_mem* tic = console->tic;
 
     processMouse(console);
-    processKeyboard(console);
     processGamepad(console);
 
     Start* start = getStartScreen(console->studio);
@@ -4427,6 +4423,8 @@ static void tick(Console* console)
         }
         else printBack(console, "\n loading cart...");
     }
+
+    processKeyboard(console);
 
     tic_api_cls(tic, TIC_COLOR_BG);
     drawConsoleText(console);

--- a/src/studio/screens/console.h
+++ b/src/studio/screens/console.h
@@ -116,4 +116,5 @@ struct Console
 
 void initConsole(Console*, Studio* studio, struct tic_fs* fs, struct tic_net* net, struct Config* config, StartArgs args);
 void freeConsole(Console* console);
+void console_terminal_input(Console* console, tic_key key, char text);
 void forceAutoSave(Console* console, const char* cart_name);

--- a/src/studio/screens/console_minimal.c
+++ b/src/studio/screens/console_minimal.c
@@ -124,3 +124,4 @@ void freeConsole(Console* console)
 }
 
 void forceAutoSave(Console* console, const char* cart_name) {}
+void console_terminal_input(Console* console, tic_key key, char text) {}

--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -1385,6 +1385,11 @@ bool checkStudioViMode(Studio* studio, ViMode mode) {
 }
 #endif
 
+void studio_terminal_input(Studio* studio, tic_key key, char text)
+{
+    console_terminal_input(studio->console, key, text);
+}
+
 static inline bool pointInRect(const tic_point* pt, const tic_rect* rect)
 {
     return (pt->x >= rect->x)

--- a/src/studio/studio.h
+++ b/src/studio/studio.h
@@ -227,6 +227,7 @@ void exitStudio(Studio* studio);
 void setStudioViMode(Studio* studio, ViMode mode);
 ViMode getStudioViMode(Studio* studio);
 bool checkStudioViMode(Studio* studio, ViMode mode);
+void studio_terminal_input(Studio* studio, tic_key key, char text);
 
 void toClipboard(const void* data, s32 size, bool flip);
 bool fromClipboard(void* data, s32 size, bool flip, bool remove_white_spaces, bool sameSize);

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2262,16 +2262,16 @@ s32 main(s32 argc, char **argv)
         {
             if (!attached)
             {
-                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                if (hOut != NULL && hOut != INVALID_HANDLE_VALUE && GetFileType(hOut) == FILE_TYPE_CHAR)
+                HWND consoleWnd = GetConsoleWindow();
+                if (consoleWnd != NULL)
                 {
                     CONSOLE_SCREEN_BUFFER_INFO info;
-                    if (GetConsoleScreenBufferInfo(hOut, &info))
+                    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info))
                     {
                         bool isFreshWindow = !info.dwCursorPosition.X && !info.dwCursorPosition.Y;
                         bool isOnlyProcess = false;
 
-                        if (!isFreshWindow && GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") == NULL)
+                        if (GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") == NULL)
                         {
                             DWORD procList[2];
                             if (GetConsoleProcessList(procList, 2) == 1)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -34,8 +34,13 @@
 extern void gotoMenu(Studio* studio);
 #endif
 
-#if defined(__TIC_LINUX__)
+#if defined(__TIC_WINDOWS__)
+#include <conio.h>
+#elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
 #include <signal.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <termios.h>
 #endif
 
 #if defined(CRT_SHADER_SUPPORT)
@@ -1263,6 +1268,80 @@ static void pollEvents()
         }
     }
 
+#if defined(__TIC_WINDOWS__)
+    while (_kbhit()) {
+        int c = _getch();
+        if (c == 0 || c == 224) {
+            c = _getch();
+            if (c == 72) platform.keyboard.pressed[tic_key_up] = true;
+            else if (c == 80) platform.keyboard.pressed[tic_key_down] = true;
+            else if (c == 77) platform.keyboard.pressed[tic_key_right] = true;
+            else if (c == 75) platform.keyboard.pressed[tic_key_left] = true;
+        }
+        else if (c == '\r' || c == '\n') platform.keyboard.pressed[tic_key_return] = true;
+        else if (c == '\b') platform.keyboard.pressed[tic_key_backspace] = true;
+        else if (c == '\t') platform.keyboard.pressed[tic_key_tab] = true;
+        else platform.keyboard.text = (char)c;
+    }
+#elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
+    {
+        fd_set readfds;
+        struct timeval tv;
+        FD_ZERO(&readfds);
+        FD_SET(STDIN_FILENO, &readfds);
+        tv.tv_sec = 0;
+        tv.tv_usec = 0;
+        if (select(STDIN_FILENO + 1, &readfds, NULL, NULL, &tv) > 0)
+        {
+            char c;
+            if (read(STDIN_FILENO, &c, 1) > 0)
+            {
+                if (c == '\033')
+                {
+                    char seq[2];
+                    FD_ZERO(&readfds);
+                    FD_SET(STDIN_FILENO, &readfds);
+                    tv.tv_sec = 0; tv.tv_usec = 10000;
+                    if (select(STDIN_FILENO + 1, &readfds, NULL, NULL, &tv) > 0)
+                    {
+                        if (read(STDIN_FILENO, &seq[0], 1) > 0 && seq[0] == '[')
+                        {
+                            FD_ZERO(&readfds);
+                            FD_SET(STDIN_FILENO, &readfds);
+                            if (select(STDIN_FILENO + 1, &readfds, NULL, NULL, &tv) > 0)
+                            {
+                                if (read(STDIN_FILENO, &seq[1], 1) > 0)
+                                {
+                                    if (seq[1] == 'A') platform.keyboard.pressed[tic_key_up] = true;
+                                    else if (seq[1] == 'B') platform.keyboard.pressed[tic_key_down] = true;
+                                    else if (seq[1] == 'C') platform.keyboard.pressed[tic_key_right] = true;
+                                    else if (seq[1] == 'D') platform.keyboard.pressed[tic_key_left] = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                else if (c == '\n' || c == '\r')
+                {
+                    platform.keyboard.pressed[tic_key_return] = true;
+                }
+                else if (c == '\b' || c == 0x7f)
+                {
+                    platform.keyboard.pressed[tic_key_backspace] = true;
+                }
+                else if (c == '\t')
+                {
+                    platform.keyboard.pressed[tic_key_tab] = true;
+                }
+                else
+                {
+                    platform.keyboard.text = c;
+                }
+            }
+        }
+    }
+#endif
+
     processMouse();
 
 #if defined(TOUCH_INPUT_SUPPORT)
@@ -2171,7 +2250,20 @@ s32 main(s32 argc, char **argv)
 
 #else
 
-    return start(argc, argv, folder);
+#if defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
+    struct termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+#endif
+
+    int ret = start(argc, argv, folder);
+
+#if defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+#endif
+    return ret;
 
 #endif
 }

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2258,7 +2258,7 @@ s32 main(s32 argc, char **argv)
         if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
             attached = true;
 
-        if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
+        if (attached || (GetStdHandle(STD_OUTPUT_HANDLE) != NULL && GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE))
         {
             // Use freopen as first choice
             if (freopen("CONIN$", "r", stdin) == NULL)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1282,9 +1282,7 @@ static void pollEvents()
         bool hasInput = false;
 
         if (dwType == FILE_TYPE_CHAR) { // Console
-            DWORD numEvents = 0;
-            if (GetNumberOfConsoleInputEvents(hIn, &numEvents) && numEvents > 0)
-                hasInput = true;
+            if (_kbhit()) hasInput = true;
         } else if (dwType == FILE_TYPE_PIPE) { // Pipe (Wine/MSYS)
             DWORD totalBytes = 0;
             if (PeekNamedPipe(hIn, NULL, 0, NULL, &totalBytes, NULL) && totalBytes > 0)
@@ -1298,7 +1296,9 @@ static void pollEvents()
             c = _getch();
         } else {
             char buf[1];
-            if (read(0, buf, 1) > 0) c = (unsigned char)buf[0];
+            DWORD readBytes = 0;
+            if (ReadFile(hIn, buf, 1, &readBytes, NULL) && readBytes > 0)
+                c = (unsigned char)buf[0];
             else break;
         }
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2260,7 +2260,7 @@ s32 main(s32 argc, char **argv)
 
         if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
-            if (!attached)
+            if (!attached && GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") == NULL)
             {
                 DWORD procList[2];
                 if (GetConsoleProcessList(procList, 2) == 1)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -1269,6 +1269,8 @@ static void pollEvents()
         }
     }
 
+    // Poll terminal stdin input independently of the SDL event loop.
+    // This allows background command processing even when the GUI is busy or focused elsewhere.
 #if defined(__TIC_WINDOWS__)
     while (_kbhit()) {
         int c = _getch();
@@ -1297,7 +1299,7 @@ static void pollEvents()
             char c;
             if (read(STDIN_FILENO, &c, 1) > 0)
             {
-                if (c == '\033')
+                if (c == '\033') // Handle ANSI escape sequences for arrow keys
                 {
                     char seq[2];
                     FD_ZERO(&readfds);
@@ -2218,11 +2220,32 @@ s32 main(s32 argc, char **argv)
 {
 #if defined(__TIC_WINDOWS__)
     {
-        CONSOLE_SCREEN_BUFFER_INFO info;
-        if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
-            FreeConsole();
+        // Try to attach to the parent process's console (e.g. if started from cmd or bash).
+        // This ensures stdout/stderr output and stdin input work correctly in the terminal.
+        if (AttachConsole(ATTACH_PARENT_PROCESS))
+        {
+            freopen("CONIN$", "r", stdin);
+            freopen("CONOUT$", "w", stdout);
+            freopen("CONOUT$", "w", stderr);
+            setvbuf(stdout, NULL, _IONBF, 0);
+            setvbuf(stderr, NULL, _IONBF, 0);
+        }
+        else
+        {
+            // If failed to attach, detect if we are starting in a fresh console and hide it if so.
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
+                FreeConsole();
+        }
     }
-#elif defined(__TIC_LINUX__)
+#elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
+    // Configure terminal to Raw Mode to capture input immediately without OS buffering.
+    struct termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+
     signal(SIGPIPE, SIG_IGN);
 #endif
 
@@ -2250,15 +2273,7 @@ s32 main(s32 argc, char **argv)
     );
 
 #else
-
-#if defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
-    struct termios oldt, newt;
-    tcgetattr(STDIN_FILENO, &oldt);
-    newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
-    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-#endif
-
+    // Start TIC-80 and restore terminal mode on exit.
     int ret = start(argc, argv, folder);
 
 #if defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2265,24 +2265,29 @@ s32 main(s32 argc, char **argv)
                 HWND consoleWnd = GetConsoleWindow();
                 if (consoleWnd != NULL)
                 {
-                    CONSOLE_SCREEN_BUFFER_INFO info;
-                    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info))
+                    bool isWine = GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") != NULL;
+                    bool shouldHide = false;
+
+                    if (isWine)
                     {
-                        bool isFreshWindow = !info.dwCursorPosition.X && !info.dwCursorPosition.Y;
-                        bool isOnlyProcess = false;
-
-                        if (GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") == NULL)
+                        if (!_isatty(0)) shouldHide = true;
+                    }
+                    else
+                    {
+                        DWORD procList[2];
+                        if (GetConsoleProcessList(procList, 2) == 1) shouldHide = true;
+                        else
                         {
-                            DWORD procList[2];
-                            if (GetConsoleProcessList(procList, 2) == 1)
-                                isOnlyProcess = true;
+                            CONSOLE_SCREEN_BUFFER_INFO info;
+                            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
+                                shouldHide = true;
                         }
+                    }
 
-                        if (isFreshWindow || isOnlyProcess)
-                        {
-                            FreeConsole();
-                            goto skip_console;
-                        }
+                    if (shouldHide)
+                    {
+                        FreeConsole();
+                        goto skip_console;
                     }
                 }
             }

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2258,37 +2258,71 @@ s32 main(s32 argc, char **argv)
         if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
             attached = true;
 
+        bool isWine = GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") != NULL;
+        char debug[2048] = {0};
+        char linkTarget[256] = "N/A";
+        char pathIn[MAX_PATH] = "N/A", pathOut[MAX_PATH] = "N/A";
+        DWORD modeIn = 0, modeOut = 0;
+        DWORD procList[8];
+        DWORD procCount = GetConsoleProcessList(procList, 8);
+        HWND consoleWnd = GetConsoleWindow();
+        CONSOLE_SCREEN_BUFFER_INFO info;
+        BOOL hasInfo = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
+        
+        GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &modeIn);
+        GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &modeOut);
+        
+        typedef DWORD (WINAPI *GetFinalPathNameByHandleA_t)(HANDLE, LPSTR, DWORD, DWORD);
+        GetFinalPathNameByHandleA_t pGetFinalPathNameByHandleA = (GetFinalPathNameByHandleA_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetFinalPathNameByHandleA");
+        if (pGetFinalPathNameByHandleA)
+        {
+            pGetFinalPathNameByHandleA(GetStdHandle(STD_INPUT_HANDLE), pathIn, MAX_PATH, 0);
+            pGetFinalPathNameByHandleA(GetStdHandle(STD_OUTPUT_HANDLE), pathOut, MAX_PATH, 0);
+        }
+
+        if (isWine)
+        {
+            typedef long (*syscall_t)(long, ...);
+            syscall_t wine_syscall = (syscall_t)GetProcAddress(GetModuleHandleA("ntdll.dll"), "syscall");
+            if (wine_syscall)
+            {
+                long ret = wine_syscall(89, "/proc/self/fd/0", linkTarget, sizeof(linkTarget) - 1);
+                if (ret > 0) linkTarget[ret] = '\0';
+            }
+        }
+
+        sprintf(debug, 
+            "isWine: %d\n"
+            "Attached: %d\n"
+            "HWND: %p\n"
+            "procCount: %lu\n"
+            "isatty(0/1): %d / %d\n"
+            "Mode(In/Out): %lu / %lu\n"
+            "Cursor: %d, %d\n"
+            "PathIn: %s\n"
+            "PathOut: %s\n"
+            "Link0: %s",
+            isWine, attached, consoleWnd, procCount, _isatty(0), _isatty(1), modeIn, modeOut,
+            hasInfo ? info.dwCursorPosition.X : -1, hasInfo ? info.dwCursorPosition.Y : -1,
+            pathIn, pathOut, linkTarget);
+
+        MessageBoxA(NULL, debug, "TIC-80 ULTIMATE DEBUG", MB_OK);
+
         if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
             if (!attached)
             {
-                HWND consoleWnd = GetConsoleWindow();
                 if (consoleWnd != NULL)
                 {
-                    bool isWine = GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") != NULL;
                     bool shouldHide = false;
-
                     if (isWine)
                     {
-                        char buf[1024];
-                        DWORD procList[2] = {0};
-                        DWORD procCount = GetConsoleProcessList(procList, 2);
-                        sprintf(buf, "isWine: %d\n_isatty(0): %d\n_isatty(1): %d\nprocCount: %lu\nHWND: %p",
-                            isWine, _isatty(0), _isatty(1), procCount, consoleWnd);
-                        MessageBoxA(NULL, buf, "TIC-80 DEBUG", MB_OK);
-
-                        if (!_isatty(0)) shouldHide = true;
+                        if (strncmp(linkTarget, "/dev/null", 9) == 0) shouldHide = true;
                     }
                     else
                     {
-                        DWORD procList[2];
-                        if (GetConsoleProcessList(procList, 2) == 1) shouldHide = true;
-                        else
-                        {
-                            CONSOLE_SCREEN_BUFFER_INFO info;
-                            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
-                                shouldHide = true;
-                        }
+                        if (procCount == 1) shouldHide = true;
+                        else if (hasInfo && !info.dwCursorPosition.X && !info.dwCursorPosition.Y) shouldHide = true;
                     }
 
                     if (shouldHide)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2254,45 +2254,53 @@ s32 main(s32 argc, char **argv)
         typedef BOOL (WINAPI *AttachConsole_t)(DWORD);
         AttachConsole_t pAttachConsole = (AttachConsole_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "AttachConsole");
         
-        bool attached = false;
-        if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
-            attached = true;
+        bool attached = pAttachConsole && pAttachConsole((DWORD)-1);
 
-        if (attached)
-        {
-            if (freopen("CONIN$", "r", stdin)) setvbuf(stdin, NULL, _IONBF, 0);
-            if (freopen("CONOUT$", "w", stdout)) setvbuf(stdout, NULL, _IONBF, 0);
-            if (freopen("CONOUT$", "w", stderr)) setvbuf(stderr, NULL, _IONBF, 0);
-        }
-        else
+        if (!attached)
         {
             HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (hOut != NULL && hOut != INVALID_HANDLE_VALUE)
+            if (hOut != NULL && hOut != INVALID_HANDLE_VALUE && GetFileType(hOut) == FILE_TYPE_CHAR)
             {
-                if (GetFileType(hOut) == FILE_TYPE_CHAR)
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if (GetConsoleScreenBufferInfo(hOut, &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
                 {
-                    CONSOLE_SCREEN_BUFFER_INFO info;
-                    if (GetConsoleScreenBufferInfo(hOut, &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
-                        FreeConsole();
+                    FreeConsole();
                 }
-                else
+            }
+        }
+
+        if (attached || (GetStdHandle(STD_OUTPUT_HANDLE) != NULL && GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE))
+        {
+            if (freopen("CONIN$", "r", stdin)) setvbuf(stdin, NULL, _IONBF, 0);
+            else
+            {
+                HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+                if (hIn != NULL && hIn != INVALID_HANDLE_VALUE)
+                {
+                    int fd = _open_osfhandle((intptr_t)hIn, _O_TEXT);
+                    if (fd != -1) _dup2(fd, 0);
+                }
+            }
+
+            if (freopen("CONOUT$", "w", stdout)) setvbuf(stdout, NULL, _IONBF, 0);
+            else
+            {
+                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+                if (hOut != NULL && hOut != INVALID_HANDLE_VALUE)
                 {
                     int fd = _open_osfhandle((intptr_t)hOut, _O_TEXT);
-                    if (fd != -1) _dup2(fd, 1);
+                    if (fd != -1) { _dup2(fd, 1); setvbuf(stdout, NULL, _IONBF, 0); }
+                }
+            }
 
-                    HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
-                    if (hErr != NULL && hErr != INVALID_HANDLE_VALUE)
-                    {
-                        int fde = _open_osfhandle((intptr_t)hErr, _O_TEXT);
-                        if (fde != -1) _dup2(fde, 2);
-                    }
-
-                    HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
-                    if (hIn != NULL && hIn != INVALID_HANDLE_VALUE)
-                    {
-                        int fdi = _open_osfhandle((intptr_t)hIn, _O_TEXT);
-                        if (fdi != -1) _dup2(fdi, 0);
-                    }
+            if (freopen("CONOUT$", "w", stderr)) setvbuf(stderr, NULL, _IONBF, 0);
+            else
+            {
+                HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+                if (hErr != NULL && hErr != INVALID_HANDLE_VALUE)
+                {
+                    int fd = _open_osfhandle((intptr_t)hErr, _O_TEXT);
+                    if (fd != -1) { _dup2(fd, 2); setvbuf(stderr, NULL, _IONBF, 0); }
                 }
             }
         }

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2270,6 +2270,13 @@ s32 main(s32 argc, char **argv)
 
                     if (isWine)
                     {
+                        char buf[1024];
+                        DWORD procList[2] = {0};
+                        DWORD procCount = GetConsoleProcessList(procList, 2);
+                        sprintf(buf, "isWine: %d\n_isatty(0): %d\n_isatty(1): %d\nprocCount: %lu\nHWND: %p",
+                            isWine, _isatty(0), _isatty(1), procCount, consoleWnd);
+                        MessageBoxA(NULL, buf, "TIC-80 DEBUG", MB_OK);
+
                         if (!_isatty(0)) shouldHide = true;
                     }
                     else

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -416,7 +416,7 @@ static void drawKeyboardLabels(tic_mem* tic, s32 shift)
     }
 }
 
-static void map2ram(tic_mem* tic)
+static void map2ramLoc(tic_mem* tic)
 {
     memcpy(tic->ram->map.data, &studio_config(platform.studio)->cart->bank0.map, sizeof tic->ram->map);
     memcpy(tic->ram->tiles.data, &studio_config(platform.studio)->cart->bank0.tiles, sizeof tic->ram->tiles * TIC_SPRITE_BANKS);
@@ -456,7 +456,7 @@ static void initTouchKeyboard()
     {
         memcpy(tic->ram->vram.palette.data, studio_config(platform.studio)->cart->bank0.palette.vbank0.data, sizeof(tic_palette));
         tic_api_cls(tic, 0);
-        map2ram(tic);
+        map2ramLoc(tic);
 
         initTouchKeyboardState(tic, &platform.keyboard.touch.texture.up, &platform.keyboard.touch.texture.upPixels, false);
         initTouchKeyboardState(tic, &platform.keyboard.touch.texture.down, &platform.keyboard.touch.texture.downPixels, true);

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -37,6 +37,8 @@ extern void gotoMenu(Studio* studio);
 
 #if defined(__TIC_WINDOWS__)
 #include <conio.h>
+#include <io.h>
+#include <fcntl.h>
 #elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
 #include <signal.h>
 #include <unistd.h>
@@ -1272,19 +1274,48 @@ static void pollEvents()
     // Poll terminal stdin input independently of the SDL event loop.
     // This allows background command processing even when the GUI is busy or focused elsewhere.
 #if defined(__TIC_WINDOWS__)
-    while (_kbhit()) {
-        int c = _getch();
-        if (c == 0 || c == 224) {
+    while (true) {
+        HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+        if (hIn == INVALID_HANDLE_VALUE) break;
+
+        DWORD dwType = GetFileType(hIn);
+        bool hasInput = false;
+
+        if (dwType == FILE_TYPE_CHAR) { // Console
+            DWORD numEvents = 0;
+            if (GetNumberOfConsoleInputEvents(hIn, &numEvents) && numEvents > 0)
+                hasInput = true;
+        } else if (dwType == FILE_TYPE_PIPE) { // Pipe (Wine/MSYS)
+            DWORD totalBytes = 0;
+            if (PeekNamedPipe(hIn, NULL, 0, NULL, &totalBytes, NULL) && totalBytes > 0)
+                hasInput = true;
+        }
+
+        if (!hasInput) break;
+
+        int c;
+        if (dwType == FILE_TYPE_CHAR) {
             c = _getch();
-            if (c == 72) studio_terminal_input(platform.studio, tic_key_up, 0);
-            else if (c == 80) studio_terminal_input(platform.studio, tic_key_down, 0);
-            else if (c == 77) studio_terminal_input(platform.studio, tic_key_right, 0);
-            else if (c == 75) studio_terminal_input(platform.studio, tic_key_left, 0);
+        } else {
+            char buf[1];
+            if (read(0, buf, 1) > 0) c = (unsigned char)buf[0];
+            else break;
+        }
+
+        if (c == 0 || c == 0xE0) { // 224
+            if (dwType == FILE_TYPE_CHAR) {
+                c = _getch();
+                if (c == 0x48) studio_terminal_input(platform.studio, tic_key_up, 0); // 72
+                else if (c == 0x50) studio_terminal_input(platform.studio, tic_key_down, 0); // 80
+                else if (c == 0x4D) studio_terminal_input(platform.studio, tic_key_right, 0); // 77
+                else if (c == 0x4B) studio_terminal_input(platform.studio, tic_key_left, 0); // 75
+            }
         }
         else if (c == '\r' || c == '\n') studio_terminal_input(platform.studio, tic_key_return, 0);
         else if (c == '\b') studio_terminal_input(platform.studio, tic_key_backspace, 0);
+        else if (c == 0x7F) studio_terminal_input(platform.studio, tic_key_backspace, 0); // DEL as backspace
         else if (c == '\t') studio_terminal_input(platform.studio, tic_key_tab, 0);
-        else studio_terminal_input(platform.studio, tic_key_unknown, (char)c);
+        else if (c >= 32) studio_terminal_input(platform.studio, tic_key_unknown, (char)c);
     }
 #elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
     {
@@ -2220,19 +2251,53 @@ s32 main(s32 argc, char **argv)
 {
 #if defined(__TIC_WINDOWS__)
     {
-        // Try to attach to the parent process's console (e.g. if started from cmd or bash).
-        // This ensures stdout/stderr output and stdin input work correctly in the terminal.
-        if (AttachConsole(ATTACH_PARENT_PROCESS))
+        typedef BOOL (WINAPI *AttachConsole_t)(DWORD);
+        AttachConsole_t pAttachConsole = (AttachConsole_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "AttachConsole");
+        
+        bool attached = false;
+        if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
+            attached = true;
+
+        if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
-            freopen("CONIN$", "r", stdin);
-            freopen("CONOUT$", "w", stdout);
-            freopen("CONOUT$", "w", stderr);
+            // Use freopen as first choice
+            if (freopen("CONIN$", "r", stdin) == NULL)
+            {
+                // Fallback for redirected input if CONIN$ fails
+                HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+                if (hIn != INVALID_HANDLE_VALUE)
+                {
+                    int fd = _open_osfhandle((intptr_t)hIn, _O_TEXT);
+                    if (fd != -1) _dup2(fd, 0);
+                }
+            }
+
+            if (freopen("CONOUT$", "w", stdout) == NULL)
+            {
+                // Fallback for redirected output
+                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+                if (hOut != INVALID_HANDLE_VALUE)
+                {
+                    int fd = _open_osfhandle((intptr_t)hOut, _O_TEXT);
+                    if (fd != -1) _dup2(fd, 1);
+                }
+            }
+
+            if (freopen("CONOUT$", "w", stderr) == NULL)
+            {
+                HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+                if (hErr != INVALID_HANDLE_VALUE)
+                {
+                    int fd = _open_osfhandle((intptr_t)hErr, _O_TEXT);
+                    if (fd != -1) _dup2(fd, 2);
+                }
+            }
+
             setvbuf(stdout, NULL, _IONBF, 0);
             setvbuf(stderr, NULL, _IONBF, 0);
         }
         else
         {
-            // If failed to attach, detect if we are starting in a fresh console and hide it if so.
             CONSOLE_SCREEN_BUFFER_INFO info;
             if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
                 FreeConsole();

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2298,9 +2298,17 @@ s32 main(s32 argc, char **argv)
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
         char classBuf[256] = "N/A";
         char linkProc[MAX_PATH] = "N/A";
+        char linkTargetResolved[MAX_PATH] = "N/A";
         COORD bufSize = {0, 0};
+        int winWidth = 0, winHeight = 0;
+        BOOL isVisible = IsWindowVisible(consoleWnd);
         if (consoleWnd) GetClassNameA(consoleWnd, classBuf, sizeof(classBuf));
-        if (hasInfo) bufSize = info.dwSize;
+        if (hasInfo)
+        {
+            bufSize = info.dwSize;
+            winWidth = info.srWindow.Right - info.srWindow.Left + 1;
+            winHeight = info.srWindow.Bottom - info.srWindow.Top + 1;
+        }
 
         if (isWine)
         {
@@ -2314,28 +2322,37 @@ s32 main(s32 argc, char **argv)
             }
             else strcpy(linkTarget, "No syscall wrapper");
 
-            // Try the Z:\ bridge
+            // Try the Z:\ bridge WITH backup semantics (to see symlink path)
             HANDLE hProc = CreateFileA("Z:\\proc\\self\\fd\\0", 0, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
             if (hProc != INVALID_HANDLE_VALUE)
             {
                 if (pGetFinalPathNameByHandleA) pGetFinalPathNameByHandleA(hProc, linkProc, MAX_PATH, 0);
                 CloseHandle(hProc);
             }
+
+            // Try the Z:\ bridge WITHOUT backup semantics (to see target path)
+            HANDLE hTarget = CreateFileA("Z:\\proc\\self\\fd\\0", 0, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+            if (hTarget != INVALID_HANDLE_VALUE)
+            {
+                if (pGetFinalPathNameByHandleA) pGetFinalPathNameByHandleA(hTarget, linkTargetResolved, MAX_PATH, 0);
+                CloseHandle(hTarget);
+            }
         }
 
         sprintf(debug, 
-            "isWine: %d HWND: %p\n"
-            "Class: %s\n"
-            "Title: %s\n"
-            "hIn: %p hOut: %p\n"
-            "procCount: %lu In/OutType: %lu/%lu\n"
-            "Mode(In/Out): %lu / %lu\n"
-            "BufSize: %d x %d Cursor: %d, %d\n"
+            "isWine: %d HWND: %p Vis: %d\n"
+            "Class: %s Title: %s\n"
+            "hIn: %p hOut: %p (procC: %lu)\n"
+            "In/OutType: %lu/%lu Mode: %lu/%lu\n"
+            "Buf: %dx%d Win: %dx%d\n"
             "Link0: %s\n"
-            "LinkProc: %s",
-            isWine, consoleWnd, classBuf, title, hIn, hOut, procCount, typeIn, typeOut, modeIn, modeOut,
-            bufSize.X, bufSize.Y, hasInfo ? info.dwCursorPosition.X : -1, hasInfo ? info.dwCursorPosition.Y : -1,
-            linkTarget, linkProc);
+            "LProc: %s\n"
+            "LRes: %s",
+            isWine, consoleWnd, isVisible,
+            classBuf, title, hIn, hOut, procCount,
+            typeIn, typeOut, modeIn, modeOut,
+            bufSize.X, bufSize.Y, winWidth, winHeight,
+            linkTarget, linkProc, linkTargetResolved);
 
         MessageBoxA(NULL, debug, "TIC-80 ULTIMATE DEBUG", MB_OK);
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2254,55 +2254,53 @@ s32 main(s32 argc, char **argv)
         typedef BOOL (WINAPI *AttachConsole_t)(DWORD);
         AttachConsole_t pAttachConsole = (AttachConsole_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "AttachConsole");
         
-        bool attached = pAttachConsole && pAttachConsole((DWORD)-1);
+        bool attached = false;
+        if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
+            attached = true;
 
-        if (!attached)
+        if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
-            HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (hOut != NULL && hOut != INVALID_HANDLE_VALUE && GetFileType(hOut) == FILE_TYPE_CHAR)
+            // Use freopen as first choice
+            if (freopen("CONIN$", "r", stdin) == NULL)
             {
-                CONSOLE_SCREEN_BUFFER_INFO info;
-                if (GetConsoleScreenBufferInfo(hOut, &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
-                {
-                    FreeConsole();
-                }
-            }
-        }
-
-        if (attached || (GetStdHandle(STD_OUTPUT_HANDLE) != NULL && GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE))
-        {
-            if (freopen("CONIN$", "r", stdin)) setvbuf(stdin, NULL, _IONBF, 0);
-            else
-            {
+                // Fallback for redirected input if CONIN$ fails
                 HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
-                if (hIn != NULL && hIn != INVALID_HANDLE_VALUE)
+                if (hIn != INVALID_HANDLE_VALUE)
                 {
                     int fd = _open_osfhandle((intptr_t)hIn, _O_TEXT);
                     if (fd != -1) _dup2(fd, 0);
                 }
             }
 
-            if (freopen("CONOUT$", "w", stdout)) setvbuf(stdout, NULL, _IONBF, 0);
-            else
+            if (freopen("CONOUT$", "w", stdout) == NULL)
             {
+                // Fallback for redirected output
                 HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                if (hOut != NULL && hOut != INVALID_HANDLE_VALUE)
+                if (hOut != INVALID_HANDLE_VALUE)
                 {
                     int fd = _open_osfhandle((intptr_t)hOut, _O_TEXT);
-                    if (fd != -1) { _dup2(fd, 1); setvbuf(stdout, NULL, _IONBF, 0); }
+                    if (fd != -1) _dup2(fd, 1);
                 }
             }
 
-            if (freopen("CONOUT$", "w", stderr)) setvbuf(stderr, NULL, _IONBF, 0);
-            else
+            if (freopen("CONOUT$", "w", stderr) == NULL)
             {
                 HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
-                if (hErr != NULL && hErr != INVALID_HANDLE_VALUE)
+                if (hErr != INVALID_HANDLE_VALUE)
                 {
                     int fd = _open_osfhandle((intptr_t)hErr, _O_TEXT);
-                    if (fd != -1) { _dup2(fd, 2); setvbuf(stderr, NULL, _IONBF, 0); }
+                    if (fd != -1) _dup2(fd, 2);
                 }
             }
+
+            setvbuf(stdout, NULL, _IONBF, 0);
+            setvbuf(stderr, NULL, _IONBF, 0);
+        }
+        else
+        {
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
+                FreeConsole();
         }
     }
 #elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2260,13 +2260,30 @@ s32 main(s32 argc, char **argv)
 
         if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
-            if (!attached && GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") == NULL)
+            if (!attached)
             {
-                DWORD procList[2];
-                if (GetConsoleProcessList(procList, 2) == 1)
+                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+                if (hOut != NULL && hOut != INVALID_HANDLE_VALUE && GetFileType(hOut) == FILE_TYPE_CHAR)
                 {
-                    FreeConsole();
-                    goto skip_console;
+                    CONSOLE_SCREEN_BUFFER_INFO info;
+                    if (GetConsoleScreenBufferInfo(hOut, &info))
+                    {
+                        bool isFreshWindow = !info.dwCursorPosition.X && !info.dwCursorPosition.Y;
+                        bool isOnlyProcess = false;
+
+                        if (!isFreshWindow && GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") == NULL)
+                        {
+                            DWORD procList[2];
+                            if (GetConsoleProcessList(procList, 2) == 1)
+                                isOnlyProcess = true;
+                        }
+
+                        if (isFreshWindow || isOnlyProcess)
+                        {
+                            FreeConsole();
+                            goto skip_console;
+                        }
+                    }
                 }
             }
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2260,6 +2260,16 @@ s32 main(s32 argc, char **argv)
 
         if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
+            if (!attached)
+            {
+                DWORD procList[2];
+                if (GetConsoleProcessList(procList, 2) == 1)
+                {
+                    FreeConsole();
+                    goto skip_console;
+                }
+            }
+
             // Use freopen as first choice
             if (freopen("CONIN$", "r", stdin) == NULL)
             {
@@ -2302,6 +2312,7 @@ s32 main(s32 argc, char **argv)
             if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
                 FreeConsole();
         }
+        skip_console:;
     }
 #elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
     // Configure terminal to Raw Mode to capture input immediately without OS buffering.

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2255,22 +2255,23 @@ s32 main(s32 argc, char **argv)
         AttachConsole_t pAttachConsole = (AttachConsole_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "AttachConsole");
         
         bool attached = false;
-        if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
-            attached = true;
-
         bool isWine = GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") != NULL;
         char debug[2048] = {0};
         char linkTarget[256] = "N/A";
         char pathIn[MAX_PATH] = "N/A", pathOut[MAX_PATH] = "N/A";
+        char title[1024] = "N/A";
         DWORD modeIn = 0, modeOut = 0;
         DWORD procList[8];
         DWORD procCount = GetConsoleProcessList(procList, 8);
         HWND consoleWnd = GetConsoleWindow();
         CONSOLE_SCREEN_BUFFER_INFO info;
         BOOL hasInfo = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
+        DWORD typeIn = GetFileType(GetStdHandle(STD_INPUT_HANDLE));
+        DWORD typeOut = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
         
         GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &modeIn);
         GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &modeOut);
+        GetConsoleTitleA(title, sizeof(title));
         
         typedef DWORD (WINAPI *GetFinalPathNameByHandleA_t)(HANDLE, LPSTR, DWORD, DWORD);
         GetFinalPathNameByHandleA_t pGetFinalPathNameByHandleA = (GetFinalPathNameByHandleA_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetFinalPathNameByHandleA");
@@ -2288,23 +2289,27 @@ s32 main(s32 argc, char **argv)
             {
                 long ret = wine_syscall(89, "/proc/self/fd/0", linkTarget, sizeof(linkTarget) - 1);
                 if (ret > 0) linkTarget[ret] = '\0';
+                else sprintf(linkTarget, "Error %ld", ret);
             }
+            else strcpy(linkTarget, "No syscall wrapper");
         }
+
+        HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
 
         sprintf(debug, 
             "isWine: %d\n"
-            "Attached: %d\n"
-            "HWND: %p\n"
-            "procCount: %lu\n"
+            "HWND: %p Title: %s\n"
+            "hIn: %p hOut: %p (Inv: %p)\n"
+            "procCount: %lu In/OutType: %lu/%lu\n"
             "isatty(0/1): %d / %d\n"
             "Mode(In/Out): %lu / %lu\n"
             "Cursor: %d, %d\n"
             "PathIn: %s\n"
-            "PathOut: %s\n"
             "Link0: %s",
-            isWine, attached, consoleWnd, procCount, _isatty(0), _isatty(1), modeIn, modeOut,
+            isWine, consoleWnd, title, hIn, hOut, INVALID_HANDLE_VALUE, procCount, typeIn, typeOut, _isatty(0), _isatty(1), modeIn, modeOut,
             hasInfo ? info.dwCursorPosition.X : -1, hasInfo ? info.dwCursorPosition.Y : -1,
-            pathIn, pathOut, linkTarget);
+            pathIn, linkTarget);
 
         MessageBoxA(NULL, debug, "TIC-80 ULTIMATE DEBUG", MB_OK);
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2258,49 +2258,43 @@ s32 main(s32 argc, char **argv)
         if (pAttachConsole && pAttachConsole((DWORD)-1)) // ATTACH_PARENT_PROCESS
             attached = true;
 
-        if (attached || (GetStdHandle(STD_OUTPUT_HANDLE) != NULL && GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE))
+        if (attached)
         {
-            // Use freopen as first choice
-            if (freopen("CONIN$", "r", stdin) == NULL)
-            {
-                // Fallback for redirected input if CONIN$ fails
-                HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
-                if (hIn != INVALID_HANDLE_VALUE)
-                {
-                    int fd = _open_osfhandle((intptr_t)hIn, _O_TEXT);
-                    if (fd != -1) _dup2(fd, 0);
-                }
-            }
-
-            if (freopen("CONOUT$", "w", stdout) == NULL)
-            {
-                // Fallback for redirected output
-                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-                if (hOut != INVALID_HANDLE_VALUE)
-                {
-                    int fd = _open_osfhandle((intptr_t)hOut, _O_TEXT);
-                    if (fd != -1) _dup2(fd, 1);
-                }
-            }
-
-            if (freopen("CONOUT$", "w", stderr) == NULL)
-            {
-                HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
-                if (hErr != INVALID_HANDLE_VALUE)
-                {
-                    int fd = _open_osfhandle((intptr_t)hErr, _O_TEXT);
-                    if (fd != -1) _dup2(fd, 2);
-                }
-            }
-
-            setvbuf(stdout, NULL, _IONBF, 0);
-            setvbuf(stderr, NULL, _IONBF, 0);
+            if (freopen("CONIN$", "r", stdin)) setvbuf(stdin, NULL, _IONBF, 0);
+            if (freopen("CONOUT$", "w", stdout)) setvbuf(stdout, NULL, _IONBF, 0);
+            if (freopen("CONOUT$", "w", stderr)) setvbuf(stderr, NULL, _IONBF, 0);
         }
         else
         {
-            CONSOLE_SCREEN_BUFFER_INFO info;
-            if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
-                FreeConsole();
+            HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+            if (hOut != NULL && hOut != INVALID_HANDLE_VALUE)
+            {
+                if (GetFileType(hOut) == FILE_TYPE_CHAR)
+                {
+                    CONSOLE_SCREEN_BUFFER_INFO info;
+                    if (GetConsoleScreenBufferInfo(hOut, &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
+                        FreeConsole();
+                }
+                else
+                {
+                    int fd = _open_osfhandle((intptr_t)hOut, _O_TEXT);
+                    if (fd != -1) _dup2(fd, 1);
+
+                    HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+                    if (hErr != NULL && hErr != INVALID_HANDLE_VALUE)
+                    {
+                        int fde = _open_osfhandle((intptr_t)hErr, _O_TEXT);
+                        if (fde != -1) _dup2(fde, 2);
+                    }
+
+                    HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+                    if (hIn != NULL && hIn != INVALID_HANDLE_VALUE)
+                    {
+                        int fdi = _open_osfhandle((intptr_t)hIn, _O_TEXT);
+                        if (fdi != -1) _dup2(fdi, 0);
+                    }
+                }
+            }
         }
     }
 #elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "studio/system.h"
+#include "studio/studio.h"
 #include "tools.h"
 
 #include "ext/fft.h"
@@ -344,7 +345,7 @@ static const u8* getSpritePtr(const tic_tile* tiles, s32 x, s32 y)
     return tiles[x / TIC_SPRITESIZE + y / TIC_SPRITESIZE * SheetCols].data;
 }
 
-static u8 getSpritePixel(const tic_tile* tiles, s32 x, s32 y)
+static u8 getSpritePixelLoc(const tic_tile* tiles, s32 x, s32 y)
 {
     return tic_tool_peek4(getSpritePtr(tiles, x, y), (x % TIC_SPRITESIZE) + (y % TIC_SPRITESIZE) * TIC_SPRITESIZE);
 }
@@ -361,7 +362,7 @@ static void setWindowIcon()
         for(s32 j = 0, index = 0; j < Size; j++)
             for(s32 i = 0; i < Size; i++, index++)
             {
-                u8 color = getSpritePixel(studio_config(platform.studio)->cart->bank0.tiles.data, i/Scale, j/Scale);
+                u8 color = getSpritePixelLoc(studio_config(platform.studio)->cart->bank0.tiles.data, i/Scale, j/Scale);
                 pixels[index] = color == ColorKey ? 0 : pal.data[color];
             }
 
@@ -1273,15 +1274,15 @@ static void pollEvents()
         int c = _getch();
         if (c == 0 || c == 224) {
             c = _getch();
-            if (c == 72) platform.keyboard.pressed[tic_key_up] = true;
-            else if (c == 80) platform.keyboard.pressed[tic_key_down] = true;
-            else if (c == 77) platform.keyboard.pressed[tic_key_right] = true;
-            else if (c == 75) platform.keyboard.pressed[tic_key_left] = true;
+            if (c == 72) studio_terminal_input(platform.studio, tic_key_up, 0);
+            else if (c == 80) studio_terminal_input(platform.studio, tic_key_down, 0);
+            else if (c == 77) studio_terminal_input(platform.studio, tic_key_right, 0);
+            else if (c == 75) studio_terminal_input(platform.studio, tic_key_left, 0);
         }
-        else if (c == '\r' || c == '\n') platform.keyboard.pressed[tic_key_return] = true;
-        else if (c == '\b') platform.keyboard.pressed[tic_key_backspace] = true;
-        else if (c == '\t') platform.keyboard.pressed[tic_key_tab] = true;
-        else platform.keyboard.text = (char)c;
+        else if (c == '\r' || c == '\n') studio_terminal_input(platform.studio, tic_key_return, 0);
+        else if (c == '\b') studio_terminal_input(platform.studio, tic_key_backspace, 0);
+        else if (c == '\t') studio_terminal_input(platform.studio, tic_key_tab, 0);
+        else studio_terminal_input(platform.studio, tic_key_unknown, (char)c);
     }
 #elif defined(__TIC_LINUX__) || defined(__APPLE__) || defined(__TIC_MACOSX__)
     {
@@ -1312,10 +1313,10 @@ static void pollEvents()
                             {
                                 if (read(STDIN_FILENO, &seq[1], 1) > 0)
                                 {
-                                    if (seq[1] == 'A') platform.keyboard.pressed[tic_key_up] = true;
-                                    else if (seq[1] == 'B') platform.keyboard.pressed[tic_key_down] = true;
-                                    else if (seq[1] == 'C') platform.keyboard.pressed[tic_key_right] = true;
-                                    else if (seq[1] == 'D') platform.keyboard.pressed[tic_key_left] = true;
+                                    if (seq[1] == 'A') studio_terminal_input(platform.studio, tic_key_up, 0);
+                                    else if (seq[1] == 'B') studio_terminal_input(platform.studio, tic_key_down, 0);
+                                    else if (seq[1] == 'C') studio_terminal_input(platform.studio, tic_key_right, 0);
+                                    else if (seq[1] == 'D') studio_terminal_input(platform.studio, tic_key_left, 0);
                                 }
                             }
                         }
@@ -1323,19 +1324,19 @@ static void pollEvents()
                 }
                 else if (c == '\n' || c == '\r')
                 {
-                    platform.keyboard.pressed[tic_key_return] = true;
+                    studio_terminal_input(platform.studio, tic_key_return, 0);
                 }
                 else if (c == '\b' || c == 0x7f)
                 {
-                    platform.keyboard.pressed[tic_key_backspace] = true;
+                    studio_terminal_input(platform.studio, tic_key_backspace, 0);
                 }
                 else if (c == '\t')
                 {
-                    platform.keyboard.pressed[tic_key_tab] = true;
+                    studio_terminal_input(platform.studio, tic_key_tab, 0);
                 }
                 else
                 {
-                    platform.keyboard.text = c;
+                    studio_terminal_input(platform.studio, tic_key_unknown, c);
                 }
             }
         }

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2294,22 +2294,46 @@ s32 main(s32 argc, char **argv)
             else strcpy(linkTarget, "No syscall wrapper");
         }
 
-        HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
-        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        char classBuf[256] = "N/A";
+        char linkProc[MAX_PATH] = "N/A";
+        COORD bufSize = {0, 0};
+        if (consoleWnd) GetClassNameA(consoleWnd, classBuf, sizeof(classBuf));
+        if (hasInfo) bufSize = info.dwSize;
+
+        if (isWine)
+        {
+            typedef long (*syscall_t)(long, ...);
+            syscall_t wine_syscall = (syscall_t)GetProcAddress(GetModuleHandleA("ntdll.dll"), "syscall");
+            if (wine_syscall)
+            {
+                long ret = wine_syscall(89, "/proc/self/fd/0", linkTarget, sizeof(linkTarget) - 1);
+                if (ret > 0) linkTarget[ret] = '\0';
+                else sprintf(linkTarget, "SYSCALL ERR %ld", ret);
+            }
+            else strcpy(linkTarget, "No syscall wrapper");
+
+            // Try the Z:\ bridge
+            HANDLE hProc = CreateFileA("Z:\\proc\\self\\fd\\0", 0, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+            if (hProc != INVALID_HANDLE_VALUE)
+            {
+                if (pGetFinalPathNameByHandleA) pGetFinalPathNameByHandleA(hProc, linkProc, MAX_PATH, 0);
+                CloseHandle(hProc);
+            }
+        }
 
         sprintf(debug, 
-            "isWine: %d\n"
-            "HWND: %p Title: %s\n"
-            "hIn: %p hOut: %p (Inv: %p)\n"
+            "isWine: %d HWND: %p\n"
+            "Class: %s\n"
+            "Title: %s\n"
+            "hIn: %p hOut: %p\n"
             "procCount: %lu In/OutType: %lu/%lu\n"
-            "isatty(0/1): %d / %d\n"
             "Mode(In/Out): %lu / %lu\n"
-            "Cursor: %d, %d\n"
-            "PathIn: %s\n"
-            "Link0: %s",
-            isWine, consoleWnd, title, hIn, hOut, INVALID_HANDLE_VALUE, procCount, typeIn, typeOut, _isatty(0), _isatty(1), modeIn, modeOut,
-            hasInfo ? info.dwCursorPosition.X : -1, hasInfo ? info.dwCursorPosition.Y : -1,
-            pathIn, linkTarget);
+            "BufSize: %d x %d Cursor: %d, %d\n"
+            "Link0: %s\n"
+            "LinkProc: %s",
+            isWine, consoleWnd, classBuf, title, hIn, hOut, procCount, typeIn, typeOut, modeIn, modeOut,
+            bufSize.X, bufSize.Y, hasInfo ? info.dwCursorPosition.X : -1, hasInfo ? info.dwCursorPosition.Y : -1,
+            linkTarget, linkProc);
 
         MessageBoxA(NULL, debug, "TIC-80 ULTIMATE DEBUG", MB_OK);
 

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2294,6 +2294,8 @@ s32 main(s32 argc, char **argv)
             else strcpy(linkTarget, "No syscall wrapper");
         }
 
+        HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
         char classBuf[256] = "N/A";
         char linkProc[MAX_PATH] = "N/A";
         COORD bufSize = {0, 0};

--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -2251,140 +2251,41 @@ s32 main(s32 argc, char **argv)
 {
 #if defined(__TIC_WINDOWS__)
     {
-        typedef BOOL (WINAPI *AttachConsole_t)(DWORD);
-        AttachConsole_t pAttachConsole = (AttachConsole_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "AttachConsole");
-        
-        bool attached = false;
         bool isWine = GetProcAddress(GetModuleHandleA("ntdll.dll"), "wine_get_version") != NULL;
-        char debug[2048] = {0};
-        char linkTarget[256] = "N/A";
-        char pathIn[MAX_PATH] = "N/A", pathOut[MAX_PATH] = "N/A";
-        char title[1024] = "N/A";
-        DWORD modeIn = 0, modeOut = 0;
-        DWORD procList[8];
-        DWORD procCount = GetConsoleProcessList(procList, 8);
         HWND consoleWnd = GetConsoleWindow();
-        CONSOLE_SCREEN_BUFFER_INFO info;
-        BOOL hasInfo = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
-        DWORD typeIn = GetFileType(GetStdHandle(STD_INPUT_HANDLE));
-        DWORD typeOut = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
-        
-        GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &modeIn);
-        GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &modeOut);
-        GetConsoleTitleA(title, sizeof(title));
-        
-        typedef DWORD (WINAPI *GetFinalPathNameByHandleA_t)(HANDLE, LPSTR, DWORD, DWORD);
-        GetFinalPathNameByHandleA_t pGetFinalPathNameByHandleA = (GetFinalPathNameByHandleA_t)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetFinalPathNameByHandleA");
-        if (pGetFinalPathNameByHandleA)
+
+        if (GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
         {
-            pGetFinalPathNameByHandleA(GetStdHandle(STD_INPUT_HANDLE), pathIn, MAX_PATH, 0);
-            pGetFinalPathNameByHandleA(GetStdHandle(STD_OUTPUT_HANDLE), pathOut, MAX_PATH, 0);
-        }
-
-        if (isWine)
-        {
-            typedef long (*syscall_t)(long, ...);
-            syscall_t wine_syscall = (syscall_t)GetProcAddress(GetModuleHandleA("ntdll.dll"), "syscall");
-            if (wine_syscall)
+            if (consoleWnd != NULL)
             {
-                long ret = wine_syscall(89, "/proc/self/fd/0", linkTarget, sizeof(linkTarget) - 1);
-                if (ret > 0) linkTarget[ret] = '\0';
-                else sprintf(linkTarget, "Error %ld", ret);
-            }
-            else strcpy(linkTarget, "No syscall wrapper");
-        }
+                bool shouldHide = false;
 
-        HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
-        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-        char classBuf[256] = "N/A";
-        char linkProc[MAX_PATH] = "N/A";
-        char linkTargetResolved[MAX_PATH] = "N/A";
-        COORD bufSize = {0, 0};
-        int winWidth = 0, winHeight = 0;
-        BOOL isVisible = IsWindowVisible(consoleWnd);
-        if (consoleWnd) GetClassNameA(consoleWnd, classBuf, sizeof(classBuf));
-        if (hasInfo)
-        {
-            bufSize = info.dwSize;
-            winWidth = info.srWindow.Right - info.srWindow.Left + 1;
-            winHeight = info.srWindow.Bottom - info.srWindow.Top + 1;
-        }
-
-        if (isWine)
-        {
-            typedef long (*syscall_t)(long, ...);
-            syscall_t wine_syscall = (syscall_t)GetProcAddress(GetModuleHandleA("ntdll.dll"), "syscall");
-            if (wine_syscall)
-            {
-                long ret = wine_syscall(89, "/proc/self/fd/0", linkTarget, sizeof(linkTarget) - 1);
-                if (ret > 0) linkTarget[ret] = '\0';
-                else sprintf(linkTarget, "SYSCALL ERR %ld", ret);
-            }
-            else strcpy(linkTarget, "No syscall wrapper");
-
-            // Try the Z:\ bridge WITH backup semantics (to see symlink path)
-            HANDLE hProc = CreateFileA("Z:\\proc\\self\\fd\\0", 0, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
-            if (hProc != INVALID_HANDLE_VALUE)
-            {
-                if (pGetFinalPathNameByHandleA) pGetFinalPathNameByHandleA(hProc, linkProc, MAX_PATH, 0);
-                CloseHandle(hProc);
-            }
-
-            // Try the Z:\ bridge WITHOUT backup semantics (to see target path)
-            HANDLE hTarget = CreateFileA("Z:\\proc\\self\\fd\\0", 0, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
-            if (hTarget != INVALID_HANDLE_VALUE)
-            {
-                if (pGetFinalPathNameByHandleA) pGetFinalPathNameByHandleA(hTarget, linkTargetResolved, MAX_PATH, 0);
-                CloseHandle(hTarget);
-            }
-        }
-
-        sprintf(debug, 
-            "isWine: %d HWND: %p Vis: %d\n"
-            "Class: %s Title: %s\n"
-            "hIn: %p hOut: %p (procC: %lu)\n"
-            "In/OutType: %lu/%lu Mode: %lu/%lu\n"
-            "Buf: %dx%d Win: %dx%d\n"
-            "Link0: %s\n"
-            "LProc: %s\n"
-            "LRes: %s",
-            isWine, consoleWnd, isVisible,
-            classBuf, title, hIn, hOut, procCount,
-            typeIn, typeOut, modeIn, modeOut,
-            bufSize.X, bufSize.Y, winWidth, winHeight,
-            linkTarget, linkProc, linkTargetResolved);
-
-        MessageBoxA(NULL, debug, "TIC-80 ULTIMATE DEBUG", MB_OK);
-
-        if (attached || GetStdHandle(STD_OUTPUT_HANDLE) != INVALID_HANDLE_VALUE)
-        {
-            if (!attached)
-            {
-                if (consoleWnd != NULL)
+                if (isWine)
                 {
-                    bool shouldHide = false;
-                    if (isWine)
-                    {
-                        if (strncmp(linkTarget, "/dev/null", 9) == 0) shouldHide = true;
-                    }
-                    else
-                    {
-                        if (procCount == 1) shouldHide = true;
-                        else if (hasInfo && !info.dwCursorPosition.X && !info.dwCursorPosition.Y) shouldHide = true;
-                    }
+                    // On Wine, terminal launches don't have a visible console window (Vis: 0).
+                    // GUI launches (e.g. from KDE) create a visible virtual console (Vis: 1).
+                    if (IsWindowVisible(consoleWnd))
+                        shouldHide = true;
+                }
+                else
+                {
+                    // Native Windows: A fresh console window (GUI launch) is shared by only 1 process.
+                    // Terminal launches (CMD/PowerShell) share the console with the shell (2+ processes).
+                    DWORD procList[2];
+                    if (GetConsoleProcessList(procList, 2) == 1)
+                        shouldHide = true;
+                }
 
-                    if (shouldHide)
-                    {
-                        FreeConsole();
-                        goto skip_console;
-                    }
+                if (shouldHide)
+                {
+                    FreeConsole();
+                    goto skip_console;
                 }
             }
 
-            // Use freopen as first choice
+            // Standard stream redirection for attached consoles
             if (freopen("CONIN$", "r", stdin) == NULL)
             {
-                // Fallback for redirected input if CONIN$ fails
                 HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
                 if (hIn != INVALID_HANDLE_VALUE)
                 {
@@ -2395,7 +2296,6 @@ s32 main(s32 argc, char **argv)
 
             if (freopen("CONOUT$", "w", stdout) == NULL)
             {
-                // Fallback for redirected output
                 HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
                 if (hOut != INVALID_HANDLE_VALUE)
                 {
@@ -2419,9 +2319,13 @@ s32 main(s32 argc, char **argv)
         }
         else
         {
-            CONSOLE_SCREEN_BUFFER_INFO info;
-            if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
-                FreeConsole();
+            // Fallback for cases where no handles are available at all
+            if (consoleWnd != NULL && IsWindowVisible(consoleWnd))
+            {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if(GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) && !info.dwCursorPosition.X && !info.dwCursorPosition.Y)
+                    FreeConsole();
+            }
         }
         skip_console:;
     }


### PR DESCRIPTION
I noticed that the output of the TIC-80 console was going to my system console, this is quite nice specially when there are a lot of output.

But then I thought: what if we could run commands from the system console too? just mirror both consoles?

This PR allows to do just that, I can type commands using the system console, or through the SDL console. It even allows to run commands while the SDL screen is on a different screen, like on the studio or running a game.

Tested on: Linux, Windows, and Wine.

<img width="1922" height="2113" alt="Screenshot from 2026-06-02 20-57-40" src="https://github.com/user-attachments/assets/12e576d2-78c2-4594-96a9-47cdade074e9" />
