### PR TITLE
Declare Studio's net field under the condition it is used

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -234,6 +234,9 @@ struct Studio
 
 #if defined(BUILD_SURF)
     Surf*       surf;
+#endif
+
+#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
     tic_net* net;
 #endif
 


### PR DESCRIPTION
`studio->net` is read wherever either `BUILD_EDITORS` or `BUILD_SURF` is set:

```c
#if defined(BUILD_EDITORS) || defined(BUILD_SURF)
    initConsole(studio->console, studio, studio->fs, studio->net, studio->config, args);
#endif
```

but the field itself is declared only under `BUILD_SURF`, so compiling the studio with `BUILD_EDITORS` and without `BUILD_SURF` fails:

```
src/studio/studio.c:2966:60: error: 'Studio' has no member named 'net'
```

**Worth being upfront:** `CMakeLists.txt:59` sets `BUILD_SURF ON` whenever `BUILD_EDITORS` is set, so no in-tree build produces that combination. This only bites builds that compile these sources directly with their own definitions — I ran into it porting TIC-80 to the ESP32-P4, wanting the editors without the network layer.

## The change

The declaration now carries the same condition as its use, matching the `Console*` field immediately above it. Three added lines, no deletions.

No configuration that builds today is affected: with `BUILD_SURF` defined the preprocessed result is identical. Verified by building the SDL target.

Note this makes that configuration *compile*; it does not make it fully work. `console.c` calls `tic_net_get(console->net, ...)` outside any `BUILD_SURF` guard, so with no network layer that would be a null `tic_net`. `net.c`'s fallback implementation handles a null and fails the request cleanly, but the naett path would not. Fixing that properly means deciding whether console's version check and download paths should be `BUILD_SURF`-only, which felt like your call rather than mine — happy to follow up if you want it.