### PR TITLE
Fix WASM libretro core build failing at runtime

### DIFF
--- a/src/system/libretro/tic80_libretro.c
+++ b/src/system/libretro/tic80_libretro.c
@@ -84,8 +84,10 @@ static struct tic80_state* state = NULL;
 /**
  * TIC-80 callback; Request counter.
  */
-static u64 tic80_libretro_counter()
+static u64 tic80_libretro_counter(void *opaque)
 {
+	TIC_UNUSED(opaque);
+
 	if (state == NULL) {
 		return 0;
 	}
@@ -96,8 +98,10 @@ static u64 tic80_libretro_counter()
 /**
  * TIC-80 callback; Request frequency.
  */
-static u64 tic80_libretro_frequency()
+static u64 tic80_libretro_frequency(void *opaque)
 {
+	TIC_UNUSED(opaque);
+
 	return TIC80_FREQUENCY;
 }
 


### PR DESCRIPTION
I had to make this change to get the TIC-80 wasm build for libretro to load games successfully, otherwise it fails at runtime.

TIC-80’s API expects callbacks shaped like `u64 callback(void*)`, but the libretro wrapper defined those callbacks as `u64 callback()`.

Wasm indirect calls are type-checked at runtime, so the mismatch traps with indirect call signature mismatch.