### PR TITLE
AndroidManifest -> Set to Game category, and fix `.tic` association on Android 12+

### DIFF
--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -66,6 +66,7 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:isGame="true"
         android:hardwareAccelerated="true" >
 
         <meta-data android:name="android.app.category" android:value="game" />
@@ -83,6 +84,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" /> <!-- Android TV -->
                 <category android:name="android.intent.category.GAME" />
             </intent-filter>
 

--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,8 @@
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
         android:hardwareAccelerated="true" >
 
+        <meta-data android:name="android.app.category" android:value="game" />
+
         <meta-data android:name="SDL_ENV.SDL_ACCELEROMETER_AS_JOYSTICK" android:value="0"/>
 
         <activity android:name="TIC"
@@ -80,7 +82,7 @@
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.GAME" />
             </intent-filter>
 
             <!-- Let Android know that we can handle some USB devices and should receive this event -->

--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -82,6 +82,7 @@
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.GAME" />
             </intent-filter>
 

--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -110,6 +110,9 @@
                 <data android:mimeType="*/*" android:pathPattern=".*\\.tIC" />
                 <data android:mimeType="*/*" android:pathPattern=".*\\.tiC" />
                 <data android:mimeType="*/*" android:pathPattern=".*\\.TiC" />
+
+                <!-- Android 12+ -->
+                <data android:mimeType="*/*" android:pathSuffix=".tic" />
             </intent-filter>
 
             <!-- Handle .png files -->

--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -66,7 +66,7 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-        android:isGame="true"
+        android:appCategory="game"
         android:hardwareAccelerated="true" >
 
         <meta-data android:name="android.app.category" android:value="game" />
@@ -94,7 +94,7 @@
             </intent-filter>
 
             <!-- Drop file event -->
-            <!-- Handle .tic files -->
+            <!-- Handle .tic files, legacy support, Android 12 or older -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -110,8 +110,14 @@
                 <data android:mimeType="*/*" android:pathPattern=".*\\.tIC" />
                 <data android:mimeType="*/*" android:pathPattern=".*\\.tiC" />
                 <data android:mimeType="*/*" android:pathPattern=".*\\.TiC" />
+            </intent-filter>
 
-                <!-- Android 12+ -->
+            <!-- Handle .tic files, Android 12+ -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
                 <data android:mimeType="*/*" android:pathSuffix=".tic" />
             </intent-filter>
 


### PR DESCRIPTION
Adds association to .tic files to newer Android versions. (12+)

The `.tic` association was working on my older phone, so this is probably a fix for just the newer versions.

The `.png` is still working fine.

And I have set the App to be in the Game category, so some launchers (like Daijisho) organize it in a Game section.