### PR TITLE
Fix missing comma in JanetKeywords and SchemeKeywords arrays

### DIFF
--- a/src/api/janet.c
+++ b/src/api/janet.c
@@ -152,7 +152,7 @@ static const JanetReg janet_c_functions[] =
 static const char* const JanetKeywords[] =
 {
     "defmacro", "with-syms", "macex1", "macex",
-    "do", "values", "break"
+    "do", "values", "break",
     "if", "when", "cond", "match",
     "each", "for", "loop", "while",
     "fn", "defn", "partial",

--- a/src/api/scheme.c
+++ b/src/api/scheme.c
@@ -934,7 +934,7 @@ static const char* const SchemeKeywords [] =
 {
     "define", "lambda", "begin", "set!", "=", "<", "<=", ">", ">=", "+", "*",
     "/", "'", "`", "`@", "define-macro", "let", "let*", "letrec", "defstruct",
-    "if", "cond", "floor", "ceiling", "sin", "cos", "log", "sqrt", "abs"
+    "if", "cond", "floor", "ceiling", "sin", "cos", "log", "sqrt", "abs",
     "logand", "logior", "logxor", "lognot", "logbit?", "sinh", "cosh", "tanh",
     "asinh", "acosh", "atanh", "nan?", "infinite?", "nan",
     "exp", "expt", "tan", "acos", "asin", "atan", "truncate", "round",


### PR DESCRIPTION
`clangd` pointed this as a possible mistake.