### PR TITLE
Declare tic80_tick's callbacks as they are defined and called

### DIFF
--- a/include/tic80.h
+++ b/include/tic80.h
@@ -186,7 +186,7 @@ typedef struct
 
 TIC80_API tic80* tic80_create(s32 samplerate, tic80_pixel_color_format format);
 TIC80_API void tic80_load(tic80* tic, void* cart, s32 size);
-TIC80_API void tic80_tick(tic80* tic, tic80_input input, u64 (*counter)(), u64 (*freq)());
+TIC80_API void tic80_tick(tic80* tic, tic80_input input, u64 (*counter)(void*), u64 (*freq)(void*));
 TIC80_API void tic80_sound(tic80* tic);
 TIC80_API void tic80_delete(tic80* tic);
 

--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -84,7 +84,7 @@ static struct tic80_state* state = NULL;
 /**
  * TIC-80 callback; Request counter.
  */
-static u64 tic80_libretro_counter()
+static u64 tic80_libretro_counter(void* data)
 {
 	if (state == NULL) {
 		return 0;
@@ -96,7 +96,7 @@ static u64 tic80_libretro_counter()
 /**
  * TIC-80 callback; Request frequency.
  */
-static u64 tic80_libretro_frequency()
+static u64 tic80_libretro_frequency(void* data)
 {
 	return TIC80_FREQUENCY;
 }

--- a/src/system/sdl/player.c
+++ b/src/system/sdl/player.c
@@ -48,12 +48,12 @@ static void onExit()
     state.quit = true;
 }
 
-static u64 tic_sys_counter_get()
+static u64 tic_sys_counter_get(void* data)
 {
     return SDL_GetPerformanceCounter();
 }
 
-static u64 tic_sys_freq_get()
+static u64 tic_sys_freq_get(void* data)
 {
     return SDL_GetPerformanceFrequency();
 }


### PR DESCRIPTION
`include/tic80.h` declares the timing callbacks as `u64 (*)()`, while `tic.c` defines `tic80_tick` taking `CounterCallback` and `FreqCallback`, which are `u64 (*)(void*)`, and `core.c` calls them with an argument:

```c
core->data->counter(core->data->data)
```

Under C17 and earlier an empty parameter list means "unspecified arguments", so the mismatch is hidden. C23 gives `()` the same meaning as `(void)`, and the declaration and definition become incompatible types. Building with a C23 compiler fails:

```
src/tic.c:104:16: error: conflicting types for 'tic80_tick'; have
'void(tic80 *, tic80_input, u64 (*)(void *), u64 (*)(void *))'
```

GCC 15 defaults to `-std=gnu23`, so this is reached simply by building with a current toolchain. I hit it porting TIC-80 to the ESP32-P4, where the SDK compiles at C23; the workaround there is pinning `-std=gnu17`, which seemed worth replacing with a real fix.

## The change

`run.c` already implements these callbacks correctly, taking `void*` and receiving `.data`. Only the two standalone callers did not, and they worked because the callee ignored the extra argument:

- `include/tic80.h` — declare the parameters the definition actually has
- `src/system/sdl/player.c` — its two static callbacks take `void*`
- `src/system/libretro/tic80_libretro.c` — likewise

Five lines. No behaviour change; the argument was already being passed at every call.

Tested by building the SDL target with GCC 15.

Happy to take the opposite approach instead if you would rather the callbacks genuinely take no argument — that would mean changing the typedefs in `api.h`, the four call sites in `core.c`, and `run.c`, and dropping the `.data` plumbing. I went with the smaller change that keeps the existing design.