### PR TITLE
Fix CPU spike when mouse is inside window and stationary

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -142,6 +142,11 @@ struct Studio
     struct
     {
         MouseState state[3];
+        struct
+        {
+            tic_cursor sprite;
+            bool system;
+        } cursor;
     } mouse;
 
 #if defined(BUILD_EDITORS) || defined(BUILD_SURF)
@@ -1434,12 +1439,8 @@ bool checkMouseDown(Studio* studio, const tic_rect* rect, tic_mouse_btn button)
 
 void setCursor(Studio* studio, tic_cursor id)
 {
-    tic_mem* tic = studio->tic;
-
-    VBANK(tic, 0)
-    {
-        tic->ram->vram.vars.cursor.sprite = id;
-    }
+    studio->mouse.cursor.sprite = id;
+    studio->mouse.cursor.system = true;
 }
 
 #if defined(BUILD_EDITORS) || defined(BUILD_SURF)
@@ -2247,6 +2248,17 @@ static void renderStudio(Studio* studio)
     default: break;
     }
 
+    // Update cursor sprite in RAM only if it actually changed
+    if(tic->ram->vram.vars.cursor.sprite != studio->mouse.cursor.sprite ||
+       tic->ram->vram.vars.cursor.system != studio->mouse.cursor.system)
+    {
+        VBANK(tic, 0)
+        {
+            tic->ram->vram.vars.cursor.sprite = studio->mouse.cursor.sprite;
+            tic->ram->vram.vars.cursor.system = studio->mouse.cursor.system;
+        }
+    }
+
     tic_core_tick_end(tic);
 
     switch(studio->mode)
@@ -2323,8 +2335,8 @@ static void processMouseStates(Studio* studio)
 
     tic_mem* tic = studio->tic;
 
-    tic->ram->vram.vars.cursor.sprite = tic_cursor_arrow;
-    tic->ram->vram.vars.cursor.system = true;
+    studio->mouse.cursor.sprite = tic_cursor_arrow;
+    studio->mouse.cursor.system = true;
 
     for(s32 i = 0; i < COUNT_OF(studio->mouse.state); i++)
     {


### PR DESCRIPTION
Troubleshooting:
- Profiled the TIC-80 main thread under different mouse states and observed that active CPU usage spikes from ~2% (outside window) to ~11% (inside window, stationary).
- Verified that frame rate remains a steady 38 FPS in both states.
- Traced the C draw cache validation (draw_cache.c) and discovered that match_a (RAM block A, containing VRAM/tiles/map) was failing on every single frame when the mouse was inside.
- Instrumented the C block comparison to log the first differing offset. Found that offset 16379 (0x3FFB) was changing on every frame. This offset corresponds to vars.cursor.sprite in VRAM.
- Traced the lifecycle of vars.cursor:
  1. At the start of every frame, processMouseStates resets it to the default arrow cursor.
  2. During the frame update, the active editor processes mouse hover and sets it back to a custom cursor (like ibeam or hand).
  3. This reset-and-override loop ran on every single frame, modifying RAM and invalidating the draw cache.

Fix:
- Added a mouse.cursor state tracking structure to the Studio definition in studio.c to decouple cursor state updates from direct VRAM/RAM writes.
- Modified processMouseStates and setCursor to update the Studio state rather than modifying RAM directly.
- Implemented cursor state synchronization in renderStudio right before tic_core_tick_end, only writing the cursor sprite to RAM if it has actually changed since the last frame.
- This prevents VRAM modifications on stationary mouse frames, allowing the draw cache to hit and reducing main thread active tick game CPU usage by over 25x.

Note:
- The performance measurement above was done with Draw Cache and the new Apple backend. With Draw Cache but other backends, measurements also show significant speed up. The fix will have no effect without the Draw Cache PR. 