### PR TITLE
Fix #2773: space key broken with KEYBOARD_LAYOUT_ES after tic_key_iso_extra removal

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -432,10 +432,10 @@ char getKeyboardText(Studio* studio)
         tic80_input* input = &tic->ram->input;
 
 #ifdef KEYBOARD_LAYOUT_ES
-        // US KEYS:                     " abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./< ";
-        static const char Symbols[] =   " abcdefghijklmnopqrstuvwxyz0123456789'!`+cn'o,.-< ";
-        static const char Shift[] =     " ABCDEFGHIJKLMNOPQRSTUVWXYZ=!\" $%&/()??^*CN\"a;:_> ";
-        static const char Alt[] =       "                            |@#        []} {\\     ";
+        // US KEYS:                     " abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./ ";
+        static const char Symbols[] =   " abcdefghijklmnopqrstuvwxyz0123456789'!`+cn'o,.- ";
+        static const char Shift[] =     " ABCDEFGHIJKLMNOPQRSTUVWXYZ=!\" $%&/()??^*CN\"a;:_ ";
+        static const char Alt[] =       "                            |@#        []} {\\    ";
 #else
         static const char Symbols[] =   " abcdefghijklmnopqrstuvwxyz0123456789-=[]\\;'`,./ ";
         static const char Shift[] =     " ABCDEFGHIJKLMNOPQRSTUVWXYZ)!@#$%^&*(_+{}|:\"~<>? ";


### PR DESCRIPTION
Closes #2773

Commit 1149e7cd (#2768) fixed baremetal space by removing `tic_key_iso_extra`, shifting `tic_key_space` to index 48. Non-ES builds were automatically fixed (the trailing `' '` was already at index 48). But `KEYBOARD_LAYOUT_ES` arrays still had `<`/`>` at position 48 (the old ISO extra key slot), so ES builds got `<` for space and `>` for shift+space. ALT+Space still worked (explaining the workaround described in the issue).

**Fix:** Remove `<` from `Symbols[48]` and `>` from `Shift[48]` in the ES layout so `tic_key_space (48)` correctly maps to `' '` across all layouts. Also trims `Alt` by one character for consistency and updates the reference comment.