### PR TITLE
Dynamic controller assignment

### DIFF
--- a/src/system/sdl/main.c
+++ b/src/system/sdl/main.c
@@ -119,7 +119,8 @@ static struct
 
     struct
     {
-        SDL_GameController* ports[TIC_GAMEPADS];
+        SDL_GameController* ports[16];
+        SDL_JoystickID mapping[TIC_GAMEPADS];
 
 #if defined(TOUCH_INPUT_SUPPORT)
         struct
@@ -947,11 +948,23 @@ static u8 getButton(SDL_GameController* controller, SDL_GameControllerButton but
         : 0;
 }
 
+static bool isControllerActive(SDL_GameController* controller)
+{
+    for(s32 i = 0; i < SDL_CONTROLLER_BUTTON_MAX; i++)
+        if(SDL_GameControllerGetButton(controller, i))
+            return true;
+
+    for(s32 i = 0; i < SDL_CONTROLLER_AXIS_MAX; i++)
+        if(abs(SDL_GameControllerGetAxis(controller, i)) > AXIS_THRESHOLD)
+            return true;
+
+    return false;
+}
+
 static void processGamepad()
 {
     {
         platform.gamepad.joystick.data = 0;
-        s32 index = 0;
 
         for(s32 i = 0; i < COUNT_OF(platform.gamepad.ports); i++)
         {
@@ -959,9 +972,45 @@ static void processGamepad()
 
             if(controller && SDL_GameControllerGetAttached(controller))
             {
+                SDL_JoystickID id = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller));
+
+                bool mapped = false;
+                for(s32 j = 0; j < TIC_GAMEPADS; j++)
+                {
+                    if(platform.gamepad.mapping[j] == id)
+                    {
+                        mapped = true;
+                        break;
+                    }
+                }
+
+                if(!mapped && isControllerActive(controller))
+                {
+                    for(s32 j = 0; j < TIC_GAMEPADS; j++)
+                    {
+                        if(platform.gamepad.mapping[j] == -1)
+                        {
+                            platform.gamepad.mapping[j] = id;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        for(s32 i = 0; i < TIC_GAMEPADS; i++)
+        {
+            SDL_JoystickID id = platform.gamepad.mapping[i];
+
+            if(id == -1) continue;
+
+            SDL_GameController* controller = SDL_GameControllerFromInstanceID(id);
+
+            if(controller && SDL_GameControllerGetAttached(controller))
+            {
                 tic80_gamepad* gamepad = NULL;
 
-                switch(index)
+                switch(i)
                 {
                 case 0: gamepad = &platform.gamepad.joystick.first; break;
                 case 1: gamepad = &platform.gamepad.joystick.second; break;
@@ -1015,8 +1064,6 @@ static void processGamepad()
                         tic80_input* input = &platform.input;
                         input->keyboard.keys[0] = tic_key_escape;
                     }
-
-                    index++;
                 }
             }
         }
@@ -1173,12 +1220,13 @@ static void pollEvents()
 
                 if(SDL_IsGameController(id))
                 {
-                    if (id < TIC_GAMEPADS)
+                    for(s32 i = 0; i < COUNT_OF(platform.gamepad.ports); i++)
                     {
-                        if(platform.gamepad.ports[id])
-                            SDL_GameControllerClose(platform.gamepad.ports[id]);
-
-                        platform.gamepad.ports[id] = SDL_GameControllerOpen(id);
+                        if(platform.gamepad.ports[i] == NULL)
+                        {
+                            platform.gamepad.ports[i] = SDL_GameControllerOpen(id);
+                            break;
+                        }
                     }
                 }
             }
@@ -1187,10 +1235,27 @@ static void pollEvents()
             {
                 s32 id = event.cdevice.which;
 
-                if (id < TIC_GAMEPADS && platform.gamepad.ports[id])
+                for(s32 i = 0; i < COUNT_OF(platform.gamepad.ports); i++)
                 {
-                    SDL_GameControllerClose(platform.gamepad.ports[id]);
-                    platform.gamepad.ports[id] = NULL;
+                    if(platform.gamepad.ports[i])
+                    {
+                        SDL_Joystick* joystick = SDL_GameControllerGetJoystick(platform.gamepad.ports[i]);
+                        if(joystick && SDL_JoystickInstanceID(joystick) == id)
+                        {
+                            SDL_GameControllerClose(platform.gamepad.ports[i]);
+                            platform.gamepad.ports[i] = NULL;
+                            break;
+                        }
+                    }
+                }
+
+                for(s32 i = 0; i < COUNT_OF(platform.gamepad.mapping); i++)
+                {
+                    if(platform.gamepad.mapping[i] == id)
+                    {
+                        platform.gamepad.mapping[i] = -1;
+                        break;
+                    }
                 }
             }
             break;
@@ -1962,6 +2027,9 @@ static s32 start(s32 argc, char **argv, const char* folder)
     {
         SDL_Log("Unable to initialize SDL Game Controller: %i, %s\n", result, SDL_GetError());
     }
+
+    for(s32 i = 0; i < COUNT_OF(platform.gamepad.mapping); i++)
+        platform.gamepad.mapping[i] = -1;
 
     platform.studio = studio_create(argc, argv, TIC80_SAMPLERATE, SCREEN_FORMAT, folder, determineMaximumScale(), detect_keyboard_layout());
 


### PR DESCRIPTION
This was mainly coded by Gemini, I mostly reviewed and tested it.

This fixes #2955. I tested with [cart 893](https://tic80.com/play?cart=893), note that this test cart is positioned as:
| P1 | P3 |
|----|----|
| P2 | P4 |

Before this patch, when I try to play on my PC with a Xbox controller, it is assigned to P3. If I plug another controller, it gets assigned to P4.

With this patch I also ested that:
The first player to that moves or press any button is the 1st player. If I turn it off and on again, it also keeps being the 1st player.

This will probably have a merge conflict with #2952

Following is the comments by Gemini:

### Key Changes:
Increased Controller Support: Expanded the internal controller ports from 4 to 16. This ensures that even if you have multiple "ghost" devices or adapters at low SDL indices, your active controller will still be detected and opened.

Assignment by First Use: Introduced a mapping system that tracks the registration order of controllers. A controller is only assigned to a player slot (1-4) once it shows some activity (button press or stick movement).

Active Removal Handling: Corrected the hotplug logic to properly identify which controller is being disconnected using its unique SDL Instance ID, ensuring assigned slots are freed if a controller is unplugged.

Robust Mapping: Initialized all player slots as unassigned at startup. The first controller to send input becomes Player 1, the second becomes Player 2, and so on.

### Details:
- Added SDL_JoystickID mapping[TIC_GAMEPADS] to the platform.gamepad structure.
- Implemented isControllerActive() to detect button presses or axis movements exceeding a deadzone threshold.
- Updated processGamepad() to perform a two-phase check: first, mapping unassigned active controllers to available slots; then, reading input from the mapped controllers.
- Fixed SDL_CONTROLLERDEVICEREMOVED to use Instance IDs instead of indices, which is the correct behavior for this SDL event.