### PR TITLE
Fix #2920: Python sfx() ignores note/octave/speed from SFX editor

### DIFF
--- a/src/api/python.c
+++ b/src/api/python.c
@@ -824,7 +824,7 @@ static bool py_reset(int argc, py_Ref argv)
     return true;
 }
 
-// sfx(id: int, note=-1, duration=-1, channel=0, volume=15, speed=0)
+// sfx(id: int, note=-1, duration=-1, channel=0, volume=15, speed=-1)
 // void (*sfx)(tic_mem*, s32, s32, s32, s32, s32, s32, s32, s32)
 static bool py_sfx(int argc, py_Ref argv)
 {
@@ -839,7 +839,29 @@ static bool py_sfx(int argc, py_Ref argv)
     s32 volume = py_toint(py_arg(4));
     s32 speed = py_toint(py_arg(5));
 
-    s32 note, octave;
+    if (channel < 0 || channel >= TIC_SOUND_CHANNELS)
+    {
+        return ValueError("invalid channel");
+    }
+    if (id >= SFX_COUNT)
+    {
+        return ValueError("invalid sfx index");
+    }
+
+    tic_core* core = get_core();
+    tic_mem* tic = (tic_mem*)core;
+
+    s32 note = -1;
+    s32 octave = -1;
+
+    if (id >= 0)
+    {
+        tic_sample* effect = tic->ram->sfx.samples.data + id;
+        note = effect->note;
+        octave = effect->octave;
+        if (speed == -1) speed = effect->speed;
+    }
+
     if (py_isstr(py_arg(1)))
     {
         const char* str_note = py_tostr(py_arg(1));
@@ -852,21 +874,14 @@ static bool py_sfx(int argc, py_Ref argv)
     {
         PY_CHECK_ARG_TYPE(1, tp_int);
         s32 raw_note = py_toint(py_arg(1));
-        note = raw_note % NOTES;
-        octave = raw_note / NOTES;
+        if (raw_note != -1)
+        {
+            note = raw_note % NOTES;
+            octave = raw_note / NOTES;
+        }
     }
 
-    if (channel < 0 || channel >= TIC_SOUND_CHANNELS)
-    {
-        return ValueError("invalid channel");
-    }
-    if (id >= SFX_COUNT)
-    {
-        return ValueError("invalid sfx index");
-    }
-
-    tic_core* core = get_core();
-    core->api.sfx((tic_mem*)core, id, note, octave, duration, channel, volume & 0xf, volume & 0xf, speed);
+    core->api.sfx(tic, id, note, octave, duration, channel, volume & 0xf, volume & 0xf, speed);
     py_newnone(py_retval());
     return true;
 }
@@ -1111,7 +1126,7 @@ static void bind_pkpy_v2()
     py_bind(mod, "rect(x: int, y: int, w: int, h: int, color: int)", py_rect);
     py_bind(mod, "rectb(x: int, y: int, w: int, h: int, color: int)", py_rectb);
     py_bind(mod, "reset()", py_reset);
-    py_bind(mod, "sfx(id: int, note=-1, duration=-1, channel=0, volume=15, speed=0)", py_sfx);
+    py_bind(mod, "sfx(id: int, note=-1, duration=-1, channel=0, volume=15, speed=-1)", py_sfx);
     py_bind(mod, "sync(mask=0, bank=0, tocart=False)", py_sync);
     py_bind(mod, "ttri(x1: float, y1: float, x2: float, y2: float, x3: float, y3: float, u1: float, v1: float, u2: float, v2: float, u3: float, v3: float, texsrc=0, chromakey=-1, z1=0.0, z2=0.0, z3=0.0)", py_ttri);
     py_bind(mod, "time() -> float", py_time);


### PR DESCRIPTION
Closes #2920

## What

The Python `sfx()` binding never read the stored note, octave, or speed from the SFX sample data. When called as `sfx(0)` (no note specified), it computed `note = -1 % 12 = -1` and `octave = -1 / 12 = 0`, causing playback at C-1 regardless of what's set in the SFX tab. All other language bindings (Lua, JS, Wren, etc.) work correctly because they read from the sample data first.

## Fix

Mirrors the Lua binding: read `effect->note`, `effect->octave`, and `effect->speed` from `tic->ram->sfx.samples.data` as defaults before applying any user-provided overrides.

Also changes `speed`'s default sentinel from `0` to `-1` (matching `note`/`duration`) so the effect's stored speed is used when not explicitly specified.