### PR TITLE
libretro: don't treat optional environment calls as fatal

### DIFF
--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -78,6 +78,8 @@ struct tic80_state
 	int mouseHideTimerStart;
 	tic80* tic;
 	retro_usec_t frameTime;
+	bool hasFrameTimeCallback;
+	bool shutdownRequested;
 };
 static struct tic80_state* state = NULL;
 
@@ -1061,15 +1063,29 @@ RETRO_API void retro_run(void)
 		return;
 	}
 
-	// Update the TIC-80 environment.
-	tic80_libretro_update(state->tic);
-
-	// Check if the game requested to quit.
+	// Check if the game requested to quit. Tearing down here would free the
+	// memory that retro_get_memory_data() handed to the frontend, so only ask
+	// the frontend to shut down and leave the cleanup to retro_unload_game().
 	if (state->quit) {
-		retro_deinit();
-		environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, NULL);
+		if (!state->shutdownRequested) {
+			state->shutdownRequested = true;
+			if (!environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, NULL)) {
+				log_cb(RETRO_LOG_WARN, "[TIC-80] Frontend ignored the shutdown request.\n");
+			}
+		}
+
+		// Send a duplicate frame while waiting for the frontend to shut down.
+		video_cb(NULL, TIC80_FULLWIDTH, TIC80_FULLHEIGHT, TIC80_FULLWIDTH << 2);
 		return;
 	}
+
+	// Advance the clock manually when the frontend doesn't drive it.
+	if (!state->hasFrameTimeCallback) {
+		tic80_libretro_frame_time(TIC80_FREQUENCY / TIC80_FRAMERATE);
+	}
+
+	// Update the TIC-80 environment.
+	tic80_libretro_update(state->tic);
 
 	// Render the screen.
 	tic80_libretro_draw(state->tic);
@@ -1121,9 +1137,12 @@ RETRO_API bool retro_load_game(const struct retro_game_info *info)
 		.callback = tic80_libretro_frame_time,
 		.reference = TIC80_FREQUENCY / TIC80_FRAMERATE,
 	};
-	if (!environ_cb(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &frame_time)) {
-		log_cb(RETRO_LOG_ERROR, "[TIC-80] Failed to set frame time callback.\n");
-		return false;
+
+	// The frame time callback is optional, so fall back to a fixed timestep
+	// when the frontend doesn't provide one.
+	state->hasFrameTimeCallback = environ_cb(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &frame_time);
+	if (!state->hasFrameTimeCallback) {
+		log_cb(RETRO_LOG_WARN, "[TIC-80] No frame time callback, so using a fixed timestep.\n");
 	}
 
 	// Set up the TIC-80 environment.
@@ -1144,6 +1163,7 @@ RETRO_API bool retro_load_game(const struct retro_game_info *info)
 
 	// Initialize some of the game state.
 	state->quit = false;
+	state->shutdownRequested = false;
 	state->input.mouse.x = 0;
 	state->input.mouse.y = 0;
 


### PR DESCRIPTION
I am a RetroAchievements administrator, and I am interested in seeing if achievement development for TIC-80 is viable.

Currently, the TIC-80 libretro core does not load in minimal frontends. This is a major blocking issue, as this is currently blocking the use of the RetroAchievements toolkit (RALibretro), which needs the core to load and to expose memory so that one can make achievements for TIC-80 carts.

RetroArch hides both problems below, because it implements the optional calls that the core assumes are always available.

### What is wrong

**1. An optional environment call is fatal.**

`retro_load_game()` returns `false` when the frontend does not implement `RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK`. That call is optional. A frontend returns `false` to say it does not implement it, and the core must continue. The check is also above `tic80_create()`, so `retro_get_memory_data()` then gives no memory. This looks like a memory problem, but it is actually a load problem.

**2. The core frees itself inside `retro_run()`.**

When a cart calls `exit()`, the core calls `retro_deinit()`. This frees the buffer that the frontend received earlier from `retro_get_memory_data()`. Frontends keep that pointer and keep reading through it. This is a use-after-free. The frontend now reads memory that has been returned to the allocator and may already hold something else. It does not crash cleanly, which is what makes it hard to notice.

`RETRO_ENVIRONMENT_SHUTDOWN` is only a request. A frontend that does not implement it keeps calling `retro_run()`, so this block runs again on every frame.

### The fix

This PR makes two remediations:
1. We record the result of the frame time call and continue. When the frontend does not drive the clock, the core advances it with a fixed timestep. Both paths use the same accumulator, so there is one clock.
2. We ask the frontend to shut down one time, then hold the last frame. Teardown stays with `retro_unload_game()` and `retro_deinit()`, where the libretro API puts it.

Frontends that implement both calls see no change in behavior.

### Testing

These changes were tested with a minimal libretro host that returns `false` for every environment call except `SET_PIXEL_FORMAT`, and with a build that accepts them.

I also tested this with ~20 carts and saw no regressions.

|                                             | before   | after           |
|---------------------------------------------|----------|-----------------|
| retro_load_game(), env 21 unsupported       | false    | true            |
| SYSTEM_RAM size / data                      | 0 / NULL | 0x18000 / valid |
| time() after 180 frames, env 21 unsupported | 0 ms     | 2999 ms         |
| time() after 180 frames, env 21 supported   | 2999 ms  | 2999 ms         |

2999ms is 180 frames x 16666µs, so the fallback clock is confirmed to be running at the correct rate.

**Before**
<img width="1138" height="840" alt="Screenshot 2026-08-09 at 2 38 51 PM" src="https://github.com/user-attachments/assets/334be9a4-20ff-4e38-b3fd-ae7a06345777" />

**After**
<img width="1140" height="850" alt="Screenshot 2026-08-09 at 2 39 39 PM" src="https://github.com/user-attachments/assets/a2bd8382-8c57-4734-9fe8-90cce4061f3d" />